### PR TITLE
Rename kameloso.string.has to contains

### DIFF
--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -478,7 +478,7 @@ if (isOutputRange!(Sink, char[]))
 ///
 @system unittest
 {
-    import kameloso.string : has;
+    import kameloso.string : contains;
     import std.array : Appender;
     import std.format : format;
     import std.stdio;
@@ -593,21 +593,21 @@ if (isOutputRange!(Sink, char[]))
 
         assert((sink.data.length > 12), "Empty sink after coloured fill");
 
-        assert(sink.data.has("-- StructName"));
-        assert(sink.data.has("int_"));
-        assert(sink.data.has("12345"));
+        assert(sink.data.contains("-- StructName"));
+        assert(sink.data.contains("int_"));
+        assert(sink.data.contains("12345"));
 
-        assert(sink.data.has("string_"));
-        assert(sink.data.has(`"foo"`));
+        assert(sink.data.contains("string_"));
+        assert(sink.data.contains(`"foo"`));
 
-        assert(sink.data.has("bool_"));
-        assert(sink.data.has("true"));
+        assert(sink.data.contains("bool_"));
+        assert(sink.data.contains("true"));
 
-        assert(sink.data.has("float_"));
-        assert(sink.data.has("3.14"));
+        assert(sink.data.contains("float_"));
+        assert(sink.data.contains("3.14"));
 
-        assert(sink.data.has("double_"));
-        assert(sink.data.has("99.9"));
+        assert(sink.data.contains("double_"));
+        assert(sink.data.contains("99.9"));
 
         // Adding Settings does nothing
         alias StructName2Settings = StructName2;

--- a/source/kameloso/config.d
+++ b/source/kameloso/config.d
@@ -448,11 +448,11 @@ string[][string] applyConfiguration(Range, Things...)(Range range, ref Things th
                                     }
                                     else
                                     {
-                                        import kameloso.string : has, nom;
+                                        import kameloso.string : contains, nom;
                                         // Slice away any comments
                                         string value = hits["value"];
-                                        value = value.has('#') ? value.nom('#') : value;
-                                        value = value.has(';') ? value.nom(';') : value;
+                                        value = value.contains('#') ? value.nom('#') : value;
+                                        value = value.contains(';') ? value.nom(';') : value;
                                         things[i].setMemberByName(entry, value);
                                     }
                                     continue thingloop;

--- a/source/kameloso/debugging.d
+++ b/source/kameloso/debugging.d
@@ -382,7 +382,7 @@ void generateAsserts(ref Client client) @system
     import kameloso.conv : Enum;
     import kameloso.debugging : formatEventAssertBlock;
     import kameloso.ircdefs : IRCServer;
-    import kameloso.string : has, nom, stripped;
+    import kameloso.string : contains, nom, stripped;
     import std.conv : ConvException;
     import std.range : chunks, only;
     import std.stdio : stdout, readln, write, writeln, writefln;
@@ -403,7 +403,7 @@ void generateAsserts(ref Client client) @system
         write("Enter daemon (ircdseven): ");
         string slice = readln().stripped;
 
-        immutable daemonstring = slice.has(" ") ? slice.nom(" ") : slice;
+        immutable daemonstring = slice.contains(" ") ? slice.nom(" ") : slice;
         immutable version_ = slice;
 
         try

--- a/source/kameloso/getopt.d
+++ b/source/kameloso/getopt.d
@@ -181,13 +181,13 @@ Flag!"quit" handleGetopt(ref Client client, string[] args, ref string[] customSe
         import std.range : only;
         foreach (immutable setting; only("--monochrome", "--bright")) //, "--brightTerminal"))
         {
-            import kameloso.string : beginsWith, has, nom;
+            import kameloso.string : beginsWith, contains, nom;
             import std.algorithm.iteration : filter;
             import std.conv : to;
 
             foreach (immutable arg; argsBackup.filter!(word => word.beginsWith(setting)))
             {
-                if (!arg.has('='))
+                if (!arg.contains('='))
                 {
                     // It's an implicitly positive assignment which do not
                     // exhibit the behaviour we're working around.

--- a/source/kameloso/irc.d
+++ b/source/kameloso/irc.d
@@ -6,7 +6,7 @@ module kameloso.irc;
 
 public import kameloso.ircdefs;
 
-import kameloso.string : has, nom;
+import kameloso.string : contains, nom;
 
 @safe:
 
@@ -48,11 +48,11 @@ void parseBasic(ref IRCParser parser, ref IRCEvent event) pure
     string slice = event.raw;
     string typestring;
 
-    if (slice.has(':'))
+    if (slice.contains(':'))
     {
         typestring = slice.nom(" :");
     }
-    else if (slice.has(' '))
+    else if (slice.contains(' '))
     {
         typestring = slice.nom(' ');
     }
@@ -70,7 +70,7 @@ void parseBasic(ref IRCParser parser, ref IRCEvent event) pure
         // PING :weber.freenode.net
         event.type = PING;
 
-        if (slice.has('.'))
+        if (slice.contains('.'))
         {
             event.sender.address = slice;
         }
@@ -193,14 +193,14 @@ void parsePrefix(ref IRCParser parser, ref IRCEvent event, ref string slice) pur
 
     with (event.sender)
     {
-        if (prefix.has('!'))
+        if (prefix.contains('!'))
         {
             // user!~ident@address
             nickname = prefix.nom('!');
             ident = prefix.nom('@');
             address = prefix;
         }
-        else if (prefix.has('.'))
+        else if (prefix.contains('.'))
         {
             // dots signify an address
             address = prefix;
@@ -300,7 +300,7 @@ void parseTypestring(ref IRCParser parser, ref IRCEvent event, ref string slice)
 
     string typestring;
 
-    if (slice.has(' '))
+    if (slice.contains(' '))
     {
         typestring = slice.nom(' ');
     }
@@ -420,7 +420,7 @@ void parseSpecialcases(ref IRCParser parser, ref IRCEvent event, ref string slic
         // :kameloso^^!~NaN@C2802314.E23AD7D8.E9841504.IP JOIN :#flerrp
         event.type = (event.sender.nickname == bot.nickname) ? SELFJOIN : JOIN;
 
-        if (slice.has(' '))
+        if (slice.contains(' '))
         {
             // :nick!user@host JOIN #channelname accountname :Real Name
             // :nick!user@host JOIN #channelname * :Real Name
@@ -443,7 +443,7 @@ void parseSpecialcases(ref IRCParser parser, ref IRCEvent event, ref string slic
         // :gallon!~MO.11063@482c29a5.e510bf75.97653814.IP4 PART :#cncnet-yr
         event.type = (event.sender.nickname == bot.nickname) ? SELFPART : PART;
 
-        if (slice.has(' '))
+        if (slice.contains(' '))
         {
             event.channel = slice.nom(" :");
             event.content = slice;
@@ -590,7 +590,7 @@ void parseSpecialcases(ref IRCParser parser, ref IRCEvent event, ref string slic
         // :niven.freenode.net 728 kameloso^ #flerrp q qqqq!*@asdf.net zorael!~NaN@2001:41d0:2:80b4:: 1514405101
         // :irc.oftc.net 344 kameloso #garderoben harbl!snarbl@* kameloso!~NaN@194.117.188.126 1515418362
         slice.nom(' ');  // bot nickname
-        event.channel = slice.has(" q ") ? slice.nom(" q ") : slice.nom(' ');
+        event.channel = slice.contains(" q ") ? slice.nom(" q ") : slice.nom(' ');
         event.content = slice.nom(' ');
         event.aux = slice;
         break;
@@ -608,7 +608,7 @@ void parseSpecialcases(ref IRCParser parser, ref IRCEvent event, ref string slic
 
     case ERR_UNKNOWNCOMMAND: // 421
         slice.nom(' ');  // bot nickname
-        if (slice.has(':'))
+        if (slice.contains(':'))
         {
             // :asimov.freenode.net 421 kameloso^ sudo :Unknown command
             event.aux = slice.nom(" :");
@@ -651,7 +651,7 @@ void parseSpecialcases(ref IRCParser parser, ref IRCEvent event, ref string slic
         // :irc.rizon.no 266 kameloso^^ :Current global users: 16115  Max: 17360
         slice.nom(' ');  // bot nickname
 
-        if (slice.has(" :"))
+        if (slice.contains(" :"))
         {
             event.aux = slice.nom(" :");
             event.content = slice;
@@ -730,7 +730,7 @@ void parseSpecialcases(ref IRCParser parser, ref IRCEvent event, ref string slic
          +/
         // :irc.uworld.se 513 kameloso :To connect type /QUOTE PONG 3705964477
 
-        if (slice.has(" :To connect"))
+        if (slice.contains(" :To connect"))
         {
             event.target.nickname = slice.nom(" :To connect");
 
@@ -791,7 +791,7 @@ void parseSpecialcases(ref IRCParser parser, ref IRCEvent event, ref string slic
         break;
 
     case CAP:
-        if (slice.has('*'))
+        if (slice.contains('*'))
         {
             // :tmi.twitch.tv CAP * LS :twitch.tv/tags twitch.tv/commands twitch.tv/membership
             slice.nom("* ");
@@ -821,7 +821,7 @@ void parseSpecialcases(ref IRCParser parser, ref IRCEvent event, ref string slic
         import std.conv : to;
 
         case HOSTTARGET:
-            if (slice.has(" :-"))
+            if (slice.contains(" :-"))
             {
                 event.type = TWITCH_HOSTEND;
                 goto case TWITCH_HOSTEND;
@@ -849,7 +849,7 @@ void parseSpecialcases(ref IRCParser parser, ref IRCEvent event, ref string slic
         case CLEARCHAT:
             // :tmi.twitch.tv CLEARCHAT #zorael
             // :tmi.twitch.tv CLEARCHAT #<channel> :<user>
-            if (slice.has(" :"))
+            if (slice.contains(" :"))
             {
                 // Banned
                 // Whether it's a tempban or a permban is decided in the Twitch plugin
@@ -866,7 +866,7 @@ void parseSpecialcases(ref IRCParser parser, ref IRCEvent event, ref string slic
     case RPL_LOGGEDIN: // 900
         // :weber.freenode.net 900 kameloso kameloso!NaN@194.117.188.126 kameloso :You are now logged in as kameloso.
         // :NickServ!NickServ@services. NOTICE kameloso^ :You are now identified for kameloso.
-        if (slice.has('!'))
+        if (slice.contains('!'))
         {
             event.target.nickname = slice.nom(' ');  // bot nick
             slice.nom('!');  // user
@@ -905,7 +905,7 @@ void parseSpecialcases(ref IRCParser parser, ref IRCEvent event, ref string slic
         string misc = slice.nom(" :");
         event.content = slice;
 
-        if (misc.has(' '))
+        if (misc.contains(' '))
         {
             misc.nom(' ');
             event.aux = misc;
@@ -934,7 +934,7 @@ void parseSpecialcases(ref IRCParser parser, ref IRCEvent event, ref string slic
         slice.nom(' '); // bot nickname
         event.channel = slice.nom(' ');
 
-        if (slice.has(' '))
+        if (slice.contains(' '))
         {
             event.aux = slice.nom(' ');
             //event.content = slice.nom(' ');
@@ -978,7 +978,7 @@ void parseSpecialcases(ref IRCParser parser, ref IRCEvent event, ref string slic
         // :niven.freenode.net 729 kameloso^ #hirrsteff q :End of Channel Quiet List
         // :irc.oftc.net 345 kameloso #garderoben :End of Channel Quiet List
         slice.nom(' ');
-        event.channel = slice.has(" q :") ? slice.nom(" q :") : slice.nom(" :");
+        event.channel = slice.contains(" q :") ? slice.nom(" q :") : slice.nom(" :");
         event.content = slice;
         break;
 
@@ -1056,12 +1056,12 @@ void parseGeneralCases(ref IRCParser parser, ref IRCEvent event, ref string slic
 
     with (parser)
     {
-        if (slice.has(" :"))
+        if (slice.contains(" :"))
         {
             // Has colon-content
             string targets = slice.nom(" :");
 
-            if (targets.has(' '))
+            if (targets.contains(' '))
             {
                 // More than one target
                 immutable firstTarget = targets.nom(' ');
@@ -1076,7 +1076,7 @@ void parseGeneralCases(ref IRCParser parser, ref IRCEvent event, ref string slic
                         // More than one target, first is bot
                         // Second target is/begins with a channel
 
-                        if (targets.has(' '))
+                        if (targets.contains(' '))
                         {
                             // More than one target, first is bot
                             // Second target is more than one, first is channel
@@ -1107,7 +1107,7 @@ void parseGeneralCases(ref IRCParser parser, ref IRCEvent event, ref string slic
                         // More than one target, first is bot
                         // Second is not a channel
 
-                        if (targets.has(' '))
+                        if (targets.contains(' '))
                         {
                             // More than one target, first is bot
                             import std.algorithm.searching : count;
@@ -1180,7 +1180,7 @@ void parseGeneralCases(ref IRCParser parser, ref IRCEvent event, ref string slic
         else
         {
             // Does not have colon-content
-            if (slice.has(' '))
+            if (slice.contains(' '))
             {
                 // More than one target
                 immutable target = slice.nom(' ');
@@ -1198,7 +1198,7 @@ void parseGeneralCases(ref IRCParser parser, ref IRCEvent event, ref string slic
                     // Assume first is nickname and second is aux
                     event.target.nickname = target;
 
-                    if ((target == parser.bot.nickname) && slice.has(' '))
+                    if ((target == parser.bot.nickname) && slice.contains(' '))
                     {
                         // First target is bot, and there is more
                         // :asimov.freenode.net 333 kameloso^ #garderoben klarrt!~bsdrouter@h150n13-aahm-a11.ias.bredband.telia.com 1476294377
@@ -1207,12 +1207,12 @@ void parseGeneralCases(ref IRCParser parser, ref IRCEvent event, ref string slic
                         // :irc.run.net 367 kameloso #Help *!*@broadband-5-228-255-*.moscow.rt.ru
                         // :irc.atw-inter.net 344 kameloso #debian.de towo!towo@littlelamb.szaf.org
 
-                        if (slice.beginsWithOneOf(parser.bot.server.chantypes) && slice.has(' '))
+                        if (slice.beginsWithOneOf(parser.bot.server.chantypes) && slice.contains(' '))
                         {
                             // Second target is channel
                             event.channel = slice.nom(' ');
 
-                            if (slice.has(' '))
+                            if (slice.contains(' '))
                             {
                                 // Remaining slice has at least two fields;
                                 // separate into content and aux
@@ -1293,19 +1293,19 @@ void postparseSanityCheck(const ref IRCParser parser, ref IRCEvent event) @trust
     Appender!string sink;
     //sink.reserve(128);
 
-    if (event.target.nickname.has(' ') || event.channel.has(' '))
+    if (event.target.nickname.contains(' ') || event.channel.contains(' '))
     {
         sink.put("Spaces in target nickname or channel");
     }
 
-    if (event.target.nickname.length && parser.bot.server.chantypes.has(event.target.nickname[0]))
+    if (event.target.nickname.length && parser.bot.server.chantypes.contains(event.target.nickname[0]))
     {
         if (sink.data.length) sink.put(". ");
         sink.put("Target nickname is a channel");
     }
 
     if (event.channel.length &&
-        !parser.bot.server.chantypes.has(event.channel[0]) &&
+        !parser.bot.server.chantypes.contains(event.channel[0]) &&
         (event.type != IRCEvent.Type.ERR_NOSUCHCHANNEL) &&
         (event.type != IRCEvent.Type.RPL_ENDOFWHO) &&
         (event.type != IRCEvent.Type.RPL_NAMREPLY) &&
@@ -1453,7 +1453,7 @@ bool isSpecial(const ref IRCParser parser, const IRCEvent event) pure
         {
             return true;
         }
-        else if (event.sender.address.has("/staff/"))
+        else if (event.sender.address.contains("/staff/"))
         {
             return true;
         }
@@ -1511,7 +1511,7 @@ void onNotice(ref IRCParser parser, ref IRCEvent event, ref string slice) pure
         {
             //event.sender.class_ = IRCUser.Class.special; // by definition
 
-            if (event.content.toLower.has("/msg nickserv identify"))
+            if (event.content.toLower.contains("/msg nickserv identify"))
             {
                 event.type = IRCEvent.Type.AUTH_CHALLENGE;
                 return;
@@ -1561,10 +1561,10 @@ void onNotice(ref IRCParser parser, ref IRCEvent event, ref string slice) pure
                 if ((content == rizon) ||
                     (content == quakenet) ||
                     (content == gamesurge) ||
-                     content.has(cast(string)freenodeInvalid) ||
+                     content.contains(cast(string)freenodeInvalid) ||
                      content.beginsWith(cast(string)freenodeRejected) ||
-                     content.has(cast(string)dalnet) ||
-                     content.has(cast(string)unreal))
+                     content.contains(cast(string)dalnet) ||
+                     content.contains(cast(string)unreal))
                 {
                     event.type = IRCEvent.Type.AUTH_FAILURE;
                 }
@@ -1639,7 +1639,7 @@ void onPRIVMSG(const ref IRCParser parser, ref IRCEvent event, ref string slice)
     if ((slice[0] == IRCControlCharacter.ctcp) && (slice[$-1] == IRCControlCharacter.ctcp))
     {
         slice = slice[1..$-1];
-        immutable ctcpEvent = slice.has(' ') ? slice.nom(' ') : slice;
+        immutable ctcpEvent = slice.contains(' ') ? slice.nom(' ') : slice;
         event.content = slice;
 
         // :zorael!~NaN@ns3363704.ip-94-23-253.eu PRIVMSG #flerrp :ACTION test test content
@@ -1723,7 +1723,7 @@ void onMode(ref IRCParser parser, ref IRCEvent event, ref string slice) pure
     {
         event.channel = target;
 
-        if (slice.has(' '))
+        if (slice.contains(' '))
         {
             // :zorael!~NaN@ns3363704.ip-94-23-253.eu MODE #flerrp +v kameloso^
             event.aux = slice.nom(' ');
@@ -1862,7 +1862,7 @@ void onISUPPORT(ref IRCParser parser, ref IRCEvent event, ref string slice) pure
     // :cherryh.freenode.net 005 CHARSET=ascii NICKLEN=16 CHANNELLEN=50 TOPICLEN=390 DEAF=D FNC TARGMAX=NAMES:1,LIST:1,KICK:1,WHOIS:1,PRIVMSG:4,NOTICE:4,ACCEPT:,MONITOR: EXTBAN=$,ajrxz CLIENTVER=3.0 CPRIVMSG CNOTICE SAFELIST :are supported by this server
     slice.nom(' ');
 
-    if (slice.has(" :"))
+    if (slice.contains(" :"))
     {
         event.content = slice.nom(" :");
     }
@@ -1871,7 +1871,7 @@ void onISUPPORT(ref IRCParser parser, ref IRCEvent event, ref string slice) pure
     {
         foreach (value; event.content.splitter(' '))
         {
-            if (!value.has('='))
+            if (!value.contains('='))
             {
                 // switch on value for things like EXCEPTS, INVEX, CPRIVMSG, etc
                 continue;
@@ -1922,7 +1922,7 @@ void onISUPPORT(ref IRCParser parser, ref IRCEvent event, ref string slice) pure
                 bModes = modeslice.nom(',');
                 cModes = modeslice.nom(',');
                 dModes = modeslice;
-                assert(!dModes.has(','), "Bad chanmodes; dModes has comma: " ~ dModes);
+                assert(!dModes.contains(','), "Bad chanmodes; dModes has comma: " ~ dModes);
                 break;
 
             case "NETWORK":
@@ -2056,7 +2056,7 @@ void onMyInfo(ref IRCParser parser, ref IRCEvent event, ref string slice) pure
 
     version(TwitchSupport)
     {
-        if ((slice == ":-") && (parser.bot.server.address.has(".twitch.tv")))
+        if ((slice == ":-") && (parser.bot.server.address.contains(".twitch.tv")))
         {
             parser.setDaemon(IRCServer.Daemon.twitch, "Twitch");
             parser.bot.server.network = "Twitch";
@@ -2083,29 +2083,29 @@ void onMyInfo(ref IRCParser parser, ref IRCEvent event, ref string slice) pure
             // Trust that the typenums did as well.
             return;
         }
-        else if (daemonstring_.has("unreal"))
+        else if (daemonstring_.contains("unreal"))
         {
             daemon = unreal;
         }
-        else if (daemonstring_.has("inspircd"))
+        else if (daemonstring_.contains("inspircd"))
         {
             daemon = inspircd;
         }
-        else if (daemonstring_.has("snircd"))
+        else if (daemonstring_.contains("snircd"))
         {
             daemon = snircd;
         }
-        else if (daemonstring_.has("u2."))
+        else if (daemonstring_.contains("u2."))
         {
             daemon = u2;
         }
-        else if (daemonstring_.has("bahamut"))
+        else if (daemonstring_.contains("bahamut"))
         {
             daemon = bahamut;
         }
-        else if (daemonstring_.has("hybrid"))
+        else if (daemonstring_.contains("hybrid"))
         {
-            if (parser.bot.server.address.has(".rizon."))
+            if (parser.bot.server.address.contains(".rizon."))
             {
                 daemon = rizon;
             }
@@ -2114,15 +2114,15 @@ void onMyInfo(ref IRCParser parser, ref IRCEvent event, ref string slice) pure
                 daemon = hybrid;
             }
         }
-        else if (daemonstring_.has("ratbox"))
+        else if (daemonstring_.contains("ratbox"))
         {
             daemon = ratbox;
         }
-        else if (daemonstring_.has("charybdis"))
+        else if (daemonstring_.contains("charybdis"))
         {
             daemon = charybdis;
         }
-        else if (daemonstring_.has("ircd-seven"))
+        else if (daemonstring_.contains("ircd-seven"))
         {
             daemon = ircdseven;
         }
@@ -2421,7 +2421,7 @@ bool isFromAuthService(const ref IRCParser parser, const IRCEvent event) pure
         return ((sender.ident == "AuthServ") && (sender.address == "Services.GameSurge.net"));
 
     default:
-        if (sender.address.has("/staff/"))
+        if (sender.address.contains("/staff/"))
         {
             // Staff notice
             return false;
@@ -2537,9 +2537,9 @@ bool isValidChannel(const string line, const IRCServer server) pure @nogc
 
     if (!line.beginsWithOneOf(server.chantypes)) return false;
 
-    if (line.has(' ') ||
-        line.has(',') ||
-        line.has(7))
+    if (line.contains(' ') ||
+        line.contains(',') ||
+        line.contains(7))
     {
         // Contains spaces, commas or byte 7
         return false;
@@ -2552,7 +2552,7 @@ bool isValidChannel(const string line, const IRCServer server) pure @nogc
         // Allow for two ##s (or &&s) in the name but no more
         foreach (immutable chansign; server.chantypes.representation)
         {
-            if (line[2..$].has(chansign)) return false;
+            if (line[2..$].contains(chansign)) return false;
         }
         return true;
     }
@@ -3175,7 +3175,7 @@ unittest
 void setMode(ref IRCChannel channel, const string signedModestring,
     const string data, IRCServer server) pure
 {
-    import kameloso.string : beginsWith, has, nom;
+    import kameloso.string : beginsWith, contains, nom;
     import std.array : array;
     import std.algorithm.iteration : splitter;
     import std.algorithm.mutation : remove;
@@ -3221,7 +3221,7 @@ void setMode(ref IRCChannel channel, const string signedModestring,
                 continue;
             }
 
-            if (!datastring.beginsWith(server.extbanPrefix) && datastring.has('!') && datastring.has('@'))
+            if (!datastring.beginsWith(server.extbanPrefix) && datastring.contains('!') && datastring.contains('@'))
             {
                 // Looks like a user and not an extban
                 newMode.user = IRCUser(datastring);
@@ -3257,12 +3257,12 @@ void setMode(ref IRCChannel channel, const string signedModestring,
                 case 'a':
                 case 'R':
                     // Match account
-                    if (slice.has(':'))
+                    if (slice.contains(':'))
                     {
                         // More than one field
                         slice.nom(':');
 
-                        if (slice.has('$'))
+                        if (slice.contains('$'))
                         {
                             // More than one field, first is account
                             newMode.user.account = slice.nom('$');
@@ -3321,7 +3321,7 @@ void setMode(ref IRCChannel channel, const string signedModestring,
 
             if (sign == '+')
             {
-                if (server.prefixes.has(modechar))
+                if (server.prefixes.contains(modechar))
                 {
                     import std.algorithm.searching : canFind;
 
@@ -3336,7 +3336,7 @@ void setMode(ref IRCChannel channel, const string signedModestring,
                     continue;
                 }
 
-                if (server.aModes.has(modechar))
+                if (server.aModes.contains(modechar))
                 {
                     /++
                      +  A = Mode that adds or removes a nick or address to a
@@ -3358,7 +3358,7 @@ void setMode(ref IRCChannel channel, const string signedModestring,
                     newMode.exceptions ~= carriedExceptions;
                     carriedExceptions.length = 0;
                 }
-                else if (server.bModes.has(modechar) || server.cModes.has(modechar))
+                else if (server.bModes.contains(modechar) || server.cModes.contains(modechar))
                 {
                     /++
                      +  B = Mode that changes a setting and always has a
@@ -3379,10 +3379,10 @@ void setMode(ref IRCChannel channel, const string signedModestring,
                         }
                     }
                 }
-                else /*if (server.dModes.has(modechar))*/
+                else /*if (server.dModes.contains(modechar))*/
                 {
                     // Some clients assume that any mode not listed is of type D
-                    if (!modechars.has(modechar)) modechars ~= modechar;
+                    if (!modechars.contains(modechar)) modechars ~= modechar;
                     continue;
                 }
 
@@ -3390,7 +3390,7 @@ void setMode(ref IRCChannel channel, const string signedModestring,
             }
             else if (sign == '-')
             {
-                if (server.prefixes.has(modechar))
+                if (server.prefixes.contains(modechar))
                 {
                     import std.algorithm.mutation : remove;
                     import std.algorithm.searching : countUntil;
@@ -3403,7 +3403,7 @@ void setMode(ref IRCChannel channel, const string signedModestring,
                     if (index != -1) *prefixedUsers = (*prefixedUsers).remove(index);
                 }
 
-                if (server.aModes.has(modechar))
+                if (server.aModes.contains(modechar))
                 {
                     /++
                      +  A = Mode that adds or removes a nick or address to a
@@ -3426,7 +3426,7 @@ void setMode(ref IRCChannel channel, const string signedModestring,
                         modes = modes.remove(i);
                     }
                 }
-                else if (server.bModes.has(modechar) || server.cModes.has(modechar))
+                else if (server.bModes.contains(modechar) || server.cModes.contains(modechar))
                 {
                     /++
                      +  B = Mode that changes a setting and always has a
@@ -3446,7 +3446,7 @@ void setMode(ref IRCChannel channel, const string signedModestring,
                         }
                     }
                 }
-                else /*if (server.dModes.has(modechar))*/
+                else /*if (server.dModes.contains(modechar))*/
                 {
                     // Some clients assume that any mode not listed is of type D
                     import std.string : indexOf;

--- a/source/kameloso/ircdefs.d
+++ b/source/kameloso/ircdefs.d
@@ -1109,7 +1109,7 @@ struct IRCUser
     /// Services account name (to `NickServ`, `AuthServ`, `Q`, etc).
     string account;
 
-    /// The highest priority "badge" the sender has, in this context.
+    /// The highest priority "badge" the sender contains, in this context.
     string badge;
 
     /// The colour (RRGGBB) to tint the user's nickname with.

--- a/source/kameloso/objmanip.d
+++ b/source/kameloso/objmanip.d
@@ -43,7 +43,7 @@ public import kameloso.meld;
 bool setMemberByName(Thing)(ref Thing thing, const string memberToSet, const string valueToSet)
 {
     import kameloso.common : logger;
-    import kameloso.string : has, stripped, stripSuffix, unquoted;
+    import kameloso.string : contains, stripSuffix, stripped, unquoted;
     import kameloso.traits : isConfigurableVariable;
     import std.conv : ConvException, to;
     import std.traits : Unqual, getUDAs, hasUDA, isArray, isAssociativeArray, isSomeString, isType;
@@ -97,7 +97,7 @@ bool setMemberByName(Thing)(ref Thing thing, const string memberToSet, const str
                                 .replace(escapedPlaceholder, separator.token);
                         }
 
-                        while (values.has(doubleEphemeral))
+                        while (values.contains(doubleEphemeral))
                         {
                             values = values.replace(doubleEphemeral, ephemeralSeparator);
                         }

--- a/source/kameloso/plugins/admin.d
+++ b/source/kameloso/plugins/admin.d
@@ -123,9 +123,9 @@ void onAnyEvent(AdminPlugin plugin, const IRCEvent event)
     if (plugin.adminSettings.printAsserts)
     {
         import kameloso.debugging : formatEventAssertBlock;
-        import kameloso.string : has;
+        import kameloso.string : contains;
 
-        if (event.raw.has(1))
+        if (event.raw.contains(1))
         {
             logger.warning("event.raw contains CTCP 1 which might not get printed");
         }
@@ -445,7 +445,7 @@ void onCommandWhitelist(AdminPlugin plugin, const IRCEvent event)
     if (!plugin.adminSettings.enabled) return;
 
     import kameloso.irc : isValidNickname;
-    import kameloso.string : has, stripped;
+    import kameloso.string : contains, stripped;
 
     immutable account = event.content.stripped;
 
@@ -501,7 +501,7 @@ void onCommandBlacklist(AdminPlugin plugin, const IRCEvent event)
     if (!plugin.adminSettings.enabled) return;
 
     import kameloso.irc : isValidNickname;
-    import kameloso.string : has, stripped;
+    import kameloso.string : contains, stripped;
 
     immutable account = event.content.stripped;
 

--- a/source/kameloso/plugins/automode.d
+++ b/source/kameloso/plugins/automode.d
@@ -39,7 +39,7 @@ struct AutomodeSettings
 void populateAutomodes(AutomodePlugin plugin)
 {
     import kameloso.json : JSONStorage;
-    import kameloso.string : has;
+    import kameloso.string : contains;
     import std.conv : text;
     import std.json : JSON_TYPE;
 

--- a/source/kameloso/plugins/chatbot.d
+++ b/source/kameloso/plugins/chatbot.d
@@ -167,7 +167,7 @@ void onCommandHelp(ChatbotPlugin plugin, const IRCEvent event)
 void peekPlugins(ChatbotPlugin plugin, IRCPlugin[] plugins, const IRCEvent event)
 {
     import kameloso.constants : KamelosoInfo;
-    import kameloso.string : has, nom;
+    import kameloso.string : contains, nom;
     import std.algorithm.searching : endsWith;
     import std.algorithm.sorting : sort;
     import std.format : format;
@@ -177,7 +177,7 @@ void peekPlugins(ChatbotPlugin plugin, IRCPlugin[] plugins, const IRCEvent event
     {
         if (content.length)
         {
-            if (content.has!(Yes.decode)(" "))
+            if (content.contains!(Yes.decode)(" "))
             {
                 string slice = content;
                 immutable specifiedPlugin = slice.nom!(Yes.decode)(" ");

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -730,7 +730,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
     {
         mixin("static import thisModule = " ~ module_ ~ ";");
 
-        import kameloso.string : beginsWith, has, nom, stripPrefix, strippedLeft;
+        import kameloso.string : beginsWith, contains, nom, stripPrefix, strippedLeft;
         import std.meta : AliasSeq, Filter, templateNot, templateOr;
         import std.traits : getSymbolsByUDA, isSomeFunction, getUDAs, hasUDA;
         import std.typecons : No, Yes;
@@ -885,7 +885,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
 
                         mutEvent.content = mutEvent.content.strippedLeft;
 
-                        if (mutEvent.content.has!(Yes.decode)(' '))
+                        if (mutEvent.content.contains!(Yes.decode)(' '))
                         {
                             thisCommand = mutEvent.content.nom!(Yes.decode)(' ');
                         }
@@ -946,7 +946,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                             mutEvent = event;
                             string thisCommand;
 
-                            if (mutEvent.content.has!(Yes.decode)(' '))
+                            if (mutEvent.content.contains!(Yes.decode)(' '))
                             {
                                 thisCommand = mutEvent.content.nom!(Yes.decode)(' ');
                             }
@@ -1598,11 +1598,11 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
      +/
     string name() @property const
     {
-        import kameloso.string : has, nom;
+        import kameloso.string : contains, nom;
 
         string moduleName = module_;
 
-        while (moduleName.has('.'))
+        while (moduleName.contains('.'))
         {
             moduleName.nom('.');
         }
@@ -2093,14 +2093,14 @@ mixin template UserAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home,
     {
         import kameloso.irc : stripModesign;
         import kameloso.meld : meldInto;
-        import kameloso.string : has, nom;
+        import kameloso.string : contains, nom;
         import std.algorithm.iteration : splitter;
         import std.algorithm.searching : canFind;
         import std.typecons : No, Yes;
 
         auto names = event.content.splitter(" ");
 
-        if (names.empty || !names.front.has('!') || !names.front.has('@'))
+        if (names.empty || !names.front.contains('!') || !names.front.contains('@'))
         {
             // Empty or Freenode-like, where the list is just of nicknames with
             // possible mode prefix
@@ -2517,7 +2517,7 @@ mixin template ChannelAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home
     void onChannelAwarenessNamesReplyMixin(IRCPlugin plugin, const IRCEvent event)
     {
         import kameloso.irc : stripModesign;
-        import kameloso.string : has, nom;
+        import kameloso.string : contains, nom;
         import std.algorithm.iteration : splitter;
         import std.algorithm.searching : canFind;
         import std.string : representation;
@@ -2533,7 +2533,7 @@ mixin template ChannelAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home
                 string slice = userstring;
                 string nickname;
 
-                if (userstring.has('!') && userstring.has('@'))
+                if (userstring.contains('!') && userstring.contains('@'))
                 {
                     // SpotChat-like, names are in full nick!ident@address form
                     nickname = slice.nom('!');
@@ -2893,7 +2893,7 @@ void doWhois(F)(IRCPlugin plugin, const IRCEvent event, PrivilegeLevel privilege
 void applyCustomSettings(IRCPlugin[] plugins, string[] customSettings) @trusted
 {
     import kameloso.common : logger;
-    import kameloso.string : has, nom;
+    import kameloso.string : contains, nom;
     import std.string : toLower;
 
     top:
@@ -2904,7 +2904,7 @@ void applyCustomSettings(IRCPlugin[] plugins, string[] customSettings) @trusted
         string setting;
         string value;
 
-        if (!slice.has!(Yes.decode)("."))
+        if (!slice.contains!(Yes.decode)("."))
         {
             logger.warning("Bad plugin.setting=value format");
             continue;
@@ -2912,7 +2912,7 @@ void applyCustomSettings(IRCPlugin[] plugins, string[] customSettings) @trusted
 
         pluginstring = slice.nom!(Yes.decode)(".").toLower;
 
-        if (slice.has!(Yes.decode)("="))
+        if (slice.contains!(Yes.decode)("="))
         {
             setting = slice.nom!(Yes.decode)("=");
             value = slice;

--- a/source/kameloso/plugins/notes.d
+++ b/source/kameloso/plugins/notes.d
@@ -179,11 +179,11 @@ void onCommandAddNote(NotesPlugin plugin, const IRCEvent event)
 {
     if (!plugin.notesSettings.enabled) return;
 
-    import kameloso.string : has, nom;
+    import kameloso.string : contains, nom;
     import std.json : JSONException;
     import std.typecons : No, Yes;
 
-    if (!event.content.has(" ")) return;
+    if (!event.content.contains(" ")) return;
 
     string slice = event.content;
     immutable nickname = slice.nom!(Yes.decode)(" ");
@@ -262,7 +262,7 @@ void onCommandFakejoin(NotesPlugin plugin, const IRCEvent event)
 {
     if (!plugin.notesSettings.enabled) return;
 
-    import kameloso.string : has, nom;
+    import kameloso.string : contains, nom;
     import std.typecons : Yes;
 
     logger.info("Faking an event");
@@ -271,7 +271,7 @@ void onCommandFakejoin(NotesPlugin plugin, const IRCEvent event)
     newEvent.type = IRCEvent.Type.CHAN;
     string nickname = event.content;
 
-    if (nickname.has!(Yes.decode)(' '))
+    if (nickname.contains!(Yes.decode)(' '))
     {
         // contains more than one word
         newEvent.sender.nickname = nickname.nom!(Yes.decode)(' ');

--- a/source/kameloso/plugins/printer.d
+++ b/source/kameloso/plugins/printer.d
@@ -751,8 +751,8 @@ void formatMessageMonochrome(Sink)(PrinterPlugin plugin, auto ref Sink sink,
 
             if (badge.length)
             {
-                import kameloso.string : has, nom;
-                immutable badgefront = badge.has('/') ? badge.nom('/') : badge;
+                import kameloso.string : contains, nom;
+                immutable badgefront = badge.contains('/') ? badge.nom('/') : badge;
                 put(sink, " [");
 
                 if (plugin.printerSettings.uppercaseTypes) put(sink, badgefront.asUpperCase);
@@ -785,8 +785,8 @@ void formatMessageMonochrome(Sink)(PrinterPlugin plugin, auto ref Sink sink,
 
             if (target.badge.length)
             {
-                import kameloso.string : has, nom;
-                immutable badgefront = target.badge.has('/') ? target.badge.nom('/') : target.badge;
+                import kameloso.string : contains, nom;
+                immutable badgefront = target.badge.contains('/') ? target.badge.nom('/') : target.badge;
                 put(sink, " [");
 
                 if (plugin.printerSettings.uppercaseTypes) put(sink, badgefront.asUpperCase);
@@ -1089,10 +1089,10 @@ void formatMessageColoured(Sink)(PrinterPlugin plugin, auto ref Sink sink,
 
             if (badge.length)
             {
-                import kameloso.string : has, nom;
+                import kameloso.string : contains, nom;
 
                 sink.colour(bright ? DefaultBright.badge : DefaultDark.badge);
-                immutable badgefront = badge.has('/') ? badge.nom('/') : badge;
+                immutable badgefront = badge.contains('/') ? badge.nom('/') : badge;
                 put(sink, " [");
 
                 if (plugin.printerSettings.uppercaseTypes) put(sink, badgefront.asUpperCase);
@@ -1147,10 +1147,10 @@ void formatMessageColoured(Sink)(PrinterPlugin plugin, auto ref Sink sink,
 
             if (target.badge.length)
             {
-                import kameloso.string : has, nom;
+                import kameloso.string : contains, nom;
 
                 sink.colour(bright ? DefaultBright.badge : DefaultDark.badge);
-                immutable badgefront = target.badge.has('/') ? target.badge.nom('/') : target.badge;
+                immutable badgefront = target.badge.contains('/') ? target.badge.nom('/') : target.badge;
                 put(sink, " [");
 
                 if (plugin.printerSettings.uppercaseTypes) put(sink, badgefront.asUpperCase);
@@ -1194,9 +1194,9 @@ void formatMessageColoured(Sink)(PrinterPlugin plugin, auto ref Sink sink,
 
                     if ((event.type == IRCEvent.Type.EMOTE) || (event.type == IRCEvent.Type.TWITCH_CHEER))
                     {
-                        import kameloso.string : has;
+                        import kameloso.string : contains;
 
-                        if (event.tags.has("emote-only=1"))
+                        if (event.tags.contains("emote-only=1"))
                         {
                             // Just highlight the whole line, make it appear as normal content
                             event.mapEffects(contentReset);
@@ -1414,29 +1414,29 @@ void mapEffects(ref IRCEvent event, BashForeground resetCode = BashForeground.de
 {
     import kameloso.bash : B = BashEffect;
     import kameloso.irc : I = IRCControlCharacter;
-    import kameloso.string : has;
+    import kameloso.string : contains;
 
     with (event)
     {
-        if (content.has(I.colour))
+        if (content.contains(I.colour))
         {
             // Colour is mIRC 3
             content = mapColours(content, resetCode);
         }
 
-        if (content.has(I.bold))
+        if (content.contains(I.bold))
         {
             // Bold is bash 1, mIRC 2
             content = mapAlternatingEffectImpl!(I.bold, B.bold)(content);
         }
 
-        if (content.has(I.italics))
+        if (content.contains(I.italics))
         {
             // Italics is bash 3 (not really), mIRC 29
             content = mapAlternatingEffectImpl!(I.italics, B.italics)(content);
         }
 
-        if (content.has(I.underlined))
+        if (content.contains(I.underlined))
         {
             // Underlined is bash 4, mIRC 31
             content = mapAlternatingEffectImpl!(I.underlined, B.underlined)(content);
@@ -1459,7 +1459,7 @@ void mapEffects(ref IRCEvent event, BashForeground resetCode = BashForeground.de
 string stripEffects(const string content)
 {
     import kameloso.irc : I = IRCControlCharacter;
-    import kameloso.string : has;
+    import kameloso.string : contains;
     import std.array : replace;
 
     enum boldCode = "" ~ I.bold;

--- a/source/kameloso/plugins/reddit.d
+++ b/source/kameloso/plugins/reddit.d
@@ -71,12 +71,12 @@ void onMessage(RedditPlugin plugin, const IRCEvent event)
 
     import kameloso.common : logger;
     import kameloso.constants : Timeout;
-    import kameloso.string : has, stripped;
+    import kameloso.string : contains, stripped;
     import std.datetime.systime : Clock, SysTime;
 
     immutable url = event.content.stripped;
 
-    if (!url.length || url.has(' '))
+    if (!url.length || url.contains(' '))
     {
         logger.error("Cannot look up Reddit post; invalid URL");
         return;

--- a/source/kameloso/plugins/seen.d
+++ b/source/kameloso/plugins/seen.d
@@ -372,11 +372,11 @@ void onNameReply(SeenPlugin plugin, const IRCEvent event)
     foreach (const signed; event.content.splitter(" "))
     {
         import kameloso.irc : stripModesign;
-        import kameloso.string : has, nom;
+        import kameloso.string : contains, nom;
 
         string nickname = signed;
 
-        if (nickname.has('!'))
+        if (nickname.contains('!'))
         {
             // SpotChat-like, signed is in full nick!ident@address form
             nickname = nickname.nom('!');
@@ -529,7 +529,7 @@ void onCommandSeen(SeenPlugin plugin, const IRCEvent event)
 
     import kameloso.common : timeSince;
     import kameloso.irc : isValidNickname;
-    import kameloso.string : has;
+    import kameloso.string : contains;
     import std.algorithm.searching : canFind;
     import std.datetime.systime; //: Clock, SysTime;
     import std.format : format;

--- a/source/kameloso/plugins/twitch.d
+++ b/source/kameloso/plugins/twitch.d
@@ -85,7 +85,7 @@ void parseTwitchTags(TwitchService service, ref IRCEvent event)
     with (IRCEvent)
     foreach (tag; event.tags.splitter(";"))
     {
-        import kameloso.string : has, nom;
+        import kameloso.string : contains, nom;
         immutable key = tag.nom("=");
         immutable value = tag;
 
@@ -253,7 +253,7 @@ void parseTwitchTags(TwitchService service, ref IRCEvent event)
             // The user’s display name, escaped as described in the IRCv3 spec.
             // This is empty if it is never set.
             import kameloso.string : strippedRight;
-            immutable alias_ = value.has('\\') ? decodeIRCv3String(value).strippedRight : value;
+            immutable alias_ = value.contains('\\') ? decodeIRCv3String(value).strippedRight : value;
 
             if (event.type == Type.USERSTATE)
             {

--- a/source/kameloso/plugins/webtitles.d
+++ b/source/kameloso/plugins/webtitles.d
@@ -88,13 +88,13 @@ void onMessage(WebtitlesPlugin plugin, const IRCEvent event)
 
     import kameloso.common : logger;
     import kameloso.constants : Timeout;
-    import kameloso.string : beginsWith, has, nom;
+    import kameloso.string : beginsWith, contains, nom;
     import std.datetime.systime : Clock, SysTime;
     import std.regex : ctRegex, matchAll;
     import std.typecons : No, Yes;
 
     // Early abort so we don't use the regex as much.
-    if (!event.content.has!(Yes.decode)("http")) return;
+    if (!event.content.contains!(Yes.decode)("http")) return;
 
     /// Regex pattern to match a URL, to see if one was pasted.
     enum stephenhay = `\bhttps?://[^\s/$.?#].[^\s]*`;
@@ -119,7 +119,7 @@ void onMessage(WebtitlesPlugin plugin, const IRCEvent event)
 
         string url = urlHit[0];  // needs mutable
 
-        if (url.has!(Yes.decode)('#'))
+        if (url.contains!(Yes.decode)('#'))
         {
             // URL contains an octorhorpe fragment identifier, like
             // https://www.google.com/index.html#this%20bit
@@ -258,7 +258,7 @@ void reportURL(IRCPluginState state, const TitleLookup lookup, const IRCEvent ev
 TitleLookup lookupTitle(IRCPluginState state, const string url)
 {
     import kameloso.constants : BufferSize;
-    import kameloso.string : beginsWith, has;
+    import kameloso.string : beginsWith, contains;
     import arsd.dom : Document;
     import requests : Request;
     import std.array : Appender;
@@ -298,8 +298,7 @@ TitleLookup lookupTitle(IRCPluginState state, const string url)
 
     lookup.title = doc.title;
 
-    if ((lookup.title == "YouTube") &&
-        url.has("youtube.com/watch?"))
+    if ((lookup.title == "YouTube") && url.contains("youtube.com/watch?"))
     {
         state.fixYoutubeTitles(lookup, url);
     }
@@ -333,7 +332,7 @@ TitleLookup lookupTitle(IRCPluginState state, const string url)
  +/
 void fixYoutubeTitles(IRCPluginState state, ref TitleLookup lookup, const string url)
 {
-    import kameloso.string : has;
+    import kameloso.string : contains;
     import std.regex : regex, replaceFirst;
 
     /// Regex pattern to match YouTube URLs.
@@ -351,7 +350,7 @@ void fixYoutubeTitles(IRCPluginState state, ref TitleLookup lookup, const string
     state.mainThread.send(ThreadMessage.TerminalOutput.Log(),
         "ListenOnRepeat title: " ~ onRepeatLookup.title);
 
-    if (!onRepeatLookup.title.has(" - ListenOnRepeat"))
+    if (!onRepeatLookup.title.contains(" - ListenOnRepeat"))
     {
         state.mainThread.send(ThreadMessage.TerminalOutput.Warning(),
             "Failed to ListenOnRepeatify YouTube title");

--- a/source/kameloso/string.d
+++ b/source/kameloso/string.d
@@ -423,7 +423,7 @@ unittest
  +  Checks whether or not the first letter of a string begins with any of the
  +  passed string of characters.
  +
- +  Merely a wrapper of `has`.
+ +  Merely a wrapper of `contains`.
  +
  +  Params:
  +      haystack = String line to check the beginning of.
@@ -446,7 +446,7 @@ if (isSomeString!T)
     // An empty line begins with nothing
     if (!haystack.length) return false;
 
-    return needles.has(haystack[0]);
+    return needles.contains(haystack[0]);
 }
 
 ///
@@ -470,7 +470,7 @@ if (isSomeString!T)
     // All strings begin with an empty string, even if we're only looking at one character
     if (!needles.length) return true;
 
-    return needles.has(haystraw);
+    return needles.contains(haystraw);
 }
 
 ///
@@ -757,7 +757,7 @@ unittest
 }
 
 
-// has
+// contains
 /++
  +  Checks a string to see if it contains a given substring or character.
  +
@@ -766,9 +766,9 @@ unittest
  +
  +  Example:
  +  ---
- +  assert("Lorem ipsum".has("Lorem"));
- +  assert(!"Lorem ipsum".has('l'));
- +  assert("Lorem ipsum".has!(Yes.decode)(" "));
+ +  assert("Lorem ipsum".contains("Lorem"));
+ +  assert(!"Lorem ipsum".contains('l'));
+ +  assert("Lorem ipsum".contains!(Yes.decode)(" "));
  +  ---
  +
  +  Params:
@@ -780,7 +780,7 @@ unittest
  +  Returns:
  +      Whether the passed string contained the passed substring or token.
  +/
-bool has(Flag!"decode" decode = No.decode, T, C)(const T haystack, const C needle) pure
+bool contains(Flag!"decode" decode = No.decode, T, C)(const T haystack, const C needle) pure
 if (isSomeString!T && isSomeString!C || (is(C : T) || is(C : ElementType!T) ||
     is(C : ElementEncodingType!T)))
 {
@@ -813,18 +813,26 @@ if (isSomeString!T && isSomeString!C || (is(C : T) || is(C : ElementType!T) ||
 ///
 unittest
 {
-    assert("Lorem ipsum sit amet".has("sit"));
-    assert("".has(""));
-    assert(!"Lorem ipsum".has("sit amet"));
-    assert("Lorem ipsum".has(' '));
-    assert(!"Lorem ipsum".has('!'));
-    assert("Lorem ipsum"d.has("m"d));
-    assert("Lorem ipsum".has(['p', 's', 'u', 'm' ]));
-    assert([ 'L', 'o', 'r', 'e', 'm' ].has([ 'L' ]));
-    assert([ 'L', 'o', 'r', 'e', 'm' ].has("Lor"));
-    assert([ 'L', 'o', 'r', 'e', 'm' ].has(cast(char[])[]));
+    assert("Lorem ipsum sit amet".contains("sit"));
+    assert("".contains(""));
+    assert(!"Lorem ipsum".contains("sit amet"));
+    assert("Lorem ipsum".contains(' '));
+    assert(!"Lorem ipsum".contains('!'));
+    assert("Lorem ipsum"d.contains("m"d));
+    assert("Lorem ipsum".contains(['p', 's', 'u', 'm' ]));
+    assert([ 'L', 'o', 'r', 'e', 'm' ].contains([ 'L' ]));
+    assert([ 'L', 'o', 'r', 'e', 'm' ].contains("Lor"));
+    assert([ 'L', 'o', 'r', 'e', 'm' ].contains(cast(char[])[]));
 }
 
+/// Legacy alias to `contains`.
+alias has = contains;
+
+///
+unittest
+{
+    assert("Lorem ipsum sit amet".has("sit"));
+}
 
 // strippedRight
 /++


### PR DESCRIPTION
It was never the intention to seem doge-like. has merely read well.

Keep an alias to the old syntax.