### PR TITLE
Postparse rework

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -15,7 +15,7 @@
         "--ex", "arsd."
     ],
     "-ddoxTool" : "scod",
-    "versions": [ "PostParseSanityCheck" ],
+    "versions": [ "AsAnApplicatiozn" ],
     "configurations":
     [
         {

--- a/source/kameloso/irc.d
+++ b/source/kameloso/irc.d
@@ -954,6 +954,13 @@ void parseSpecialcases(ref IRCParser parser, ref IRCEvent event, ref string slic
     case RPL_LIST: // 322
         // :irc.RomaniaChat.eu 322 kameloso #GameOfThrones 1 :[+ntTGfB]
         // :irc.RomaniaChat.eu 322 kameloso #radioclick 63 :[+ntr]  Bun venit pe #Radioclick! Site oficial www.radioclick.ro sau servere irc.romaniachat.eu, irc.radioclick.ro
+        // :eggbert.ca.na.irchighway.net 322 kameloso * 3 :
+        /*
+            (asterisk channels)
+            milky | channel isn't public nor are you a member
+            milky | Unreal inserts that instead of not sending the result
+            milky | Other IRCd may do same because they are all derivatives
+         */
         slice.nom(' '); // bot nickname
         event.channel = slice.nom(' ');
         event.aux = slice.nom(" :");

--- a/source/kameloso/irc.d
+++ b/source/kameloso/irc.d
@@ -12,6 +12,24 @@ import kameloso.string : has, nom;
 
 private:
 
+version(AsAnApplication)
+{
+    /+
+        As an application; log sanity check failures to screen. Parsing proceeds
+        and plugins are processed.
+     +/
+    version = PrintSanityFailures;
+}
+else
+{
+    /+
+        As a library; throw an exception on sanity check failures. Parsing halts
+        and the event dies mid-flight. However, no Logger will be imported,
+        leaving the library headless.
+     +/
+    version = ThrowSanityFailures;
+}
+
 
 // parseBasic
 /++

--- a/source/kameloso/irc.d
+++ b/source/kameloso/irc.d
@@ -2017,12 +2017,9 @@ IRCEvent toIRCEvent(ref IRCParser parser, const string raw)
     // useful strings, like sender, target and content
     parser.parseSpecialcases(event, slice);
 
-    version(PostParseSanityCheck)
-    {
-        // Final pass: sanity check. This verifies some fields and gives
-        // meaningful error messages if something doesn't look right.
-        parser.postparseSanityCheck(event);
-    }
+    // Final pass: sanity check. This verifies some fields and gives
+    // meaningful error messages if something doesn't look right.
+    parser.postparseSanityCheck(event);
 
     return event;
 }

--- a/source/kameloso/ircdefs.d
+++ b/source/kameloso/ircdefs.d
@@ -1091,22 +1091,75 @@ struct IRCUser
     /// User classifier.
     Class class_;
 
+
+    // lowercaseNickname
     /++
      +  Produces this user's nickname in lowercase as per the supplied case
      +  mappings.
      +
-     +  Member function to work on `this`. Wraps to the static function below.
+     +  Member function to work on `this`. Wraps to the static function.
+     +
+     +  Params:
+     +      caseMapping = Server case mapping; maps uppercase to lowercase
+     +          characters.
+     +
+     +  Returns:
+     +      The passed nickname string with uppercase characters replaced as per
+     +      the case mappings.
      +/
     string lowercaseNickname(IRCServer.CaseMapping caseMapping = IRCServer.CaseMapping.rfc1459) const nothrow pure
     {
         return lowercaseNickname(nickname, caseMapping);
     }
 
+    ///
+    unittest
+    {
+        IRCServer.CaseMapping m = IRCServer.CaseMapping.rfc1459;
+        IRCUser user;
+
+        user.nickname = "ABCDEF";
+        assert((user.lowercaseNickname(m) == "abcdef"), user.lowercaseNickname);
+
+        user.nickname = "123";
+        assert((user.lowercaseNickname(m) == "123"), user.lowercaseNickname);
+
+        user.nickname = "^[0v0]^";
+        assert((user.lowercaseNickname(m) == "~{0v0}~"), user.lowercaseNickname);
+
+        user.nickname = `A|\|`;
+        assert((user.lowercaseNickname(m) == `a|||`), user.lowercaseNickname);
+
+        m = IRCServer.CaseMapping.ascii;
+
+        user.nickname = "^[0v0]^";
+        assert((user.lowercaseNickname(m) == "^[0v0]^"), user.lowercaseNickname);
+
+        user.nickname = `A|\|`;
+        assert((user.lowercaseNickname(m) == `a|\|`), user.lowercaseNickname);
+
+        m = IRCServer.CaseMapping.strict_rfc1459;
+
+        user.nickname = "^[0v0]^";
+        assert((user.lowercaseNickname(m) == "^{0v0}^"), user.lowercaseNickname);
+    }
+
+
+    // lowercaseNickname
     /++
      +  Produces the passed nickname in lowercase as per the supplied case
      +  mappings.
      +
      +  Static version to work on passed strings.
+     +
+     +  Params:
+     +      nickname = String nickname to parse into lowercase.
+     +      caseMapping = Server case mapping; maps uppercase to lowercase
+     +          characters.
+     +
+     +  Returns:
+     +      The passed nickname string with uppercase characters replaced as per
+     +      the case mappings.
      +/
     static string lowercaseNickname(const string nickname,
         IRCServer.CaseMapping caseMapping = IRCServer.CaseMapping.rfc1459) nothrow pure
@@ -1156,32 +1209,41 @@ struct IRCUser
     unittest
     {
         IRCServer.CaseMapping m = IRCServer.CaseMapping.rfc1459;
-        IRCUser user;
 
-        user.nickname = "ABCDEF";
-        assert((user.lowercaseNickname(m) == "abcdef"), user.lowercaseNickname);
+        {
+            immutable lowercase = lowercaseNickname("ABCDEF", m);
+            assert((lowercase == "abcdef"), lowercase);
+        }
+        {
+            immutable lowercase = lowercaseNickname("123", m);
+            assert((lowercase == "123"), lowercase);
+        }
+        {
+            immutable lowercase = lowercaseNickname("^[0v0]^", m);
+            assert((lowercase == "~{0v0}~"), lowercase);
+        }
+        {
+            immutable lowercase = lowercaseNickname(`A|\|`, m);
+            assert((lowercase == "a|||"), lowercase);
+        }
 
-        user.nickname = "123";
-        assert((user.lowercaseNickname(m) == "123"), user.lowercaseNickname);
+        m = IRCServer.caseMapping.ascii;
 
-        user.nickname = "^[0v0]^";
-        assert((user.lowercaseNickname(m) == "~{0v0}~"), user.lowercaseNickname);
-
-        user.nickname = `A|\|`;
-        assert((user.lowercaseNickname(m) == `a|||`), user.lowercaseNickname);
-
-        m = IRCServer.CaseMapping.ascii;
-
-        user.nickname = "^[0v0]^";
-        assert((user.lowercaseNickname(m) == "^[0v0]^"), user.lowercaseNickname);
-
-        user.nickname = `A|\|`;
-        assert((user.lowercaseNickname(m) == `a|\|`), user.lowercaseNickname);
+        {
+            immutable lowercase = lowercaseNickname("^[0v0]^", m);
+            assert((lowercase == "^[0v0]^"), lowercase);
+        }
+        {
+            immutable lowercase = lowercaseNickname(`A|\|`, m);
+            assert((lowercase == `a|\|`), lowercase);
+        }
 
         m = IRCServer.CaseMapping.strict_rfc1459;
 
-        user.nickname = "^[0v0]^";
-        assert((user.lowercaseNickname(m) == "^{0v0}^"), user.lowercaseNickname);
+        {
+            immutable lowercase = lowercaseNickname("^[0v0]^", m);
+            assert((lowercase == "^{0v0}^"), lowercase);
+        }
     }
 
 

--- a/source/kameloso/ircdefs.d
+++ b/source/kameloso/ircdefs.d
@@ -879,8 +879,8 @@ struct IRCBot
         string[] channels;
     }
 
-    /// Status of a process.
-    enum Status
+    /// Progress of a process.
+    enum Progress
     {
         unset,
         notStarted,
@@ -896,11 +896,11 @@ struct IRCBot
         /// The original bot nickname before connecting, in case it changed.
         string origNickname;
 
-        /// Status of authentication process (SASL, NickServ).
-        Status authentication;
+        /// Progress of authentication process (SASL, NickServ).
+        Progress authentication;
 
-        /// Status of registration process (logon).
-        Status registration;
+        /// Progress of registration process (logon).
+        Progress registration;
 
         /// Whether or not the bot was altered.
         bool updated;

--- a/source/kameloso/main.d
+++ b/source/kameloso/main.d
@@ -877,8 +877,8 @@ int main(string[] args)
             import kameloso.ircdefs : IRCBot;  // fix visibility warning
             import kameloso.irc : IRCParser;
 
-            bot.registration = IRCBot.Status.notStarted;
-            bot.authentication = IRCBot.Status.notStarted;
+            bot.registration = IRCBot.Progress.notStarted;
+            bot.authentication = IRCBot.Progress.notStarted;
 
             /+
              +  If we're reconnecting we're connecting to the same server, so we

--- a/source/kameloso/plugins/connect.d
+++ b/source/kameloso/plugins/connect.d
@@ -44,8 +44,8 @@ struct ConnectSettings
 }
 
 
-/// Shorthand alias to `kameloso.ircdefs.IRCBot.Status`.
-alias Status = IRCBot.Status;
+/// Shorthand alias to `kameloso.ircdefs.IRCBot.Progress`.
+alias Progress = IRCBot.Progress;
 
 
 // onSelfpart
@@ -188,10 +188,10 @@ void onPing(ConnectService service, const IRCEvent event)
     {
         mainThread.prioritySend(ThreadMessage.Pong(), target);
 
-        if (bot.authentication == Status.started)
+        if (bot.authentication == Progress.started)
         {
             logger.log("Auth timed out. Joining channels ...");
-            bot.authentication = Status.finished;
+            bot.authentication = Progress.finished;
             bot.updated = true;
             service.joinChannels();
         }
@@ -232,7 +232,7 @@ void tryAuth(ConnectService service)
 
         case "EFNet":
             // No registration available
-            bot.authentication = Status.finished;
+            bot.authentication = Progress.finished;
             bot.updated = true;
             return;
 
@@ -245,7 +245,7 @@ void tryAuth(ConnectService service)
             break;
         }
 
-        bot.authentication = Status.started;
+        bot.authentication = Progress.started;
         bot.updated = true;
 
         with (IRCServer.Daemon)
@@ -261,7 +261,7 @@ void tryAuth(ConnectService service)
                 logger.warningf("Cannot auth when you have changed your nickname " ~
                     "(%s != %s)", bot.nickname, bot.origNickname);
 
-                bot.authentication = Status.finished;
+                bot.authentication = Progress.finished;
                 bot.updated = true;
                 service.joinChannels();
                 return;
@@ -297,7 +297,7 @@ void tryAuth(ConnectService service)
 
         case twitch:
             // No registration available
-            bot.authentication = Status.finished;
+            bot.authentication = Progress.finished;
             bot.updated = true;
             return;
 
@@ -326,12 +326,12 @@ void onEndOfMotd(ConnectService service)
 {
     with (service.state)
     {
-        if (bot.authPassword.length && (bot.authentication == Status.notStarted))
+        if (bot.authPassword.length && (bot.authentication == Progress.notStarted))
         {
             service.tryAuth();
         }
 
-        if ((bot.authentication == Status.finished) ||
+        if ((bot.authentication == Progress.finished) ||
             !bot.authPassword.length ||
             (bot.server.daemon == IRCServer.Daemon.twitch))
         {
@@ -365,12 +365,12 @@ void onAuthEnd(ConnectService service)
 {
     with (service.state)
     {
-        bot.authentication = Status.finished;
+        bot.authentication = Progress.finished;
         bot.updated = true;
 
         // This can be before registration ends in case of SASL
         // return if still registering
-        if (bot.registration == Status.started) return;
+        if (bot.registration == Progress.started) return;
 
         logger.log("Joining channels ...");
         service.joinChannels();
@@ -388,7 +388,7 @@ void onNickInUse(ConnectService service)
 {
     with (service.state)
     {
-        if (service.state.bot.registration == IRCBot.Status.started)
+        if (service.state.bot.registration == Progress.started)
         {
             if (service.renamedDuringRegistration)
             {
@@ -419,7 +419,7 @@ void onNickInUse(ConnectService service)
 @(IRCEvent.Type.ERR_ERRONEOUSNICKNAME)
 void onBadNick(ConnectService service)
 {
-    if (service.state.bot.registration == IRCBot.Status.started)
+    if (service.state.bot.registration == Progress.started)
     {
         // Mid-registration and invalid nickname; abort
         logger.error("Your nickname is too long or contains invalid characters");
@@ -567,7 +567,7 @@ void onSASLAuthenticate(ConnectService service)
         import kameloso.string : beginsWith;
         import std.base64 : Base64;
 
-        authentication = Status.started;
+        authentication = Progress.started;
         updated = true;
 
         immutable authLogin = authLogin.length ? authLogin : origNickname;
@@ -595,7 +595,7 @@ void onSASLSuccess(ConnectService service)
 {
     with (service.state)
     {
-        bot.authentication = Status.finished;
+        bot.authentication = Progress.finished;
         bot.updated = true;
 
         /++
@@ -636,7 +636,7 @@ void onSASLFailure(ConnectService service)
 
         // Auth failed and will fail even if we try NickServ, so flag as
         // finished auth and invoke `CAP END`
-        bot.authentication = Status.finished;
+        bot.authentication = Progress.finished;
         bot.updated = true;
 
         // See `onSASLSuccess` for info on `CAP END`
@@ -654,7 +654,7 @@ void onWelcome(ConnectService service)
 {
     with (service.state)
     {
-        bot.registration = IRCBot.Status.finished;
+        bot.registration = Progress.finished;
         bot.updated = true;
     }
 }
@@ -687,7 +687,7 @@ void register(ConnectService service)
 {
     with (service.state)
     {
-        bot.registration = Status.started;
+        bot.registration = Progress.started;
         bot.updated = true;
 
         service.raw!(Yes.quiet)("CAP LS 302");


### PR DESCRIPTION
This reworks `postParseSanityCheck` in several ways. Prominent among them is that abnormal events will now throw if compiled outside version `AsAnApplication`, allowing for using the IRC bits as a library to catch the errors while still remaining headless.