### PR TITLE
Channel awareness

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The available *build configurations* are:
 * `colours+web`, includes both of the above
 * `posix`, default on Posix-like systems, compiles both `colours` and `web`
 * `windows`, default on Windows, equals `vanilla`
+* `cygwin`, equals `windows` but with extra code needed for running it under the default Cygwin terminal (*mintty*)
 
 You can specify which to build with the `-c` switch.
 
@@ -133,6 +134,8 @@ Generate one [here](https://twitchapps.com/tmi), then add it to your `kameloso.c
 
 `pass` is different from `authPassword` in that it is supplied very early during login/registration to even allow you to connect, when the username and nickname is still being negotiated, whereas `authPassword` is something that is sent to nickname services after registration is finished and you have successfully logged onto the server. (In the case of SASL, `authPassword` is used late during registration.)
 
+Mind that a full Twitch bot cannot be implemented as an IRC client.
+
 # TODO
 
 * "online" help; listing of verbs/commands
@@ -144,7 +147,7 @@ Generate one [here](https://twitchapps.com/tmi), then add it to your `kameloso.c
 * more modules? uda.d/attribute.d?
 * more specific users in configuration arrays? nick/address/etc... needs rework of config.d
 * concurrency message-checking as Fiber?
-* backlog of `FIXME`s
+* update `seen.d` again
 
 # Built With
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Once the bot has joined a channel it's ready. Mind that you need to authorise yo
     kameloso | herp
          you | !8ball
     kameloso | It is decidedly so
-         you | !quote you This is a quote
+         you | !addquote you This is a quote
     kameloso | Quote saved. (1 on record)
          you | !quote you
     kameloso | you | This is a quote
@@ -140,11 +140,11 @@ Generate one [here](https://twitchapps.com/tmi), then add it to your `kameloso.c
 * pipedream: DCC
 * pipedream two: `ncurses`
 * Travis LDC tests
-* ready for channel-awareness (+channel modes)
 * more command-line flags
 * more modules? uda.d/attribute.d?
 * more specific users in configuration arrays? nick/address/etc... needs rework of config.d
 * concurrency message-checking as Fiber?
+* backlog of `FIXME`s
 
 # Built With
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ There are a few Windows caveats.
 
 * Web URL title lookup, including the Bash and Reddit plugins, may not work out of the box with secure `HTTPS` connections, due to the default installation of `dlang-requests` not finding the correct `OpenSSL` libraries. Unsure of how to fix this.
 * Terminal colours may also not work, depending on your version of Windows and likely your terminal font. Unsure of how to enable this. By default it will compile on Windows with colours *disabled*, but they can be enabled by specifying a different *build configuration*.
-* Text output will *not* work well with the default **Cygwin** terminal, due to some nuances of how it does or doesn't present itself as a `tty`. There are some workarounds for most output, though they aren't exposed for now.
 
 # Getting Started
 

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -1466,12 +1466,12 @@ struct Client
         foreach (plugin; plugins)
         {
             plugin.start();
-            auto yieldedBot = plugin.yieldBot();
+            auto pluginBot = plugin.bot;
 
-            if (yieldedBot != bot)
+            if (pluginBot != bot)
             {
                 // start changed the bot; propagate
-                bot = yieldedBot;
+                bot = pluginBot;
                 parser.bot = bot;
                 propagateBot(bot);
             }
@@ -1492,7 +1492,7 @@ struct Client
     {
         foreach (plugin; plugins)
         {
-            plugin.newBot(bot);
+            plugin.bot = bot;
         }
     }
 }

--- a/source/kameloso/getopt.d
+++ b/source/kameloso/getopt.d
@@ -210,7 +210,8 @@ Flag!"quit" handleGetopt(ref Client client, string[] args)
             writeln();
 
             // FIXME: Hardcoded width
-            printObjects!18(bot, bot.server, settings);
+            enum width = 18;
+            printObjects!width(bot, bot.server, settings);
 
             initPlugins();
             foreach (plugin; plugins) plugin.printSettings();

--- a/source/kameloso/irc.d
+++ b/source/kameloso/irc.d
@@ -1349,8 +1349,6 @@ void onPRIVMSG(const ref IRCParser parser, ref IRCEvent event, ref string slice)
     import kameloso.constants : IRCControlCharacter;
     import kameloso.string : beginsWith;
 
-    // FIXME, change so that it assigns to the proper field
-
     immutable target = slice.nom(" :");
     event.content = slice;
 

--- a/source/kameloso/irc.d
+++ b/source/kameloso/irc.d
@@ -826,6 +826,22 @@ void parseSpecialcases(ref IRCParser parser, ref IRCEvent event, ref string slic
         break;
 
     case RPL_CHANNELMODEIS: // 324
+        // :niven.freenode.net 324 kameloso^ ##linux +CLPcnprtf ##linux-overflow
+        slice.nom(' '); // bot nickname
+        event.channel = slice.nom(' ');
+
+        if (slice.has(' '))
+        {
+            event.aux = slice.nom(' ');
+            //event.content = slice.nom(' ');
+            event.content = slice;
+        }
+        else
+        {
+            event.aux = slice;
+        }
+        break;
+
     case RPL_CREATIONTIME: // 32
         // :kornbluth.freenode.net 324 kameloso #flerrp +ns
         // :kornbluth.freenode.net 329 kameloso #flerrp 1512995737

--- a/source/kameloso/irc.d
+++ b/source/kameloso/irc.d
@@ -1472,20 +1472,21 @@ void onMode(const ref IRCParser parser, ref IRCEvent event, ref string slice)
 
     if (target.isValidChannel(parser.bot.server))
     {
+        event.type = IRCEvent.Type.CHANMODE;
         event.channel = target;
 
         if (slice.has(' '))
         {
             // :zorael!~NaN@ns3363704.ip-94-23-253.eu MODE #flerrp +v kameloso^
-            // :zorael!~NaN@ns3363704.ip-94-23-253.eu MODE #flerrp +i
-            event.type = IRCEvent.Type.CHANMODE;
             event.aux = slice.nom(' ');
             // save target in content; there may be more than one
             event.content = slice;
         }
         else
         {
-            event.type = IRCEvent.Type.USERMODE;
+            // :zorael!~NaN@ns3363704.ip-94-23-253.eu MODE #flerrp +i
+            // :niven.freenode.net MODE #sklabjoier +ns
+            //event.type = IRCEvent.Type.USERMODE;
             event.aux = slice;
         }
     }

--- a/source/kameloso/ircdefs.d
+++ b/source/kameloso/ircdefs.d
@@ -71,7 +71,6 @@ struct IRCEvent
         NICK,       /// Someone changed nickname
         MODE,       /// Someone changed the modes of a user
         CHANMODE,   /// Someone changed the modes of a channel
-        USERMODE,   /// Someone changed the modes of a user
         SELFQUIT,   /// You quit the server
         SELFJOIN,   /// You joined a channel
         SELFPART,   /// You left a channel

--- a/source/kameloso/ircdefs.d
+++ b/source/kameloso/ircdefs.d
@@ -2027,7 +2027,7 @@ struct IRCChannel
     string topic;
     string channelModes;
     Mode[] modes;
-    IRCUser[] users;
+    string[] users;
 
     void newMode(const string modeline) @system
     {

--- a/source/kameloso/ircdefs.d
+++ b/source/kameloso/ircdefs.d
@@ -2056,6 +2056,7 @@ struct IRCChannel
     char[] modechars;
     Mode[] modes;
     string[] users;
+    long created;
     bool queried;
 
     void toString(scope void delegate(const(char)[]) @safe sink) const

--- a/source/kameloso/ircdefs.d
+++ b/source/kameloso/ircdefs.d
@@ -1077,6 +1077,13 @@ struct IRCUser
         userstring.formattedRead("%s!%s@%s", nickname, ident, address);
     }
 
+    this(const string nickname, const string ident, const string address)
+    {
+        this.nickname = nickname;
+        this.ident = ident;
+        this.address = address;
+    }
+
     void toString(scope void delegate(const(char)[]) @safe sink) const
     {
         import std.format : formattedWrite;

--- a/source/kameloso/ircdefs.d
+++ b/source/kameloso/ircdefs.d
@@ -2029,7 +2029,7 @@ struct IRCChannel
     Mode[] modes;
     string[] users;
 
-    void newMode(const string modeline) @system
+    void setMode(const string modeline) @system
     {
         import kameloso.string : has, nom;
         import std.algorithm.iteration : splitter;
@@ -2171,39 +2171,42 @@ unittest
 {
     {
         import std.stdio;
+        import std.conv : text;
 
         IRCChannel chan;
 
         chan.topic = "Huerbla";
-        chan.newMode("+b kameloso!~NaN@aasdf.freenode.org");
-        foreach (i, mode; chan.modes) writefln("%2d: %s", i, mode.toString());
+
+        chan.setMode("+b kameloso!~NaN@aasdf.freenode.org");
+        foreach (i, mode; chan.modes) writefln("%2d: %s", i, mode);
         assert(chan.modes.length == 1);
         writeln("-------------------------------------");
 
-        chan.newMode("+bbe hirrsteff!*@* harblsnarf!ident@* NICK!~IDENT@ADDRESS");
-        foreach (i, mode; chan.modes) writefln("%2d: %s", i, mode.toString());
+        chan.setMode("+bbe hirrsteff!*@* harblsnarf!ident@* NICK!~IDENT@ADDRESS");
+        foreach (i, mode; chan.modes) writefln("%2d: %s", i, mode);
         assert(chan.modes.length == 3);
+        assert((chan.modes[2].exemptions.length == 1), chan.modes[2].exemptions.length.text);
         writeln("-------------------------------------");
 
-        chan.newMode("-b *!*@*");
-        foreach (i, mode; chan.modes) writefln("%2d: %s", i, mode.toString());
+        chan.setMode("-b *!*@*");
+        foreach (i, mode; chan.modes) writefln("%2d: %s", i, mode);
         assert(chan.modes.length == 0);
         writeln("-------------------------------------");
 
-        chan.newMode("+i");
+        chan.setMode("+i");
         assert(chan.channelModes == "i", chan.channelModes);
 
-        chan.newMode("+v");
+        chan.setMode("+v");
         assert(chan.channelModes == "iv", chan.channelModes);
 
-        chan.newMode("-i");
+        chan.setMode("-i");
         assert(chan.channelModes == "v", chan.channelModes);
 
-        chan.newMode("+l 200");
+        chan.setMode("+l 200");
         IRCChannel.Mode lMode;
         lMode.modechar = 'l';
         lMode.data = "200";
-        foreach (i, mode; chan.modes) writefln("%2d: %s", i, mode.toString());
+        foreach (i, mode; chan.modes) writefln("%2d: %s", i, mode);
         assert((chan.modes[0] == lMode), chan.modes[0].toString());
     }
 }

--- a/source/kameloso/ircdefs.d
+++ b/source/kameloso/ircdefs.d
@@ -471,7 +471,7 @@ struct IRCEvent
         ERR_SUMMONDISABLED, // = 445,   // ":SUMMON has been disabled"
         ERR_USERSDISABLED, // = 446,    // ":USERS has been disabled"
         ERR_NONICKCHANGE, // = 447,
-        ERR_FORBIDDENCHANEL, // = 448,
+        ERR_FORBIDDENCHANNEL, // = 448,
         ERR_NOTIMPLEMENTED, // = 449,
         ERR_NOTREGISTERED, // = 451,    // ":You have not registered"
         ERR_IDCOLLISION, // = 452,
@@ -1379,7 +1379,7 @@ struct Typenums
         445 : Type.ERR_SUMMONDISABLED,
         446 : Type.ERR_USERSDISABLED,
         447 : Type.ERR_NONICKCHANGE,
-        448 : Type.ERR_FORBIDDENCHANEL,
+        448 : Type.ERR_FORBIDDENCHANNEL,
         449 : Type.ERR_NOTIMPLEMENTED,
         451 : Type.ERR_NOTREGISTERED,
         452 : Type.ERR_IDCOLLISION,

--- a/source/kameloso/ircdefs.d
+++ b/source/kameloso/ircdefs.d
@@ -2007,11 +2007,20 @@ struct IRCChannel
             return true;*/
         }
 
+        void toString(scope void delegate(const(char)[]) @safe sink) const
+        {
+            import std.format : formattedWrite;
+
+            sink.formattedWrite("+%c (%s)\n@ %s\n< %s\n", modechar, data, user,
+                exemptions);
+        }
+
         string toString()
         {
             import std.format : format;
-            return "+%c (%s)\n@ %s\n< %s\n"
-                .format(modechar, data, user, exemptions);
+
+            return "+%c (%s)\n@ %s\n< %s\n".format(modechar, data, user,
+                exemptions);
         }
     }
 

--- a/source/kameloso/ircdefs.d
+++ b/source/kameloso/ircdefs.d
@@ -1088,7 +1088,7 @@ struct IRCUser
     {
         import std.format : formattedWrite;
 
-        sink.formattedWrite("n:%s l:%s a:%s i:%s s:%s%s w:%s",
+        sink.formattedWrite("n:%s L:%s a:%s i:%s a:%s%s w:%s",
             nickname, login, alias_, ident, address,
             special ? " (*)" : string.init, lastWhois);
     }

--- a/source/kameloso/main.d
+++ b/source/kameloso/main.d
@@ -411,12 +411,12 @@ Flag!"quit" mainLoop(ref Client client, Generator!string generator)
                 foreach (plugin; plugins)
                 {
                     plugin.postprocess(mutEvent);
-                    auto yieldedBot = plugin.yieldBot();
+                    auto pluginBot = plugin.bot;
 
-                    if (yieldedBot.updated)
+                    if (pluginBot.updated)
                     {
                         // Postprocessing changed the bot; propagate
-                        bot = yieldedBot;
+                        bot = pluginBot;
                         bot.updated = false;
                         parser.bot = bot;
                         propagateBot(bot);
@@ -464,9 +464,9 @@ Flag!"quit" mainLoop(ref Client client, Generator!string generator)
                         auto reqs = plugin.yieldWHOISRequests();
                         client.handleWHOISQueue(reqs, event, event.target.nickname);
 
-                        auto yieldedBot = plugin.yieldBot();
+                        auto pluginBot = plugin.bot;
 
-                        if (yieldedBot.updated)
+                        if (pluginBot.updated)
                         {
                             /*  Plugin `onEvent` or `WHOIS` reaction updated the
                                 bot. There's no need to check for both
@@ -474,7 +474,7 @@ Flag!"quit" mainLoop(ref Client client, Generator!string generator)
                                 processing; it keeps its update internally
                                 between both passes.
                             */
-                            bot = yieldedBot;
+                            bot = pluginBot;
                             bot.updated = false;
                             parser.bot = bot;
                             propagateBot(bot);

--- a/source/kameloso/main.d
+++ b/source/kameloso/main.d
@@ -438,26 +438,21 @@ Flag!"quit" mainLoop(ref Client client, Generator!string generator)
 
                             foreach (immutable i, ref fiber; *fibers)
                             {
-                                if (!fiber)
+                                if (fiber.state == Fiber.State.TERM)
                                 {
-                                    writeln("null fiber SHOULD NEVER HAPPEN");
                                     toRemove ~= i;
                                 }
-                                else if (fiber.state == Fiber.State.TERM)
+                                else if (fiber.state == Fiber.State.HOLD)
                                 {
-                                    import core.memory : GC;
-                                    writeln("Found a dead fiber!");
-                                    GC.free(&fiber);
-                                    toRemove ~= i;
+                                    fiber.call();
                                 }
                                 else
                                 {
-                                    writeln("Calling fiber ", i);
-                                    fiber.call();
+                                    assert(0);
                                 }
                             }
 
-                            foreach (i; toRemove)
+                            foreach_reverse (i; toRemove)
                             {
                                 import std.algorithm.mutation : remove;
                                 plugin.awaitingFibers[event.type] =

--- a/source/kameloso/main.d
+++ b/source/kameloso/main.d
@@ -191,10 +191,6 @@ Flag!"quit" checkMessages(ref Client client)
             line = "MODE %s %s :%s".format(channel, aux, content);
             break;
 
-        case USERMODE:
-            line = "MODE %s %s".format(aux, target.nickname);
-            break;
-
         case TOPIC:
             line = "TOPIC %s :%s".format(channel, content);
             break;
@@ -229,10 +225,6 @@ Flag!"quit" checkMessages(ref Client client)
         case PRIVMSG:
             if (channel.length) goto case CHAN;
             else goto case QUERY;
-
-        case MODE:
-            if (channel.length) goto case CHANMODE;
-            else goto case USERMODE;
 
         case UNSET:
             line = content;

--- a/source/kameloso/messaging.d
+++ b/source/kameloso/messaging.d
@@ -7,8 +7,8 @@ import std.concurrency : Tid, send;
 
 // chan
 /++
-+  FIXME
-+/
+ +  Sends a channel message.
+ +/
 void chan(Flag!"quiet" quiet = No.quiet)(Tid tid, const string channel,
     const string content)
 {
@@ -22,10 +22,11 @@ void chan(Flag!"quiet" quiet = No.quiet)(Tid tid, const string channel,
     tid.send(event);
 }
 
+
 // query
 /++
-+  FIXME
-+/
+ +  Sends a private query message to a user.
+ +/
 void query(Flag!"quiet" quiet = No.quiet)(Tid tid, const string nickname,
     const string content)
 {
@@ -38,10 +39,15 @@ void query(Flag!"quiet" quiet = No.quiet)(Tid tid, const string nickname,
     tid.send(event);
 }
 
+
 // privmsg
 /++
-+  FIXME
-+/
+ +  Sends either a channel message or a private query message depending on
+ +  the arguments passed to it.
+ +
+ +  This reflects how channel messages and private messages are both the
+ +  underlying same type; `PRIVMSG`.
+ +/
 void privmsg(Flag!"quiet" quiet = No.quiet)(Tid tid, const string channel,
     const string nickname, const string content)
 {
@@ -61,10 +67,15 @@ void privmsg(Flag!"quiet" quiet = No.quiet)(Tid tid, const string channel,
     }
 }
 
+
 // throttleline
 /++
-+  FIXME
-+/
+ +  Sends either a channel message or a private query message depending on
+ +  the arguments passed to it.
+ +
+ +  It sends it in a throttled fashion, usable for long output when the bot
+ +  may otherwise get kicked for spamming.
+ +/
 void throttleline(Flag!"quiet" quiet = No.quiet)(Tid tid, const string channel,
     const string nickname, const string content)
 {
@@ -91,10 +102,11 @@ void throttleline(Flag!"quiet" quiet = No.quiet)(Tid tid, const string channel,
     tid.send(ThreadMessage.Throttleline(), line);
 }
 
+
 // emote
 /++
-+  FIXME
-+/
+ +  Sends an `ACTION` "emote" to the supplied target (nickname or channel).
+ +/
 void emote(Flag!"quiet" quiet = No.quiet)(Tid tid, const string emoteTarget,
     const string content)
 {
@@ -117,10 +129,14 @@ void emote(Flag!"quiet" quiet = No.quiet)(Tid tid, const string emoteTarget,
     tid.send(event);
 }
 
+
 // chanmode
 /++
-+  FIXME
-+/
+ +  Sets a channel mode.
+ +
+ +  This includes modes that pertain to a user in the context of a channel,
+ +  like bans.
+ +/
 void chanmode(Flag!"quiet" quiet = No.quiet)(Tid tid, const string channel,
     const string modes, const string content = string.init)
 {
@@ -136,28 +152,11 @@ void chanmode(Flag!"quiet" quiet = No.quiet)(Tid tid, const string channel,
     tid.send(event);
 }
 
-// usermode
-/++
-+  FIXME
-+/
-void usermode(Flag!"quiet" quiet = No.quiet)(Tid tid, const string nickname,
-    const string modes)
-{
-    assert((nickname[0] != '#'), "usermode was passed channel as nickname: " ~ nickname);
-
-    IRCEvent event;
-    event.type = IRCEvent.Type.USERMODE;
-    event.target.special = quiet;
-    event.target.nickname = nickname;
-    event.aux = modes;
-
-    tid.send(event);
-}
 
 // topic
 /++
-+  FIXME
-+/
+ +  Sets the topic of a channel.
+ +/
 void topic(Flag!"quiet" quiet = No.quiet)(Tid tid, const string channel,
     const string content)
 {
@@ -172,10 +171,11 @@ void topic(Flag!"quiet" quiet = No.quiet)(Tid tid, const string channel,
     tid.send(event);
 }
 
+
 // invite
 /++
-+  FIXME
-+/
+ +  Invites a user to a channel.
+ +/
 void invite(Flag!"quiet" quiet = No.quiet)(Tid tid, const string channel,
     const string nickname)
 {
@@ -189,10 +189,11 @@ void invite(Flag!"quiet" quiet = No.quiet)(Tid tid, const string channel,
     tid.send(event);
 }
 
+
 // join
 /++
-+  FIXME
-+/
+ +  Joins a channel.
+ +/
 void join(Flag!"quiet" quiet = No.quiet)(Tid tid, const string channel)
 {
     assert((channel[0] == '#'), "join was passed invalid channel: " ~ channel);
@@ -204,10 +205,11 @@ void join(Flag!"quiet" quiet = No.quiet)(Tid tid, const string channel)
     tid.send(event);
 }
 
+
 // kick
 /++
-+  FIXME
-+/
+ +  Kicks a user from a channel.
+ +/
 void kick(Flag!"quiet" quiet = No.quiet)(Tid tid, const string channel,
     const string nickname, const string reason = string.init)
 {
@@ -223,10 +225,11 @@ void kick(Flag!"quiet" quiet = No.quiet)(Tid tid, const string channel,
     tid.send(event);
 }
 
+
 // part
 /++
-+  FIXME
-+/
+ +  Leaves a channel.
+ +/
 void part(Flag!"quiet" quiet = No.quiet)(Tid tid, const string channel)
 {
     assert((channel[0] == '#'), "part was passed invalid channel: " ~ channel);
@@ -238,10 +241,11 @@ void part(Flag!"quiet" quiet = No.quiet)(Tid tid, const string channel)
     tid.send(event);
 }
 
+
 // quit
 /++
-+  FIXME
-+/
+ +  Disconnects from the server, optionally with a quit reason.
+ +/
 void quit(Flag!"quiet" quiet = No.quiet)(Tid tid, const string reason = string.init)
 {
     IRCEvent event;
@@ -252,10 +256,14 @@ void quit(Flag!"quiet" quiet = No.quiet)(Tid tid, const string reason = string.i
     tid.send(event);
 }
 
+
 // raw
 /++
-+  FIXME
-+/
+ +  Sends text to the server, verbatim.
+ +
+ +  This is used to send messages of types for which there exist no helper
+ +  functions.
+ +/
 void raw(Flag!"quiet" quiet = No.quiet)(Tid tid, const string line)
 {
     IRCEvent event;

--- a/source/kameloso/plugins/admin.d
+++ b/source/kameloso/plugins/admin.d
@@ -136,7 +136,6 @@ void onCommandShowChannels(AdminPlugin plugin)
 @Prefix(NickPolicy.required, "sudo")
 void onCommandSudo(AdminPlugin plugin, const IRCEvent event)
 {
-    // FIXME
     plugin.raw(event.content);
 }
 

--- a/source/kameloso/plugins/admin.d
+++ b/source/kameloso/plugins/admin.d
@@ -98,6 +98,30 @@ void onCommandShowUsers(AdminPlugin plugin)
     version(Cygwin_) stdout.flush();
 }
 
+// onCommandShowChannels
+/++
+ +  Prints out the current `state.users` array in the local terminal.
+ +/
+@(IRCEvent.Type.CHAN)
+@(IRCEvent.Type.QUERY)
+@(PrivilegeLevel.master)
+@Prefix(NickPolicy.required, "channels")
+void onCommandShowChannels(AdminPlugin plugin)
+{
+    import kameloso.common : printObject;
+
+    logger.trace("Printing Admin's channels");
+
+    printObject(plugin.state.bot);
+
+    foreach (entry; plugin.state.channels.byKeyValue)
+    {
+        writefln("%-12s [%s]", entry.key, entry.value);
+    }
+
+    version(Cygwin_) stdout.flush();
+}
+
 
 // onCommandSudo
 /++
@@ -451,6 +475,7 @@ void joinPartImpl(AdminPlugin plugin, const string prefix, const IRCEvent event)
 
 
 mixin BasicEventHandlers;
+mixin ChannelAwareness;
 
 public:
 

--- a/source/kameloso/plugins/admin.d
+++ b/source/kameloso/plugins/admin.d
@@ -474,7 +474,7 @@ void joinPartImpl(AdminPlugin plugin, const string prefix, const IRCEvent event)
 }
 
 
-mixin BasicEventHandlers;
+mixin UserAwareness;
 mixin ChannelAwareness;
 
 public:

--- a/source/kameloso/plugins/admin.d
+++ b/source/kameloso/plugins/admin.d
@@ -95,6 +95,9 @@ void onCommandShowUsers(AdminPlugin plugin)
         writefln("%-12s [%s]", entry.key, entry.value);
     }
 
+    writefln("%d bytes from %d users",
+        (IRCUser.sizeof * plugin.state.users.length), plugin.state.users.length);
+
     version(Cygwin_) stdout.flush();
 }
 

--- a/source/kameloso/plugins/admin.d
+++ b/source/kameloso/plugins/admin.d
@@ -64,8 +64,8 @@ void onAnyEvent(AdminPlugin plugin, const IRCEvent event)
 @(IRCEvent.Type.CHAN)
 @(IRCEvent.Type.QUERY)
 @(PrivilegeLevel.master)
-@Prefix(NickPolicy.required, "save")
-@Prefix(NickPolicy.required, "writeconfig")
+@BotCommand(NickPolicy.required, "save")
+@BotCommand(NickPolicy.required, "writeconfig")
 void onCommandSave(AdminPlugin plugin)
 {
     import kameloso.common : ThreadMessage;
@@ -82,7 +82,7 @@ void onCommandSave(AdminPlugin plugin)
 @(IRCEvent.Type.CHAN)
 @(IRCEvent.Type.QUERY)
 @(PrivilegeLevel.master)
-@Prefix(NickPolicy.required, "users")
+@BotCommand(NickPolicy.required, "users")
 void onCommandShowUsers(AdminPlugin plugin)
 {
     import kameloso.common : printObject;
@@ -109,7 +109,7 @@ void onCommandShowUsers(AdminPlugin plugin)
 @(IRCEvent.Type.CHAN)
 @(IRCEvent.Type.QUERY)
 @(PrivilegeLevel.master)
-@Prefix(NickPolicy.required, "channels")
+@BotCommand(NickPolicy.required, "channels")
 void onCommandShowChannels(AdminPlugin plugin)
 {
     import kameloso.common : printObject;
@@ -134,7 +134,7 @@ void onCommandShowChannels(AdminPlugin plugin)
 @(IRCEvent.Type.CHAN)
 @(IRCEvent.Type.QUERY)
 @(PrivilegeLevel.master)
-@Prefix(NickPolicy.required, "sudo")
+@BotCommand(NickPolicy.required, "sudo")
 void onCommandSudo(AdminPlugin plugin, const IRCEvent event)
 {
     plugin.raw(event.content);
@@ -152,7 +152,7 @@ void onCommandSudo(AdminPlugin plugin, const IRCEvent event)
 @(IRCEvent.Type.CHAN)
 @(IRCEvent.Type.QUERY)
 @(PrivilegeLevel.master)
-@Prefix(NickPolicy.required, "quit")
+@BotCommand(NickPolicy.required, "quit")
 void onCommandQuit(AdminPlugin plugin, const IRCEvent event)
 {
     with (plugin.state)
@@ -176,7 +176,7 @@ void onCommandQuit(AdminPlugin plugin, const IRCEvent event)
 @(IRCEvent.Type.CHAN)
 @(IRCEvent.Type.QUERY)
 @(PrivilegeLevel.master)
-@Prefix(NickPolicy.required, "addhome")
+@BotCommand(NickPolicy.required, "addhome")
 void onCommandAddHome(AdminPlugin plugin, const IRCEvent event)
 {
     import kameloso.irc : isValidChannel;
@@ -212,7 +212,7 @@ void onCommandAddHome(AdminPlugin plugin, const IRCEvent event)
 @(IRCEvent.Type.CHAN)
 @(IRCEvent.Type.QUERY)
 @(PrivilegeLevel.master)
-@Prefix(NickPolicy.required, "delhome")
+@BotCommand(NickPolicy.required, "delhome")
 void onCommandDelHome(AdminPlugin plugin, const IRCEvent event)
 {
     import kameloso.irc : isValidChannel;
@@ -253,7 +253,7 @@ void onCommandDelHome(AdminPlugin plugin, const IRCEvent event)
 @(IRCEvent.Type.CHAN)
 @(IRCEvent.Type.QUERY)
 @(PrivilegeLevel.master)
-@Prefix(NickPolicy.required, "addfriend")
+@BotCommand(NickPolicy.required, "addfriend")
 void onCommandAddFriend(AdminPlugin plugin, const IRCEvent event)
 {
     import kameloso.string : has;
@@ -288,7 +288,7 @@ void onCommandAddFriend(AdminPlugin plugin, const IRCEvent event)
 @(IRCEvent.Type.CHAN)
 @(IRCEvent.Type.QUERY)
 @(PrivilegeLevel.master)
-@Prefix(NickPolicy.required, "delfriend")
+@BotCommand(NickPolicy.required, "delfriend")
 void onCommandDelFriend(AdminPlugin plugin, const IRCEvent event)
 {
     import kameloso.string : has;
@@ -336,7 +336,7 @@ void onCommandDelFriend(AdminPlugin plugin, const IRCEvent event)
 @(IRCEvent.Type.CHAN)
 @(IRCEvent.Type.QUERY)
 @(PrivilegeLevel.master)
-@Prefix(NickPolicy.required, "resetterm")
+@BotCommand(NickPolicy.required, "resetterm")
 void onCommandResetTerminal()
 {
     import kameloso.bash : TerminalToken;
@@ -354,7 +354,7 @@ void onCommandResetTerminal()
 @(IRCEvent.Type.CHAN)
 @(IRCEvent.Type.QUERY)
 @(PrivilegeLevel.master)
-@Prefix(NickPolicy.required, "printall")
+@BotCommand(NickPolicy.required, "printall")
 void onCommandPrintAll(AdminPlugin plugin)
 {
     plugin.printAll = !plugin.printAll;
@@ -371,7 +371,7 @@ void onCommandPrintAll(AdminPlugin plugin)
 @(IRCEvent.Type.CHAN)
 @(IRCEvent.Type.QUERY)
 @(PrivilegeLevel.master)
-@Prefix(NickPolicy.required, "printbytes")
+@BotCommand(NickPolicy.required, "printbytes")
 void onCommandPrintBytes(AdminPlugin plugin)
 {
     plugin.printBytes = !plugin.printBytes;
@@ -388,7 +388,7 @@ void onCommandPrintBytes(AdminPlugin plugin)
 @(IRCEvent.Type.CHAN)
 @(IRCEvent.Type.QUERY)
 @(PrivilegeLevel.master)
-@Prefix(NickPolicy.required, "asserts")
+@BotCommand(NickPolicy.required, "asserts")
 void onCommandAsserts(AdminPlugin plugin)
 {
     import kameloso.debugging : formatBot;
@@ -409,7 +409,7 @@ void onCommandAsserts(AdminPlugin plugin)
 @(IRCEvent.Type.CHAN)
 @(IRCEvent.Type.QUERY)
 @(PrivilegeLevel.master)
-@Prefix(NickPolicy.required, "join")
+@BotCommand(NickPolicy.required, "join")
 void onCommandJoin(AdminPlugin plugin, const IRCEvent event)
 {
     plugin.joinPartImpl("JOIN", event);
@@ -425,7 +425,7 @@ void onCommandJoin(AdminPlugin plugin, const IRCEvent event)
 @(IRCEvent.Type.CHAN)
 @(IRCEvent.Type.QUERY)
 @(PrivilegeLevel.master)
-@Prefix(NickPolicy.required, "part")
+@BotCommand(NickPolicy.required, "part")
 void onCommandPart(AdminPlugin plugin, const IRCEvent event)
 {
     plugin.joinPartImpl("PART", event);

--- a/source/kameloso/plugins/admin.d
+++ b/source/kameloso/plugins/admin.d
@@ -5,6 +5,7 @@ import kameloso.ircdefs;
 import kameloso.common : logger;
 
 import std.concurrency : send;
+import std.typecons : Flag, No, Yes;
 
 import std.stdio;
 

--- a/source/kameloso/plugins/bashquotes.d
+++ b/source/kameloso/plugins/bashquotes.d
@@ -22,8 +22,8 @@ private:
 @(IRCEvent.Type.QUERY)
 @(ChannelPolicy.homeOnly)
 @(PrivilegeLevel.friend)
-@Prefix("bash")
-@Prefix(NickPolicy.required, "bash")
+@BotCommand("bash")
+@BotCommand(NickPolicy.required, "bash")
 void onMessage(BashQuotesPlugin plugin, const IRCEvent event)
 {
     import std.concurrency : spawn;

--- a/source/kameloso/plugins/bashquotes.d
+++ b/source/kameloso/plugins/bashquotes.d
@@ -113,7 +113,7 @@ void worker(shared IRCPluginState sState, const IRCEvent event)
 }
 
 
-mixin BasicEventHandlers;
+mixin UserAwareness;
 
 public:
 

--- a/source/kameloso/plugins/chanqueries.d
+++ b/source/kameloso/plugins/chanqueries.d
@@ -58,7 +58,7 @@ void onPing(ChanQueriesPlugin plugin, const IRCEvent event)
 
             loopedOnce = true;
         }
-    };
+    }
 
     import core.thread : Fiber;
 

--- a/source/kameloso/plugins/chanqueries.d
+++ b/source/kameloso/plugins/chanqueries.d
@@ -1,0 +1,117 @@
+module kameloso.plugins.chanqueries;
+
+import kameloso.plugins.common;
+import kameloso.ircdefs;
+
+import std.stdio;
+
+private:
+
+
+// onPing
+/++
+ +  FIXME
+ +/
+@(IRCEvent.Type.PING)
+void onPing(ChanQueriesPlugin plugin, const IRCEvent event)
+{
+    if (plugin.state.bot.server.daemon == IRCServer.Daemon.twitch)
+    {
+        // Can't do WHO on Twitch
+        return;
+    }
+
+    string[] querylist;
+
+    foreach (channel, queried; plugin.channels)
+    {
+        if (queried) continue;
+        plugin.channels[channel] = true;
+        querylist ~= channel;
+    }
+
+    if (!querylist.length) return;
+
+    void fiberFn()
+    {
+        import kameloso.messaging : raw;
+        import core.thread : Fiber, Thread;
+        import core.time : seconds;
+        //import std.format : format;
+
+        bool loopedOnce;
+
+        foreach (channel; querylist)
+        {
+            if (loopedOnce)
+            {
+                Fiber.yield();
+                Thread.sleep(plugin.secondsBetween.seconds);
+            }
+
+            raw(plugin.state.mainThread, "MODE " ~ channel);
+            Fiber.yield();
+            /*Thread.sleep(plugin.secondsBetween.seconds);
+            raw(plugin.state.mainThread, "MODE %s +b".format(channel));*/
+            Thread.sleep(plugin.secondsBetween.seconds);
+            raw(plugin.state.mainThread, "WHO " ~ channel);
+
+            loopedOnce = true;
+        }
+    };
+
+    import core.thread : Fiber;
+
+    Fiber fiber = new Fiber(&fiberFn);
+
+    plugin.awaitingFibers[IRCEvent.Type.RPL_CHANNELMODEIS] ~= fiber;
+    plugin.awaitingFibers[IRCEvent.Type.RPL_ENDOFWHO] ~= fiber;
+
+    fiber.call();
+}
+
+
+// onSelfjoin
+/++
+ +  FIXME
+ +/
+@(ChannelPolicy.any)
+@(IRCEvent.Type.SELFJOIN)
+void onSelfjoin(ChanQueriesPlugin plugin, const IRCEvent event)
+{
+    plugin.channels[event.channel] = false;
+}
+
+
+// onSelfpart
+/++
+ +  FIXME
+ +/
+@(ChannelPolicy.any)
+@(IRCEvent.Type.SELFPART)
+void onSelfpart(ChanQueriesPlugin plugin, const IRCEvent event)
+{
+    plugin.channels.remove(event.channel);
+}
+
+
+public:
+
+
+// ChanQueriesPlugin
+/++
+ +  FIXME
+ +/
+final class ChanQueriesPlugin : IRCPlugin
+{
+    /// Extra seconds delay between channel mode/user queries.
+    enum secondsBetween = 2;
+
+    /++
+     +  Short associative array of the channels the bot is in and whether they
+     +  have been queried.
+     +/
+    bool[string] channels;
+
+    mixin IRCPluginImpl;
+}

--- a/source/kameloso/plugins/chanqueries.d
+++ b/source/kameloso/plugins/chanqueries.d
@@ -15,11 +15,7 @@ private:
 @(IRCEvent.Type.PING)
 void onPing(ChanQueriesPlugin plugin, const IRCEvent event)
 {
-    if (plugin.state.bot.server.daemon == IRCServer.Daemon.twitch)
-    {
-        // Can't do WHO on Twitch
-        return;
-    }
+    if (plugin.state.bot.server.daemon == IRCServer.Daemon.twitch) return;
 
     string[] querylist;
 
@@ -79,6 +75,8 @@ void onPing(ChanQueriesPlugin plugin, const IRCEvent event)
 @(IRCEvent.Type.SELFJOIN)
 void onSelfjoin(ChanQueriesPlugin plugin, const IRCEvent event)
 {
+    if (plugin.state.bot.server.daemon == IRCServer.Daemon.twitch) return;
+
     plugin.channels[event.channel] = false;
 }
 
@@ -91,6 +89,8 @@ void onSelfjoin(ChanQueriesPlugin plugin, const IRCEvent event)
 @(IRCEvent.Type.SELFPART)
 void onSelfpart(ChanQueriesPlugin plugin, const IRCEvent event)
 {
+    if (plugin.state.bot.server.daemon == IRCServer.Daemon.twitch) return;
+
     plugin.channels.remove(event.channel);
 }
 

--- a/source/kameloso/plugins/chanqueries.d
+++ b/source/kameloso/plugins/chanqueries.d
@@ -10,7 +10,10 @@ private:
 
 // onPing
 /++
- +  FIXME
+ +  Query channels for information about themselves and their users.
+ +
+ +  Check an internal list of channels once every `PING`, and if one we inhabit
+ +  hasn't been queried, query it.
  +/
 @(IRCEvent.Type.PING)
 void onPing(ChanQueriesPlugin plugin, const IRCEvent event)
@@ -69,7 +72,7 @@ void onPing(ChanQueriesPlugin plugin, const IRCEvent event)
 
 // onSelfjoin
 /++
- +  FIXME
+ +  Add a channel we join to the internal list of channels.
  +/
 @(ChannelPolicy.any)
 @(IRCEvent.Type.SELFJOIN)
@@ -83,7 +86,7 @@ void onSelfjoin(ChanQueriesPlugin plugin, const IRCEvent event)
 
 // onSelfpart
 /++
- +  FIXME
+ +  Remove a channel we part from the internal list of channels.
  +/
 @(ChannelPolicy.any)
 @(IRCEvent.Type.SELFPART)
@@ -100,7 +103,8 @@ public:
 
 // ChanQueriesPlugin
 /++
- +  FIXME
+ +  The Channel Queries plugin queries channels for information about it, so
+ +  that other plugins that implement channel awareness can catch the results.
  +/
 final class ChanQueriesPlugin : IRCPlugin
 {

--- a/source/kameloso/plugins/chatbot.d
+++ b/source/kameloso/plugins/chatbot.d
@@ -140,9 +140,9 @@ JSONValue loadQuotes(const string filename)
 @(IRCEvent.Type.CHAN)
 @(IRCEvent.Type.QUERY)
 @(PrivilegeLevel.friend)
-@Prefix("say")
-@Prefix(NickPolicy.required, "say")
-@Prefix(NickPolicy.required, "säg")
+@BotCommand("say")
+@BotCommand(NickPolicy.required, "say")
+@BotCommand(NickPolicy.required, "säg")
 void onCommandSay(ChatbotPlugin plugin, const IRCEvent event)
 {
     if (!plugin.chatbotSettings.say) return;
@@ -173,8 +173,8 @@ void onCommandSay(ChatbotPlugin plugin, const IRCEvent event)
 @(IRCEvent.Type.CHAN)
 @(IRCEvent.Type.QUERY)
 @(PrivilegeLevel.friend)
-@Prefix("8ball")
-@Prefix(NickPolicy.required, "8ball")
+@BotCommand("8ball")
+@BotCommand(NickPolicy.required, "8ball")
 void onCommand8ball(ChatbotPlugin plugin, const IRCEvent event)
 {
     if (!plugin.chatbotSettings.eightball) return;
@@ -226,8 +226,8 @@ void onCommand8ball(ChatbotPlugin plugin, const IRCEvent event)
 @(IRCEvent.Type.CHAN)
 @(IRCEvent.Type.QUERY)
 @(PrivilegeLevel.friend)
-@Prefix("quote")
-@Prefix(NickPolicy.required, "quote")
+@BotCommand("quote")
+@BotCommand(NickPolicy.required, "quote")
 void onCommandQuote(ChatbotPlugin plugin, const IRCEvent event)
 {
     import std.json : JSONException;
@@ -282,8 +282,8 @@ void onCommandQuote(ChatbotPlugin plugin, const IRCEvent event)
 @(IRCEvent.Type.CHAN)
 @(IRCEvent.Type.QUERY)
 @(PrivilegeLevel.friend)
-@Prefix("addquote")
-@Prefix(NickPolicy.required, "addquote")
+@BotCommand("addquote")
+@BotCommand(NickPolicy.required, "addquote")
 void onCommanAddQuote(ChatbotPlugin plugin, const IRCEvent event)
 {
     if (!plugin.chatbotSettings.quotes) return;
@@ -323,7 +323,7 @@ void onCommanAddQuote(ChatbotPlugin plugin, const IRCEvent event)
 @(IRCEvent.Type.CHAN)
 @(IRCEvent.Type.QUERY)
 @(PrivilegeLevel.master)
-@Prefix(NickPolicy.required, "printquotes")
+@BotCommand(NickPolicy.required, "printquotes")
 void onCommandPrintQuotes(ChatbotPlugin plugin)
 {
     if (!plugin.chatbotSettings.quotes) return;
@@ -343,7 +343,7 @@ void onCommandPrintQuotes(ChatbotPlugin plugin)
 @(IRCEvent.Type.CHAN)
 @(IRCEvent.Type.QUERY)
 @(PrivilegeLevel.master)
-@Prefix(NickPolicy.required, "reloadquotes")
+@BotCommand(NickPolicy.required, "reloadquotes")
 void onCommandReloadQuotes(ChatbotPlugin plugin)
 {
     if (!plugin.chatbotSettings.quotes) return;

--- a/source/kameloso/plugins/chatbot.d
+++ b/source/kameloso/plugins/chatbot.d
@@ -364,7 +364,7 @@ void onEndOfMotd(ChatbotPlugin plugin)
 }
 
 
-mixin BasicEventHandlers;
+mixin UserAwareness;
 
 public:
 

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -276,6 +276,9 @@ struct IRCPluginState
     /// Hashmap of IRC user details
     IRCUser[string] users;
 
+    /// Hashmap of IRC channels
+    IRCChannel[string] channels;
+
     /// Queued `WHOIS` requests and pertaining `IRCEvents` to replay
     WHOISRequest[string] whoisQueue;
 }

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -330,21 +330,17 @@ enum PrivilegeLevel
 }
 
 
-// Prefix
+// BotCommand
 /++
- +  Describes how an on-text function is triggered.
+ +  Defines an IRC bot command, for people to trigger with messages.
  +
- +  The prefix policy decides to what extent the actual prefix string_ is
- +  required. It isn't needed for functions that don't trigger on text messages;
- +  this is merely to gather everything needed to have trigger "verb" commands.
- +
- +  If no `NickPolicy` is specified then it will default to `NickPolicy.direrct`
+ +  If no `NickPolicy` is specified then it will default to `NickPolicy.direct`
  +  and look for `CoreSettings.prefix` at the beginning of messages, to prefix
- +  the string. (Usually "!", making it "!command".)
+ +  the `string_`. (Usually "`!`", making it "`!command`".)
  +/
-struct Prefix
+struct BotCommand
 {
-    /// The policy to which extent the prefix string_ is required
+    /// The policy to which extent the command needs the bot's nickname
     NickPolicy policy;
 
     /// The prefix string, one word with no spaces
@@ -363,6 +359,8 @@ struct Prefix
     }
 }
 
+deprecated("Prefix has been replaced with Command. This alias will be removed in time.")
+alias Prefix = BotCommand;
 
 /++
  +  Flag denoting that an event-handling function let other functions in the
@@ -1685,6 +1683,7 @@ mixin template ChannelAwareness(bool debug_ = false, string module_ = __MODULE__
     import std.format : format;
     static assert(is(typeof(.doWhois)), module_ ~ " is missing UserAwareness " ~
         "mixin (needed for ChannelAwareness).");
+
 
     // onChannelAwarenessSelfjoinMixin
     /++

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -1217,6 +1217,7 @@ mixin template MessagingProxy(bool debug_ = false, string module_ = __MODULE__)
     /++
     +  FIXME
     +/
+    pragma(inline)
     void chan(Flag!"quiet" quiet = No.quiet)(const string channel,
         const string content)
     {
@@ -1227,6 +1228,7 @@ mixin template MessagingProxy(bool debug_ = false, string module_ = __MODULE__)
     /++
     +  FIXME
     +/
+    pragma(inline)
     void query(Flag!"quiet" quiet = No.quiet)(const string nickname,
         const string content)
     {
@@ -1237,6 +1239,7 @@ mixin template MessagingProxy(bool debug_ = false, string module_ = __MODULE__)
     /++
     +  FIXME
     +/
+    pragma(inline)
     void privmsg(Flag!"quiet" quiet = No.quiet)(const string channel,
         const string nickname, const string content)
     {
@@ -1247,6 +1250,7 @@ mixin template MessagingProxy(bool debug_ = false, string module_ = __MODULE__)
     /++
     +  FIXME
     +/
+    pragma(inline)
     void throttleline(Flag!"quiet" quiet = No.quiet)(const string channel,
         const string nickname, const string content)
     {
@@ -1258,6 +1262,7 @@ mixin template MessagingProxy(bool debug_ = false, string module_ = __MODULE__)
     /++
     +  FIXME
     +/
+    pragma(inline)
     void emote(Flag!"quiet" quiet = No.quiet)(const string emoteTarget,
         const string content)
     {
@@ -1268,6 +1273,7 @@ mixin template MessagingProxy(bool debug_ = false, string module_ = __MODULE__)
     /++
     +  FIXME
     +/
+    pragma(inline)
     void chanmode(Flag!"quiet" quiet = No.quiet)(const string channel,
         const string modes, const string content = string.init)
     {
@@ -1278,6 +1284,7 @@ mixin template MessagingProxy(bool debug_ = false, string module_ = __MODULE__)
     /++
     +  FIXME
     +/
+    pragma(inline)
     void usermode(Flag!"quiet" quiet = No.quiet)(const string nickname,
         const string modes)
     {
@@ -1288,6 +1295,7 @@ mixin template MessagingProxy(bool debug_ = false, string module_ = __MODULE__)
     /++
     +  FIXME
     +/
+    pragma(inline)
     void topic(Flag!"quiet" quiet = No.quiet)(const string channel,
         const string content)
     {
@@ -1298,6 +1306,7 @@ mixin template MessagingProxy(bool debug_ = false, string module_ = __MODULE__)
     /++
     +  FIXME
     +/
+    pragma(inline)
     void invite(Flag!"quiet" quiet = No.quiet)(const string channel,
         const string nickname)
     {
@@ -1308,6 +1317,7 @@ mixin template MessagingProxy(bool debug_ = false, string module_ = __MODULE__)
     /++
     +  FIXME
     +/
+    pragma(inline)
     void join(Flag!"quiet" quiet = No.quiet)(const string channel)
     {
         return kameloso.messaging.join!quiet(state.mainThread, channel);
@@ -1327,6 +1337,7 @@ mixin template MessagingProxy(bool debug_ = false, string module_ = __MODULE__)
     /++
     +  FIXME
     +/
+    pragma(inline)
     void part(Flag!"quiet" quiet = No.quiet)(const string channel)
     {
         return kameloso.messaging.part!quiet(state.mainThread, channel);
@@ -1336,6 +1347,7 @@ mixin template MessagingProxy(bool debug_ = false, string module_ = __MODULE__)
     /++
     +  FIXME
     +/
+    pragma(inline)
     void quit(Flag!"quiet" quiet = No.quiet)(const string reason = string.init)
     {
         return kameloso.messaging.quit!quiet(state.mainThread, reason);
@@ -1345,6 +1357,7 @@ mixin template MessagingProxy(bool debug_ = false, string module_ = __MODULE__)
     /++
     +  FIXME
     +/
+    pragma(inline)
     void raw(Flag!"quiet" quiet = No.quiet)(const string line)
     {
         return kameloso.messaging.raw!quiet(state.mainThread, line);

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -21,10 +21,10 @@ interface IRCPlugin
     import std.array : Appender;
 
     /// Executed on update to the internal `IRCBot` struct
-    void newBot(IRCBot);
+    void bot(IRCBot) @property;
 
     /// Executed after a plugin has run its `onEvent` course to pick up bot changes
-    IRCBot yieldBot();
+    IRCBot bot() @property;
 
     /// Executed to get a list of nicknames a plugin wants `WHOIS`ed
     ref WHOISRequest[string] yieldWHOISRequests();
@@ -431,8 +431,8 @@ FilterResult filterUser(const IRCPluginState state, const IRCEvent event)
  +  Uses compile-time introspection to call top-level functions to extend
  +  behaviour;
  +      .onEvent            (doesn't proxy anymore)
- +      .newBot             (assigns bot)
- +      .yieldBot           (returns bot)
+ +      .bot                (assigns bot)
+ +      .bot                (returns bot)
  +      .postprocess
  +      .yieldWHOISRequests (returns queue)
  +      .writeConfig
@@ -894,7 +894,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
         }
     }
 
-    // newBot
+    // bot
     /++
      +  Inherits a new `IRCBot`.
      +
@@ -903,12 +903,12 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
      +  Params:
      +      bot = the new bot to inherit
      +/
-    void newBot(IRCBot bot)
+    void bot(IRCBot bot) @property
     {
         privateState.bot = bot;
     }
 
-    // yieldBot
+    // bot
     /++
      +  Yields a copy of the current `IRCBot` to the caller.
      +
@@ -918,7 +918,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
      +  Returns:
      +      a copy of the current `IRCBot`.
      +/
-    IRCBot yieldBot()
+    IRCBot bot() @property
     {
         return privateState.bot;
     }

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -716,6 +716,10 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
 
                     static if (hasUDA!(fun, PrivilegeLevel))
                     {
+                        static assert (is(typeof(.doWhois)),
+                            module_ ~ " is missing UserAwareness mixin " ~
+                            "(needed for PrivilegeLevel checks).");
+
                         enum privilegeLevel = getUDAs!(fun,
                             PrivilegeLevel)[0];
 
@@ -1678,6 +1682,10 @@ alias BasicEventHandlers = UserAwareness;
  +/
 mixin template ChannelAwareness(bool debug_ = false, string module_ = __MODULE__)
 {
+    import std.format : format;
+    static assert(is(typeof(.doWhois)), module_ ~ " is missing UserAwareness " ~
+        "mixin (needed for ChannelAwareness).");
+
     // onChannelAwarenessSelfjoinMixin
     /++
      +  Create a new `IRCChannel` in the `state.channels` associative array list

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -544,18 +544,19 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                     IRCEvent mutEvent = event;  // mutable
                     string contextPrefix;
 
-                    static if (hasUDA!(fun, Prefix))
+                    static if (hasUDA!(fun, BotCommand))
                     {
                         if (!event.content.length)
                         {
-                            // Event has a `Prefix` set up but `event.content`
-                            // is empty; cannot possibly be of interest
+                            // Event has a `BotCommand` set up but
+                            // `event.content` is empty; cannot possibly be of
+                            // interest.
                             return;
                         }
 
                         bool matches;
 
-                        foreach (prefixUDA; getUDAs!(fun, Prefix))
+                        foreach (prefixUDA; getUDAs!(fun, BotCommand))
                         {
                             import kameloso.string : beginsWith, has, nom,
                                 stripPrefix;

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -448,6 +448,7 @@ FilterResult filterUser(const IRCPluginState state, const IRCEvent event)
  +/
 mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
 {
+    import core.thread : Fiber;
     import std.concurrency : Tid;
 
     IRCPluginState privateState;

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -1656,12 +1656,10 @@ mixin template ChannelAwareness(bool debug_ = false, string module_ = __MODULE__
                     user = nickname in users;
                 }
 
-                //writefln("onSelfpart %s: %d", nickname, (*user).refcount);
                 if (--(*user).refcount == 0)
                 {
                     users.remove(nickname);
                 }
-                //else if ((*user).refcount < 0) writeln(nickname," REFOUNT < 0");
             }
 
             channels.remove(event.channel);

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -424,7 +424,7 @@ FilterResult filterUser(const IRCPluginState state, const IRCEvent event)
 }
 
 
-// IRCPluginBasics
+// IRCPluginImpl
 /++
  +  Mixin that fully implements an `IRCPlugin`.
  +
@@ -453,6 +453,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
 
     IRCPluginState privateState;
     Fiber[][IRCEvent.Type] privateAwaitingFibers;
+
 
     // onEvent
     /++
@@ -873,6 +874,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
         }
     }
 
+
     // this(IRCPluginState)
     /++
      +  Basic constructor for a plugin.
@@ -894,6 +896,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
         }
     }
 
+
     // bot
     /++
      +  Inherits a new `IRCBot`.
@@ -907,6 +910,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
     {
         privateState.bot = bot;
     }
+
 
     // bot
     /++
@@ -923,6 +927,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
         return privateState.bot;
     }
 
+
     // postprocess
     /++
      +  Lets a plugin modify an `IRCEvent` while it's begin constructed, before
@@ -938,6 +943,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
             .postprocess(this, event);
         }
     }
+
 
     // yieldWHOISReuests
     /++
@@ -956,6 +962,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
         return privateState.whoisQueue;
     }
 
+
     // writeConfig
     /++
      +  Writes configuration to disk.
@@ -963,13 +970,14 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
      +  Params:
      +      configFile = the file to write to.
      +/
-     void writeConfig(const string configFile)
-     {
-         static if (__traits(compiles, .writeConfig(this, string.init)))
-         {
-             .writeConfig(this, configFile);
-         }
-     }
+    void writeConfig(const string configFile)
+    {
+        static if (__traits(compiles, .writeConfig(this, string.init)))
+        {
+            .writeConfig(this, configFile);
+        }
+    }
+
 
     // loadConfig
     /++
@@ -1031,6 +1039,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
         }
     }
 
+
     // present
     /++
      +  Print some information to the screen, usually settings.
@@ -1042,6 +1051,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
             .present(this);
         }
     }
+
 
     // printSettings
     /++
@@ -1085,6 +1095,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
         }
     }
 
+
     // addToConfig
     /++
      +  Gathers the configuration text the plugin wants to contribute to the
@@ -1121,6 +1132,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
         }
     }
 
+
     // start
     /++
      +  Activates the plugin, run when connection has been established.
@@ -1133,6 +1145,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
         }
     }
 
+
     // teardown
     /++
      +  Deinitialises the plugin.
@@ -1144,6 +1157,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
             .teardown(this);
         }
     }
+
 
     // name
     /++
@@ -1166,6 +1180,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
         return moduleName;
     }
 
+
     // state
     /++
      +  Accessor and mutator, returns a reference to the current private
@@ -1179,6 +1194,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
     {
         return this.privateState;
     }
+
 
     // awaitingFibers
     /++
@@ -1224,6 +1240,7 @@ mixin template MessagingProxy(bool debug_ = false, string module_ = __MODULE__)
     static import kameloso.messaging;
     import std.typecons : Flag, No, Yes;
 
+
     // chan
     /++
      +  Sends a channel message.
@@ -1235,6 +1252,7 @@ mixin template MessagingProxy(bool debug_ = false, string module_ = __MODULE__)
         return kameloso.messaging.chan!quiet(state.mainThread, channel, content);
     }
 
+
     // query
     /++
      +  Sends a private query message to a user.
@@ -1245,6 +1263,7 @@ mixin template MessagingProxy(bool debug_ = false, string module_ = __MODULE__)
     {
         return kameloso.messaging.query!quiet(state.mainThread, nickname, content);
     }
+
 
     // privmsg
     /++
@@ -1262,6 +1281,7 @@ mixin template MessagingProxy(bool debug_ = false, string module_ = __MODULE__)
             nickname, content);
     }
 
+
     // throttleline
     /++
      +  Sends either a channel message or a private query message depending on
@@ -1278,6 +1298,7 @@ mixin template MessagingProxy(bool debug_ = false, string module_ = __MODULE__)
             nickname, content);
     }
 
+
     // emote
     /++
      +  Sends an `ACTION` "emote" to the supplied target (nickname or channel).
@@ -1289,6 +1310,7 @@ mixin template MessagingProxy(bool debug_ = false, string module_ = __MODULE__)
         return kameloso.messaging.emote!quiet(state.mainThread, emoteTarget,
             content);
     }
+
 
     // chanmode
     /++
@@ -1304,6 +1326,7 @@ mixin template MessagingProxy(bool debug_ = false, string module_ = __MODULE__)
         return kameloso.messaging.chanmode!quiet(state.mainThread, channel, modes, content);
     }
 
+
     // topic
     /++
      +  Sets the topic of a channel.
@@ -1314,6 +1337,7 @@ mixin template MessagingProxy(bool debug_ = false, string module_ = __MODULE__)
     {
         return kameloso.messaging.topic!quiet(state.mainThread, channel, content);
     }
+
 
     // invite
     /++
@@ -1326,6 +1350,7 @@ mixin template MessagingProxy(bool debug_ = false, string module_ = __MODULE__)
         return kameloso.messaging.invite!quiet(state.mainThread, channel, nickname);
     }
 
+
     // join
     /++
      +  Joins a channel.
@@ -1335,6 +1360,7 @@ mixin template MessagingProxy(bool debug_ = false, string module_ = __MODULE__)
     {
         return kameloso.messaging.join!quiet(state.mainThread, channel);
     }
+
 
     // kick
     /++
@@ -1346,6 +1372,7 @@ mixin template MessagingProxy(bool debug_ = false, string module_ = __MODULE__)
         return kameloso.messaging.kick!quiet(state.mainThread, channel, nickname, reason);
     }
 
+
     // part
     /++
      +  Leaves a channel.
@@ -1356,6 +1383,7 @@ mixin template MessagingProxy(bool debug_ = false, string module_ = __MODULE__)
         return kameloso.messaging.part!quiet(state.mainThread, channel);
     }
 
+
     // quit
     /++
      +  Disconnects from the server, optionally with a quit reason.
@@ -1365,6 +1393,7 @@ mixin template MessagingProxy(bool debug_ = false, string module_ = __MODULE__)
     {
         return kameloso.messaging.quit!quiet(state.mainThread, reason);
     }
+
 
     // raw
     /++

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -1569,3 +1569,152 @@ mixin template BasicEventHandlers(string module_ = __MODULE__)
         return doWhois!(F, typeof(null))(plugin, null, event, nickname, fn);
     }
 }
+
+
+// ChannelAwareness
+/++
+ +  FIXME
+ +/
+mixin template ChannelAwareness(string module_ = __MODULE__)
+{
+    @(Chainable)
+    @(ChannelPolicy.homeOnly)
+    @(IRCEvent.Type.SELFJOIN)
+    void onSelfjoinMixin(IRCPlugin plugin, const IRCEvent event)
+    {
+        with (plugin)
+        with (plugin.state)
+        {
+            // FIXME
+            channels[event.channel] = IRCChannel.init;
+        }
+    }
+
+    @(Chainable)
+    @(ChannelPolicy.homeOnly)
+    @(IRCEvent.Type.SELFPART)
+    void onSelfpartMixin(IRCPlugin plugin, const IRCEvent event)
+    {
+        with (plugin)
+        with (plugin.state)
+        {
+            // FIXME
+            channels.remove(event.channel);
+        }
+    }
+
+    @(Chainable)
+    @(ChannelPolicy.homeOnly)
+    @(IRCEvent.Type.JOIN)
+    void onJoinMixin(IRCPlugin plugin, const IRCEvent event)
+    {
+        with (plugin)
+        with (plugin.state)
+        {
+            // FIXME
+
+        }
+    }
+
+    @(Chainable)
+    @(ChannelPolicy.homeOnly)
+    @(IRCEvent.Type.PART)
+    void onPartMixin(IRCPlugin plugin, const IRCEvent event)
+    {
+        with (plugin)
+        with (plugin.state)
+        {
+            // FIXME
+
+        }
+    }
+
+    @(Chainable)
+    @(ChannelPolicy.homeOnly)
+    @(IRCEvent.Type.TOPIC)
+    @(IRCEvent.Type.RPL_TOPIC)
+    void onTopicMixin(IRCPlugin plugin, const IRCEvent event)
+    {
+        with (plugin)
+        with (plugin.state)
+        {
+            // FIXME
+            channels[event.channel].topic = event.content;
+        }
+    }
+
+    @(Chainable)// FIXME
+    @(ChannelPolicy.homeOnly)
+    @(IRCEvent.Type.CHANMODE)
+    void onChanModeMixin(IRCPlugin plugin, const IRCEvent event)
+    {
+        with (plugin)
+        with (plugin.state)
+        {
+            // FIXME REALLY REALLy
+            //channels[event.channel].setMode(event.aux, event.content);
+            channels[event.channel].setMode(event.aux ~ " " ~ event.content);
+        }
+    }
+
+    @(Chainable)
+    @(ChannelPolicy.homeOnly)
+    @(IRCEvent.Type.USERMODE)
+    void onUserModeMixin(IRCPlugin plugin, const IRCEvent event)
+    {
+        with (plugin)
+        with (plugin.state)
+        {
+            // FIXME
+            logger.warning("WHEN DOES THIS HAPPEN");
+            logger.trace(event.raw);
+        }
+    }
+
+    @(Chainable)
+    @(ChannelPolicy.homeOnly)
+    @(IRCEvent.Type.RPL_WHOREPLY)
+    void onWHOReplyMixin(IRCPlugin plugin, const IRCEvent event)
+    {
+        with (plugin)
+        with (plugin.state)
+        with (event.target)
+        {
+            // FIXME
+            auto user = nickname in users;
+            if (user) return;
+
+            users[nickname] = IRCUser(nickname, ident, address);
+        }
+    }
+
+    /*@(Chainable)
+    @(ChannelPolicy.homeOnly)
+    @(IRCEvent.Type.RPL_NAMREPLY)
+    void onNamesReplyMixin(IRCPlugin plugin, const IRCEvent event)
+    {
+        with (plugin)
+        {
+            // FIXME
+        }
+    }*/
+
+    @(Chainable)
+    @(ChannelPolicy.homeOnly)
+    @(IRCEvent.Type.RPL_BANLIST)
+    void onBanListMixin(IRCPlugin plugin, const IRCEvent event)
+    {
+        with (plugin)
+        with (plugin.state)
+        with (event.target)
+        {
+            // :kornbluth.freenode.net 367 kameloso #flerrp huerofi!*@* zorael!~NaN@2001:41d0:2:80b4:: 1513899527
+            // :kornbluth.freenode.net 367 kameloso #flerrp harbl!harbl@snarbl.com zorael!~NaN@2001:41d0:2:80b4:: 1513899521
+            // FIXME
+            auto user = nickname in users;
+            if (user) return;
+
+            users[nickname] = IRCUser(event.content);
+        }
+    }
+}

--- a/source/kameloso/plugins/connect.d
+++ b/source/kameloso/plugins/connect.d
@@ -117,28 +117,6 @@ void onSelfjoin(ConnectPlugin plugin, const IRCEvent event)
 }
 
 
-// onEndOfNames
-/++
- +  Query `WHO` on a channel after its list of names ends, to get the services
- +  login names of everyone in it.
- +
- +  Bugs: If it joins too many (home) channels at once, you will be kicked due
- +        to flooding and possibly tempbanned. Consider disabling if you have a
- +        lot of homes.
- +/
-@(IRCEvent.Type.RPL_ENDOFNAMES)
-@(ChannelPolicy.homeOnly)
-void onEndOfNames(ConnectPlugin plugin, const IRCEvent event)
-{
-    with (plugin.state)
-    {
-        if (bot.server.daemon == IRCServer.Daemon.twitch) return;
-
-        mainThread.send(ThreadMessage.Throttleline(), "WHO " ~ event.channel);
-    }
-}
-
-
 // joinChannels
 /++
  +  Joins all channels listed as homes *and* channels in the `IRCBot` object.

--- a/source/kameloso/plugins/connect.d
+++ b/source/kameloso/plugins/connect.d
@@ -685,7 +685,7 @@ void start(IRCPlugin plugin)
 }
 
 
-mixin BasicEventHandlers;
+mixin UserAwareness;
 
 public:
 

--- a/source/kameloso/plugins/ctcp.d
+++ b/source/kameloso/plugins/ctcp.d
@@ -214,7 +214,8 @@ void onCTCPClientinfo(CTCPPlugin plugin, const IRCEvent event)
 
     enum string allCTCPTypes = ()
     {
-        import std.conv   : to;
+        import kameloso.string : beginsWith;
+        import std.conv : to;
         import std.string : stripRight;
         import std.traits : getSymbolsByUDA, getUDAs, isSomeFunction;
 
@@ -226,7 +227,12 @@ void onCTCPClientinfo(CTCPPlugin plugin, const IRCEvent event)
             {
                 foreach (type; getUDAs!(fun, IRCEvent.Type))
                 {
-                    allTypes = allTypes ~ type.to!string[5..$] ~ " ";
+                    enum typestring = type.to!string;
+
+                    static if (typestring.beginsWith("CTCP_"))
+                    {
+                        allTypes = allTypes ~ typestring[5..$] ~ " ";
+                    }
                 }
             }
         }

--- a/source/kameloso/plugins/notes.d
+++ b/source/kameloso/plugins/notes.d
@@ -410,7 +410,7 @@ void onEndOfMotd(NotesPlugin plugin)
 }
 
 
-mixin BasicEventHandlers;
+mixin UserAwareness;
 
 public:
 

--- a/source/kameloso/plugins/notes.d
+++ b/source/kameloso/plugins/notes.d
@@ -125,9 +125,9 @@ void onNames(NotesPlugin plugin, const IRCEvent event)
  +/
 @(IRCEvent.Type.CHAN)
 @(PrivilegeLevel.friend)
-@Prefix("note")
-@Prefix(NickPolicy.required, "addnote")
-@Prefix(NickPolicy.required, "note")
+@BotCommand("note")
+@BotCommand(NickPolicy.required, "addnote")
+@BotCommand(NickPolicy.required, "note")
 void onCommandAddNote(NotesPlugin plugin, const IRCEvent event)
 {
     import std.format : format, formattedRead;
@@ -164,7 +164,7 @@ void onCommandAddNote(NotesPlugin plugin, const IRCEvent event)
 @(IRCEvent.Type.CHAN)
 @(IRCEvent.Type.QUERY)
 @(PrivilegeLevel.master)
-@Prefix(NickPolicy.required, "printnotes")
+@BotCommand(NickPolicy.required, "printnotes")
 void onCommandPrintNotes(NotesPlugin plugin)
 {
     writeln(plugin.notes.toPrettyString);
@@ -181,7 +181,7 @@ void onCommandPrintNotes(NotesPlugin plugin)
 @(IRCEvent.Type.CHAN)
 @(IRCEvent.Type.QUERY)
 @(PrivilegeLevel.master)
-@Prefix(NickPolicy.required, "reloadnotes")
+@BotCommand(NickPolicy.required, "reloadnotes")
 void onCommandReloadQuotes(NotesPlugin plugin)
 {
     logger.log("Reloading notes");
@@ -197,7 +197,7 @@ void onCommandReloadQuotes(NotesPlugin plugin)
  +/
 @(IRCEvent.Type.CHAN)
 @(PrivilegeLevel.master)
-@Prefix(NickPolicy.required, "fakejoin")
+@BotCommand(NickPolicy.required, "fakejoin")
 void onCommandFakejoin(NotesPlugin plugin, const IRCEvent event)
 {
     import kameloso.string : has, nom;

--- a/source/kameloso/plugins/package.d
+++ b/source/kameloso/plugins/package.d
@@ -13,6 +13,7 @@ public import kameloso.plugins.printer;
 public import kameloso.plugins.sedreplace;
 public import kameloso.plugins.twitch;
 public import kameloso.plugins.seen;
+public import kameloso.plugins.chanqueries;
 
 version(Posix)
 {
@@ -32,6 +33,7 @@ version(Web)
 public alias EnabledPlugins = AliasSeq!(
     PrinterPlugin,
     ConnectPlugin,
+    ChanQueriesPlugin,
     AdminPlugin,
     ChatbotPlugin,
     NotesPlugin,

--- a/source/kameloso/plugins/printer.d
+++ b/source/kameloso/plugins/printer.d
@@ -911,8 +911,6 @@ unittest
 }
 
 
-mixin BasicEventHandlers;
-
 public:
 
 

--- a/source/kameloso/plugins/printer.d
+++ b/source/kameloso/plugins/printer.d
@@ -424,7 +424,6 @@ void formatMessage(Sink)(PrinterPlugin plugin, auto ref Sink sink, IRCEvent even
                     return fg[colourIndex];
                 }
 
-                // fixme
                 return bright ? DefaultBright.sender : DefaultDark.sender;
             }
 

--- a/source/kameloso/plugins/reddit.d
+++ b/source/kameloso/plugins/reddit.d
@@ -47,8 +47,8 @@ struct RedditLookup
  +/
 @(IRCEvent.Type.CHAN)
 @(IRCEvent.Type.QUERY)
-@Prefix(NickPolicy.direct, "reddit")
-@Prefix(NickPolicy.required, "reddit")
+@BotCommand(NickPolicy.direct, "reddit")
+@BotCommand(NickPolicy.required, "reddit")
 void onMessage(RedditPlugin plugin, const IRCEvent event)
 {
     import kameloso.constants : Timeout;

--- a/source/kameloso/plugins/reddit.d
+++ b/source/kameloso/plugins/reddit.d
@@ -234,7 +234,7 @@ void start(IRCPlugin basePlugin)
 
 public:
 
-mixin BasicEventHandlers;
+mixin UserAwareness;
 
 
 // RedditPlugin

--- a/source/kameloso/plugins/sedreplace.d
+++ b/source/kameloso/plugins/sedreplace.d
@@ -208,7 +208,7 @@ void onMessage(SedReplacePlugin plugin, const IRCEvent event)
 }
 
 
-mixin BasicEventHandlers;
+mixin UserAwareness;
 
 public:
 

--- a/source/kameloso/plugins/seen.d
+++ b/source/kameloso/plugins/seen.d
@@ -222,8 +222,6 @@ void onPing(SeenPlugin plugin)
 
         foreach (const channel; state.bot.homes)
         {
-            import std.concurrency : send;
-
             /++
              +  The bot uses concurrency messages to queue strings to be sent to
              +  the server. This has benefits such as that even a multi-threaded
@@ -238,7 +236,7 @@ void onPing(SeenPlugin plugin)
              +  of why we wanted to import that.
              +/
             // FIXME
-            raw!(Yes.quiet)("WHO " ~ channel);
+            //raw!(Yes.quiet)("WHO " ~ channel);
         }
 
         import std.datetime.systime : Clock;

--- a/source/kameloso/plugins/seen.d
+++ b/source/kameloso/plugins/seen.d
@@ -461,7 +461,7 @@ void teardown(IRCPlugin basePlugin)
  +  It's boilerplate so you don't have to deal with some very basic things. It
  +  is not mandatory but highly recommended in nearly all cases.
  +/
-mixin BasicEventHandlers;
+mixin UserAwareness;
 
 
 /++

--- a/source/kameloso/plugins/seen.d
+++ b/source/kameloso/plugins/seen.d
@@ -258,12 +258,14 @@ void onPing(SeenPlugin plugin)
  +  Whenever someone says "seen" in a `CHAN` or a `QUERY`, and if `CHAN` then
  +  only if in a *home*, process this function.
  +
- +  The `Prefix` annotation defines a piece of text that the incoming message
- +  must start with for this function to be called. `NickPolicy` deals with
- +  whether the message has to start with the name of the *bot* or not, and to
- +  what extent. It can be one of:
+ +  The `BotCommand` annotation defines a piece of text that the incoming
+ +  message must start with for this function to be called. `NickPolicy` deals
+ +  with whether the message has to start with the name of the *bot* or not, and
+ +  to what extent.
+ +
+ +  It can be one of:
  +  * `optional`, where the bot's nickname will be allowed and stripped away,
- +     but the function will still be invoked given the right prefix string.
+ +     but the function will still be invoked given the right command string.
  +  * `required`, where the message has to start with the name of the bot if in
  +     a `CHAN` message, but it needn't be there in a `QUERY`.
  +  * `hardRequired`, where the message *has* to start with the bot's nickname
@@ -280,8 +282,9 @@ void onPing(SeenPlugin plugin)
  +  --------------
  +
  +  The plugin system will have made certain we only get messages starting with
- +  "seen", since we annotated this function with such a `Prefix`. It will since
- +  have been sliced off, so we're left only with the "arguments" to "seen".
+ +  "`seen`", since we annotated this function with such a `BotCommand`. It will
+ +  since have been sliced off, so we're left only with the "arguments" to
+ +  "`seen`".
  +
  +  If this is a `CHAN` event, the original lines was probably
  +  "`kameloso: seen Joe`". If it was a `QUERY`, the `kameloso:` prefix may have

--- a/source/kameloso/plugins/seen.d
+++ b/source/kameloso/plugins/seen.d
@@ -292,8 +292,8 @@ void onPing(SeenPlugin plugin)
 @(IRCEvent.Type.QUERY)
 @(ChannelPolicy.homeOnly)
 @(PrivilegeLevel.friend)
-@Prefix("seen")
-@Prefix(NickPolicy.required, "seen")
+@BotCommand("seen")
+@BotCommand(NickPolicy.required, "seen")
 void onCommandSeen(SeenPlugin plugin, const IRCEvent event)
 {
     import kameloso.string : timeSince;
@@ -346,7 +346,7 @@ void onCommandSeen(SeenPlugin plugin, const IRCEvent event)
 @(IRCEvent.Type.QUERY)
 @(ChannelPolicy.homeOnly)
 @(PrivilegeLevel.master)
-@Prefix(NickPolicy.required, "printseen")
+@BotCommand(NickPolicy.required, "printseen")
 void onCommandPrintSeen(SeenPlugin plugin)
 {
     writeln(plugin.seenUsers.toPrettyString);

--- a/source/kameloso/plugins/twitch.d
+++ b/source/kameloso/plugins/twitch.d
@@ -361,8 +361,6 @@ void parseTwitchTags(TwitchPlugin plugin, ref IRCEvent event)
 }
 
 
-mixin BasicEventHandlers;
-
 public:
 
 

--- a/source/kameloso/plugins/webtitles.d
+++ b/source/kameloso/plugins/webtitles.d
@@ -178,8 +178,7 @@ void worker(shared IRCPluginState sState, ref shared TitleLookup[string] cache,
  +/
 void reportURL(Tid tid, const TitleLookup lookup, const IRCEvent event)
 {
-    //import kameloso.outgoing : privmsg;
-    import std.concurrency : send;
+    import kameloso.messaging : privmsg;
     import std.format : format;
 
     string line;

--- a/source/kameloso/plugins/webtitles.d
+++ b/source/kameloso/plugins/webtitles.d
@@ -193,8 +193,7 @@ void reportURL(Tid tid, const TitleLookup lookup, const IRCEvent event)
         line = lookup.title;
     }
 
-    // FIXME
-    //tid.privmsg(event.channel, event.sender.nickname, line);
+    tid.privmsg(event.channel, event.sender.nickname, line);
 }
 
 

--- a/source/kameloso/plugins/webtitles.d
+++ b/source/kameloso/plugins/webtitles.d
@@ -398,7 +398,7 @@ void start(IRCPlugin basePlugin)
 }
 
 
-mixin BasicEventHandlers;
+mixin UserAwareness;
 
 public:
 

--- a/tests/events.d
+++ b/tests/events.d
@@ -1515,13 +1515,26 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == USERMODE), type.to!string);
+            assert((type == CHANMODE), type.to!string);
             assert((sender.nickname == "zorael"), sender.nickname);
             assert((sender.ident == "~NaN"), sender.ident);
             assert((sender.address == "ns3363704.ip-94-23-253.eu"), sender.address);
             assert(!sender.special, sender.special.to!string);
             assert((channel == "#flerrp"), channel);
             assert((aux == "+i"), aux);
+        }
+    }
+
+    {
+        immutable event = parser.toIRCEvent(":niven.freenode.net MODE #sklabjoier +ns");
+        with (IRCEvent.Type)
+        with (event)
+        {
+            assert((type == CHANMODE), type.to!string);
+            assert((sender.address == "niven.freenode.net"), sender.address);
+            assert(sender.special, sender.special.to!string);
+            assert((channel == "#sklabjoier"), channel);
+            assert((aux == "+ns"), aux);
         }
     }
 


### PR DESCRIPTION
This adds (the option of) channel awareness to plugins.

With it, current channels are kept track of, including topics, modes and participants.

Also included are some renames, notably `BasicEventHandler` to `UserAwareness` and `Prefix` to `BotCommand`, to better convey what they do.