### PR TITLE
Working directory-independent file storage

### DIFF
--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -1055,6 +1055,21 @@ struct Client
     }
 
 
+    // initPluginResources
+    /++
+     +  Initialises all plugins' resource files.
+     +
+     +  This merely calls `IRCPlugin.initResources()` on each plugin.
+     +/
+    void initPluginResources()
+    {
+        foreach (plugin; plugins)
+        {
+            plugin.initResources();
+        }
+    }
+
+
     // teardownPlugins
     /++
     +  Tears down all plugins, deinitialising them and having them save their

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -1710,7 +1710,7 @@ unittest
 }
 
 
-// defaultResourceBaseDirectory
+// defaultResourcePrefix
 /++
  +  Divines the default resource base directory, depending on what platform
  +  we're currently running.
@@ -1724,7 +1724,7 @@ unittest
  +  Returns:
  +      A string path to the default resource directory.
  +/
-string defaultResourceBaseDirectory() @property
+string defaultResourcePrefix() @property
 {
     import std.path : buildNormalizedPath;
     import std.process : environment;
@@ -1758,11 +1758,11 @@ unittest
         import std.process : environment;
 
         environment["XDG_DATA_HOME"] = "/tmp";
-        string df = defaultResourceBaseDirectory;
+        string df = defaultResourcePrefix;
         assert((df == "/tmp/kameloso"), df);
 
         environment.remove("XDG_DATA_HOME");
-        df = defaultResourceBaseDirectory;
+        df = defaultResourcePrefix;
         assert(df.beginsWith("/home/") && df.endsWith("/.local/share/kameloso"));
     }
     else version(Windows)

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -1549,7 +1549,8 @@ void complainAboutInvalidConfigurationEntries(const string[][string] invalidEntr
     }
 
     logger.logf("They are either malformed or no longer in use. " ~
-        "Use %s--writeconfig%s to update your configuration file.", infotint, logtint);
+        "Use %s--writeconfig%s to update your configuration file. [%s]",
+        infotint, logtint, settings.configFile);
 }
 
 

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -1657,7 +1657,8 @@ enum Next
  +  back to `~/.config/kameloso/kameloso.conf` if no `XDG_CONFIG_HOME`
  +  environment variable present.
  +
- +  On Windows it defaults to `%APPDATA%\\Local\\kameloso\\kameloso`.
+ +  On Windows it defaults to
+ +  `%LOCALAPPDATA%\\Local\\kameloso\\kameloso.conf`.
  +
  +  Returns:
  +      A string path to the default configuration file.
@@ -1676,8 +1677,8 @@ string defaultConfigFile() @property
     }
     else version(Windows)
     {
-        return buildNormalizedPath(environment["APPDATA"], "Local",
-            "kameloso", "kameloso", "kameloso.conf");
+        // Blindly assume %LOCALAPPDATA% is defined
+        return buildNormalizedPath(environment["LOCALAPPDATA"], "kameloso", "kameloso.conf");
     }
     else
     {
@@ -1705,7 +1706,7 @@ unittest
     else version(Windows)
     {
         immutable df = defaultConfigFile;
-        assert(df.endsWith("\\Local\\kameloso\\kameloso\\kameloso.conf"), df);
+        assert(df.endsWith("\\Local\\kameloso\\kameloso.conf"), df);
     }
 }
 
@@ -1719,7 +1720,7 @@ unittest
  +  `~/.local/share/kameloso` if no `XDG_DATA_HOME` environment variable
  +  present.
  +
- +  On Windows it defaults to `%APPDATA%\\Local\\kameloso\\kameloso`.
+ +  On Windows it defaults to `%LOCALAPPDATA%\\Local\\kameloso\\kameloso`.
  +
  +  Returns:
  +      A string path to the default resource directory.
@@ -1738,8 +1739,8 @@ string defaultResourcePrefix() @property
     }
     else version(Windows)
     {
-        return buildNormalizedPath(environment["APPDATA"], "Local",
-            "kameloso", "kameloso");
+        // Blindly assume %LOCALAPPDATA% is defined
+        return buildNormalizedPath(environment["LOCALAPPDATA"], "kameloso");
     }
     else
     {
@@ -1767,6 +1768,7 @@ unittest
     }
     else version(Windows)
     {
-        assert(defaultConfigFile.endsWith("\\Local\\kameloso\\kameloso"));
+        immutable df = defaultResourcePrefix;
+        assert(df.endsWith("\\Local\\kameloso"), df);
     }
 }

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -1648,6 +1648,16 @@ enum Next
 }
 
 
+version(Linux)
+{
+    version = XDG;
+}
+else version(FreeBSD)
+{
+    version = XDG;
+}
+
+
 // defaultConfigFile
 /++
  +  Divines the default path to the configuration file, depending on what

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -1658,6 +1658,9 @@ enum Next
  +  environment variable present.
  +
  +  On Windows it defaults to `%APPDATA%\\Local\\kameloso\\kameloso`.
+ +
+ +  Returns:
+ +      A string path to the default configuration file.
  +/
 string defaultConfigFile() @property
 {
@@ -1717,6 +1720,9 @@ unittest
  +  present.
  +
  +  On Windows it defaults to `%APPDATA%\\Local\\kameloso\\kameloso`.
+ +
+ +  Returns:
+ +      A string path to the default resource directory.
  +/
 string defaultResourceBaseDirectory() @property
 {

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -1648,6 +1648,11 @@ enum Next
 }
 
 
+/++
+ +  A version identifier that catches non-OSX Posix platforms.
+ +
+ +  We need it to version code for freedesktop.org-aware environments.
+ +/
 version(linux)
 {
     version = XDG;

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -1720,8 +1720,8 @@ unittest
     }
     else version(OSX)
     {
-        return buildNormalizedPath(environment["HOME"], "Library",
-            "Application Support", "kameloso", "kameloso.conf");
+        immutable df = defaultConfigFile;
+        assert((df.endsWith("Library/Application Support/kameloso/kameloso.conf"), df);
     }
     else version(Windows)
     {
@@ -1790,6 +1790,11 @@ unittest
         environment.remove("XDG_DATA_HOME");
         df = defaultResourcePrefix;
         assert(df.beginsWith("/home/") && df.endsWith("/.local/share/kameloso"));
+    }
+    else version (OSX)
+    {
+        immutable df = defaultResourcePrefix;
+        assert((df.endsWith("Library/Application Support/kameloso"), df);
     }
     else version(Windows)
     {

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -1678,12 +1678,17 @@ string defaultConfigFile() @property
     import std.path : buildNormalizedPath;
     import std.process : environment;
 
-    version(Posix)
+    version(XDG)
     {
         import std.path : expandTilde;
         enum defaultDir = "~/.config";
         return buildNormalizedPath(environment.get("XDG_CONFIG_HOME", defaultDir),
             "kameloso", "kameloso.conf").expandTilde;
+    }
+    else version(OSX)
+    {
+        return buildNormalizedPath(environment["HOME"], "Library",
+            "Application Support", "kameloso", "kameloso.conf");
     }
     else version(Windows)
     {
@@ -1701,7 +1706,7 @@ unittest
 {
     import std.algorithm.searching : endsWith;
 
-    version(Posix)
+    version(XDG)
     {
         import std.process : environment;
 
@@ -1712,6 +1717,11 @@ unittest
         environment.remove("XDG_CONFIG_HOME");
         df = defaultConfigFile;
         assert(df.endsWith("/.config/kameloso/kameloso.conf"), df);
+    }
+    else version(OSX)
+    {
+        return buildNormalizedPath(environment["HOME"], "Library",
+            "Application Support", "kameloso", "kameloso.conf");
     }
     else version(Windows)
     {
@@ -1740,12 +1750,17 @@ string defaultResourcePrefix() @property
     import std.path : buildNormalizedPath;
     import std.process : environment;
 
-    version(Posix)
+    version(XDG)
     {
         import std.path : expandTilde;
         enum defaultDir = "~/.local/share";
         return buildNormalizedPath(environment.get("XDG_DATA_HOME", defaultDir),
             "kameloso").expandTilde;
+    }
+    else version(OSX)
+    {
+        return buildNormalizedPath(environment["HOME"], "Library",
+            "Application Support", "kameloso");
     }
     else version(Windows)
     {
@@ -1763,7 +1778,7 @@ unittest
 {
     import std.algorithm.searching : endsWith;
 
-    version(Posix)
+    version(XDG)
     {
         import kameloso.string : beginsWith;
         import std.process : environment;

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -172,9 +172,10 @@ struct CoreSettings
     string prefix = "!";
 
     @Unconfigurable
+    @Hidden
     {
-        @Hidden
-        string configFile = "kameloso.conf";  /// Main configuration file.
+        string configFile;  /// Main configuration file.
+        string resourceDirectory;  /// Path to resource directory.
     }
 }
 

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -1648,7 +1648,7 @@ enum Next
 }
 
 
-version(Linux)
+version(linux)
 {
     version = XDG;
 }

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -1237,7 +1237,6 @@ void writeConfigurationFile(ref Client client, const string filename)
 
         foreach (plugin; plugins)
         {
-            plugin.initResources();  // This is sort of out of place
             plugin.serialiseConfigInto(sink);
         }
 

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -1747,7 +1747,7 @@ unittest
  +  `~/.local/share/kameloso` if no `XDG_DATA_HOME` environment variable
  +  present.
  +
- +  On Windows it defaults to `%LOCALAPPDATA%\\Local\\kameloso\\kameloso`.
+ +  On Windows it defaults to `%LOCALAPPDATA%\\Local\\kameloso`.
  +
  +  Returns:
  +      A string path to the default resource directory.

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -1692,7 +1692,6 @@ unittest
 
     version(Posix)
     {
-        import kameloso.string : beginsWith;
         import std.process : environment;
 
         environment["XDG_CONFIG_HOME"] = "/tmp";
@@ -1701,11 +1700,12 @@ unittest
 
         environment.remove("XDG_CONFIG_HOME");
         df = defaultConfigFile;
-        assert(df.beginsWith("/home/") && df.endsWith("/.config/kameloso/kameloso.conf"));
+        assert(df.endsWith("/.config/kameloso/kameloso.conf"), df);
     }
     else version(Windows)
     {
-        assert(defaultConfigFile.endsWith("\\Local\\kameloso\\kameloso\\kameloso.conf"));
+        immutable df = defaultConfigFile;
+        assert(df.endsWith("\\Local\\kameloso\\kameloso\\kameloso.conf"), df);
     }
 }
 

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -1697,7 +1697,9 @@ string defaultConfigFile() @property
     }
     else
     {
-        static assert(0, "Unsupported platform? Cannot divine default config file path.");
+        pragma(msg, "Unsupported platform? Cannot divine default config file path.");
+        pragma(msg, "Configuration file will be placed in the working directory.");
+        return "kameloso.conf";
     }
 }
 
@@ -1769,7 +1771,9 @@ string defaultResourcePrefix() @property
     }
     else
     {
-        static assert(0, "Unsupported platform? Cannot divine default resource file directory.");
+        pragma(msg, "Unsupported platform? Cannot divine default resource prefix.");
+        pragma(msg, "Resource files will be placed in the working directory.");
+        return ".";
     }
 }
 

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -1728,7 +1728,7 @@ unittest
     else version(OSX)
     {
         immutable df = defaultConfigFile;
-        assert((df.endsWith("Library/Application Support/kameloso/kameloso.conf"), df);
+        assert(df.endsWith("Library/Application Support/kameloso/kameloso.conf"), df);
     }
     else version(Windows)
     {
@@ -1803,7 +1803,7 @@ unittest
     else version (OSX)
     {
         immutable df = defaultResourcePrefix;
-        assert((df.endsWith("Library/Application Support/kameloso"), df);
+        assert(df.endsWith("Library/Application Support/kameloso"), df);
     }
     else version(Windows)
     {

--- a/source/kameloso/config.d
+++ b/source/kameloso/config.d
@@ -34,7 +34,12 @@ import std.typecons : Flag, No, Yes;
 void writeToDisk(Flag!"addBanner" banner = Yes.addBanner)
     (const string filename, const string configurationText)
 {
+    import std.file : mkdirRecurse;
+    import std.path : dirName;
     import std.stdio : File, writefln, writeln;
+
+    immutable dir = filename.dirName;
+    mkdirRecurse(dir);
 
     auto file = File(filename, "w");
 

--- a/source/kameloso/config.d
+++ b/source/kameloso/config.d
@@ -99,6 +99,7 @@ string configReader(const string configFile)
  +/
 final class FileIsNotAFileException : Exception
 {
+    /// The name of the non-file the exception refers to.
     string filename;
 
     /++

--- a/source/kameloso/getopt.d
+++ b/source/kameloso/getopt.d
@@ -201,7 +201,7 @@ Next handleGetopt(ref Client client, string[] args, ref string[] customSettings)
 
                 default:
                     // Should never get here.
-                    assert(0);
+                    assert(0, "Unexpected getopt: " ~ setting);
                 }
             }
         }
@@ -290,7 +290,7 @@ Next handleGetopt(ref Client client, string[] args, ref string[] customSettings)
             // --writeconfig was passed; write configuration to file and quit
 
             BashForeground bannertint;
-            string infotint, logtint;
+            string infotint;
 
             version(Colours)
             {
@@ -304,7 +304,6 @@ Next handleGetopt(ref Client client, string[] args, ref string[] customSettings)
                         BashForeground.black : BashForeground.white;
 
                     infotint = KamelosoLogger.tint(LogLevel.info, settings.brightTerminal).colour;
-                    logtint = KamelosoLogger.tint(LogLevel.all, settings.brightTerminal).colour;
                 }
             }
 

--- a/source/kameloso/getopt.d
+++ b/source/kameloso/getopt.d
@@ -143,8 +143,11 @@ Next handleGetopt(ref Client client, string[] args, ref string[] customSettings)
             "set",          "Manually change a setting (--set plugin.option=setting)", &customSettings,
             "asserts",      genDescription, &shouldGenerateAsserts,
             "gen",          &shouldGenerateAsserts,
-            "c|config",     "Read configuration from file (default %s)"
-                                .format(CoreSettings.init.configFile), &settings.configFile,
+            "c|config",     "Specify a different configuration file [%s]"
+                                .format(settings.configFile), &settings.configFile,
+            "r|resourceDir","Specify a different resource directory [%s]"
+                                .format(settings.resourceDirectory),
+                                &settings.resourceDirectory,
             "w|writeconfig","Write configuration to file", &shouldWriteConfig,
             "writeconf",    &shouldWriteConfig,
             "init",         &shouldWriteConfig,

--- a/source/kameloso/main.d
+++ b/source/kameloso/main.d
@@ -977,6 +977,11 @@ int main(string[] args)
             return 1;
         }
 
+        // Resolve the resource directory
+        import std.path : buildNormalizedPath;
+        settings.resourceDirectory = buildNormalizedPath(settings.resourceDirectory,
+            "server", bot.server.address);
+
         // Initialise plugins outside the loop once, for the error messages
         const invalidEntries = initPlugins(customSettings);
         complainAboutInvalidConfigurationEntries(invalidEntries);

--- a/source/kameloso/main.d
+++ b/source/kameloso/main.d
@@ -1037,9 +1037,6 @@ int main(string[] args)
                 return 1;
             }
 
-            logger.infof("%s%s resolved into %s%s%s IPs.",
-            bot.server.address, logtint, infotint, conn.ips.length, logtint);
-
             string infotint, logtint;
 
             version(Colours)
@@ -1054,6 +1051,9 @@ int main(string[] args)
                     logtint = KamelosoLogger.tint(LogLevel.all, settings.brightTerminal).colour;
                 }
             }
+
+            logger.infof("%s%s resolved into %s%s%s IPs.",
+            bot.server.address, logtint, infotint, conn.ips.length, logtint);
 
             import std.file : exists;
 

--- a/source/kameloso/main.d
+++ b/source/kameloso/main.d
@@ -1059,6 +1059,7 @@ int main(string[] args)
 
             if (!settings.resourceDirectory.exists)
             {
+                import std.file : mkdirRecurse;
                 mkdirRecurse(settings.resourceDirectory);
                 logger.logf("Created resource directory %s%s", infotint, settings.resourceDirectory);
             }

--- a/source/kameloso/main.d
+++ b/source/kameloso/main.d
@@ -1054,6 +1054,17 @@ int main(string[] args)
 
             logger.infof("%s%s resolved into %s%s%s IPs.",
                 bot.server.address, logtint, infotint, conn.ips.length, logtint);
+            import std.file : exists;
+
+            if (!settings.resourceDirectory.exists)
+            {
+                mkdirRecurse(settings.resourceDirectory);
+                logger.logf("Created resource directory %s%s", infotint, settings.resourceDirectory);
+            }
+
+            // Ensure initialised resources after resolve so we know we have a
+            // valid server to create a directory for.
+            initPluginResources();
 
             conn.connect(*abort);
 

--- a/source/kameloso/main.d
+++ b/source/kameloso/main.d
@@ -1030,7 +1030,9 @@ int main(string[] args)
 
             if (!resolved)
             {
-                teardownPlugins();
+                // No need to teardown; if it's the first connect there's
+                // nothing to tear down, and if it's after the first, later code
+                // will have already torn it down.
                 logger.info("Exiting...");
                 return 1;
             }

--- a/source/kameloso/main.d
+++ b/source/kameloso/main.d
@@ -914,7 +914,7 @@ int main(string[] args)
     client.abort = &abort;
 
     settings.configFile = defaultConfigFile;
-    settings.resourceDirectory = defaultResourceBaseDirectory;
+    settings.resourceDirectory = defaultResourcePrefix;
 
     // Prepare an array for `handleGetopt` to fill by ref with custom settings
     // set on the command-line using `--set plugin.setting=value`

--- a/source/kameloso/main.d
+++ b/source/kameloso/main.d
@@ -913,6 +913,9 @@ int main(string[] args)
     Client client;
     client.abort = &abort;
 
+    settings.configFile = defaultConfigFile;
+    settings.resourceDirectory = defaultResourceBaseDirectory;
+
     // Prepare an array for `handleGetopt` to fill by ref with custom settings
     // set on the command-line using `--set plugin.setting=value`
     string[] customSettings;

--- a/source/kameloso/main.d
+++ b/source/kameloso/main.d
@@ -1037,6 +1037,9 @@ int main(string[] args)
                 return 1;
             }
 
+            logger.infof("%s%s resolved into %s%s%s IPs.",
+            bot.server.address, logtint, infotint, conn.ips.length, logtint);
+
             string infotint, logtint;
 
             version(Colours)
@@ -1052,8 +1055,6 @@ int main(string[] args)
                 }
             }
 
-            logger.infof("%s%s resolved into %s%s%s IPs.",
-                bot.server.address, logtint, infotint, conn.ips.length, logtint);
             import std.file : exists;
 
             if (!settings.resourceDirectory.exists)

--- a/source/kameloso/meld.d
+++ b/source/kameloso/meld.d
@@ -390,11 +390,9 @@ unittest
         bool b = false;
     }
 
-    Bools bools1, bools2, backupBools1, backupBools2, inverted, backupInverted;
+    Bools bools1, bools2, inverted, backupInverted;
 
     bools2.a = false;
-    backupBools1 = bools1;
-    backupBools2 = bools2;
 
     inverted.a = false;
     inverted.b = true;
@@ -475,7 +473,7 @@ if (isArray!Array1 && isArray!Array2 && !is(Array2 == const)
     }
     else
     {
-        static assert(0);
+        static assert(0, "Attempted to meld an unsupported type");
     }
 
     foreach (immutable i, val; meldThis)

--- a/source/kameloso/plugins/automode.d
+++ b/source/kameloso/plugins/automode.d
@@ -22,9 +22,6 @@ struct AutomodeSettings
 {
     /// Toggles whether or not the plugin should react to events at all.
     bool enabled = true;
-
-    /// The file to read and save automode definitions from/to.
-    string automodeFile = "automodes.json";
 }
 
 
@@ -44,7 +41,7 @@ void populateAutomodes(AutomodePlugin plugin)
     import std.json : JSON_TYPE;
 
     JSONStorage automodes;
-    automodes.load(plugin.automodeSettings.automodeFile);
+    automodes.load(plugin.automodeFile);
     plugin.automodes = typeof(plugin.automodes).init;
 
     foreach (immutable channel, const modesigns; automodes.object)
@@ -72,7 +69,7 @@ void saveAutomodes(AutomodePlugin plugin)
     JSONStorage automodes;
     pruneChannels(plugin.automodes);
     automodes.storage = JSONValue(plugin.automodes);
-    automodes.save(plugin.automodeSettings.automodeFile);
+    automodes.save(plugin.automodeFile);
 }
 
 
@@ -85,8 +82,8 @@ void initResources(AutomodePlugin plugin)
     import kameloso.json : JSONStorage;
 
     JSONStorage json;
-    json.load(plugin.automodeSettings.automodeFile);
-    json.save(plugin.automodeSettings.automodeFile);
+    json.load(plugin.automodeFile);
+    json.save(plugin.automodeFile);
 }
 
 
@@ -427,6 +424,9 @@ final class AutomodePlugin : IRCPlugin
 
     /// All Automode options gathered.
     @Settings AutomodeSettings automodeSettings;
+
+    /// The file to read and save automode definitions from/to.
+    @ResourceFile string automodeFile = "automodes.json";
 
     mixin IRCPluginImpl;
 }

--- a/source/kameloso/plugins/automode.d
+++ b/source/kameloso/plugins/automode.d
@@ -128,7 +128,7 @@ void onAccountInfo(AutomodePlugin plugin, const IRCEvent event)
         return;
 
     default:
-        assert(0);
+        assert(0, "Invalid IRCEvent annotation on " ~ __FUNCTION__);
     }
 
     plugin.applyAutomodes(nickname, account);

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -1285,7 +1285,20 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
      +/
     this(IRCPluginState state) @system
     {
+        import kameloso.common : settings;
+        import kameloso.traits : isConfigurableVariable;
+        import std.traits : getSymbolsByUDA, hasUDA;
+
         this.privateState = state;
+
+        foreach (immutable i, ref member; this.tupleof)
+        {
+            static if (isConfigurableVariable!member && hasUDA!(this.tupleof[i], ResourceFile))
+            {
+                import std.path : buildNormalizedPath;
+                member = buildNormalizedPath(settings.resourceDirectory, member);
+            }
+        }
 
         static if (__traits(compiles, .initialise))
         {

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -600,6 +600,13 @@ struct Description
 }
 
 
+/++
+ +  Annotation denoting that a variable is a filename to a resource file, such
+ +  as JSONs.
+ +/
+struct ResourceFile;
+
+
 // filterUser
 /++
  +  Decides whether a nickname is known good (whitelisted/admin), known bad (not

--- a/source/kameloso/plugins/notes.d
+++ b/source/kameloso/plugins/notes.d
@@ -33,9 +33,6 @@ struct NotesSettings
     /// Toggles whether or not the plugin should react to events at all.
     bool enabled = true;
 
-    /// Filename of file to save the notes to.
-    string notesFile = "notes.json";
-
     /// Whether or not to replay notes when the user joins.
     bool replayOnJoin = true;
 
@@ -104,7 +101,7 @@ void onReplayEvent(NotesPlugin plugin, const IRCEvent event)
         }
 
         plugin.clearNotes(event.sender.nickname, event.channel);
-        plugin.notes.save(plugin.notesSettings.notesFile);
+        plugin.notes.save(plugin.notesFile);
     }
     catch (const JSONException e)
     {
@@ -114,7 +111,7 @@ void onReplayEvent(NotesPlugin plugin, const IRCEvent event)
         if (e.msg == "JSONValue is not an object")
         {
             plugin.notes.reset();
-            plugin.notes.save(plugin.notesSettings.notesFile);
+            plugin.notes.save(plugin.notesFile);
         }
     }
 }
@@ -193,7 +190,7 @@ void onCommandAddNote(NotesPlugin plugin, const IRCEvent event)
     {
         plugin.addNote(nickname, event.sender.nickname, event.channel, line);
         plugin.chan(event.channel, "Note added.");
-        plugin.notes.save(plugin.notesSettings.notesFile);
+        plugin.notes.save(plugin.notesFile);
     }
     catch (const JSONException e)
     {
@@ -242,7 +239,7 @@ void onCommandReloadQuotes(NotesPlugin plugin)
     if (!plugin.notesSettings.enabled) return;
 
     logger.log("Reloading notes");
-    plugin.notes.load(plugin.notesSettings.notesFile);
+    plugin.notes.load(plugin.notesFile);
 }
 
 
@@ -466,7 +463,7 @@ void onEndOfMotd(NotesPlugin plugin)
 {
     if (!plugin.notesSettings.enabled) return;
 
-    plugin.notes.load(plugin.notesSettings.notesFile);
+    plugin.notes.load(plugin.notesFile);
 }
 
 
@@ -479,8 +476,8 @@ void initResources(NotesPlugin plugin)
     import kameloso.json : JSONStorage;
 
     JSONStorage json;
-    json.load(plugin.notesSettings.notesFile);
-    json.save(plugin.notesSettings.notesFile);
+    json.load(plugin.notesFile);
+    json.save(plugin.notesFile);
 }
 
 
@@ -509,6 +506,9 @@ final class NotesPlugin : IRCPlugin
     +  string key is a channel and the second a nickname.
     +/
     JSONStorage notes;
+
+    /// Filename of file to save the notes to.
+    @ResourceFile string notesFile = "notes.json";
 
     mixin IRCPluginImpl;
     mixin MessagingProxy;

--- a/source/kameloso/plugins/persistence.d
+++ b/source/kameloso/plugins/persistence.d
@@ -309,7 +309,7 @@ public:
 final class PersistenceService : IRCPlugin
 {
     /// File with user definitions.
-    enum userFile = "users.json";
+    @ResourceFile string userFile = "users.json";
 
     /// Associative array of user classifications, per account string name.
     IRCUser.Class[string] userClasses;

--- a/source/kameloso/plugins/pipeline.d
+++ b/source/kameloso/plugins/pipeline.d
@@ -200,7 +200,7 @@ File createFIFO(IRCPluginState state)
  +  Spawns the pipereader thread.
  +/
 @(IRCEvent.Type.RPL_WELCOME)
-void onWelcome(PipelinePlugin plugin, const IRCEvent event)
+void onWelcome(PipelinePlugin plugin)
 {
     plugin.fifoThread = spawn(&pipereader, cast(shared)plugin.state);
 }

--- a/source/kameloso/plugins/printer.d
+++ b/source/kameloso/plugins/printer.d
@@ -1444,7 +1444,6 @@ unittest
 
     enum boldCode = "" ~ I.bold;
     enum italicsCode = "" ~ I.italics;
-    enum underlinedCode = "" ~ I.underlined;
 
     {
         immutable withTags = "This is " ~ boldCode ~ "riddled" ~ boldCode ~ " with " ~

--- a/source/kameloso/plugins/quotes.d
+++ b/source/kameloso/plugins/quotes.d
@@ -32,9 +32,6 @@ struct QuotesSettings
 {
     /// Whether the Quotes plugin should react to events at all.
     bool enabled = true;
-
-    /// Filename of file to save the quotes to.
-    string quotesFile = "quotes.json";
 }
 
 
@@ -195,7 +192,7 @@ void onCommandAddQuote(QuotesPlugin plugin, const IRCEvent event)
     try
     {
         plugin.addQuote(nickname, slice);
-        plugin.quotes.save(plugin.quotesSettings.quotesFile);
+        plugin.quotes.save(plugin.quotesFile);
 
         plugin.privmsg(event.channel, event.sender.nickname,
             "Quote for %s saved (%d on record)"
@@ -249,7 +246,7 @@ void onCommandReloadQuotes(QuotesPlugin plugin)
     if (!plugin.quotesSettings.enabled) return;
 
     logger.log("Reloading quotes");
-    plugin.quotes.load(plugin.quotesSettings.quotesFile);
+    plugin.quotes.load(plugin.quotesFile);
 }
 
 
@@ -263,7 +260,7 @@ void onEndOfMotd(QuotesPlugin plugin)
 {
     if (!plugin.quotesSettings.enabled) return;
 
-    plugin.quotes.load(plugin.quotesSettings.quotesFile);
+    plugin.quotes.load(plugin.quotesFile);
 }
 
 
@@ -276,8 +273,8 @@ void initResources(QuotesPlugin plugin)
     import kameloso.json : JSONStorage;
 
     JSONStorage json;
-    json.load(plugin.quotesSettings.quotesFile);
-    json.save(plugin.quotesSettings.quotesFile);
+    json.load(plugin.quotesFile);
+    json.save(plugin.quotesFile);
 }
 
 
@@ -309,6 +306,9 @@ final class QuotesPlugin : IRCPlugin
 
     /// All Quotes plugin settings gathered.
     @Settings QuotesSettings quotesSettings;
+
+    /// Filename of file to save the quotes to.
+    @ResourceFile string quotesFile = "quotes.json";
 
     mixin IRCPluginImpl;
     mixin MessagingProxy;

--- a/source/kameloso/plugins/seen.d
+++ b/source/kameloso/plugins/seen.d
@@ -148,6 +148,20 @@ final class SeenPlugin : IRCPlugin
     long[string] seenUsers;
 
 
+    // seenFile
+    /+
+     +  The filename to which to persistently store our list of seen users
+     +  between executions of the program.
+     +
+     +  This is only the basename of the file. It will be completed with a path
+     +  to the default (or specified) resource directory, which varies by
+     +  platform. Expect this variable to have values like
+     +  "/home/user/.local/share/kameloso/servers/irc.freenode.net/seen.json"
+     +  after the plugin has been instantiated.
+     +/
+    @ResourceFile string seenFile = "seen.json";
+
+
     // mixin IRCPluginImpl
     /++
      +  This mixes in functions that fully implement an
@@ -214,13 +228,6 @@ struct SeenSettings
 
     /// How often to save seen users to disk (aside from program exit).
     int hoursBetweenSaves = 6;
-
-    // seenFile
-    /+
-     +  The filename to which to persistently store our list of seen users
-     +  between executions of the program.
-     +/
-    string seenFile = "seen.json";
 }
 
 
@@ -434,7 +441,7 @@ void onEndOfList(SeenPlugin plugin)
  +      with (plugin)
  +      while (true)
  +      {
- +          seenUser.saveSeen(seenSettings.seenFile);
+ +          seenUsers.saveSeen(seenFile);
  +          fiber.delayFiber(secs);  // <-- needs visibility of fiber
  +          Fiber.yield();
  +      }
@@ -463,7 +470,7 @@ void onPing(SeenPlugin plugin)
         if ((seenSettings.hoursBetweenSaves > 0) && (now.hour == nextHour))
         {
             nextHour = (nextHour + seenSettings.hoursBetweenSaves) % 24;
-            seenUsers.rehash().saveSeen(seenSettings.seenFile);
+            seenUsers.rehash().saveSeen(seenFile);
         }
     }
 }
@@ -781,7 +788,7 @@ void onEndOfMotd(SeenPlugin plugin)
 
     with (plugin)
     {
-        seenUsers = plugin.loadSeen(seenSettings.seenFile);
+        seenUsers = plugin.loadSeen(seenFile);
 
         if ((seenSettings.hoursBetweenSaves > 24) ||
             (seenSettings.hoursBetweenSaves < 0))
@@ -808,7 +815,7 @@ void onEndOfMotd(SeenPlugin plugin)
  +/
 void teardown(SeenPlugin plugin)
 {
-    plugin.seenUsers.saveSeen(plugin.seenSettings.seenFile);
+    plugin.seenUsers.saveSeen(plugin.seenFile);
 }
 
 
@@ -821,8 +828,8 @@ void initResources(SeenPlugin plugin)
     import kameloso.json : JSONStorage;
 
     JSONStorage json;
-    json.load(plugin.seenSettings.seenFile);
-    json.save(plugin.seenSettings.seenFile);
+    json.load(plugin.seenFile);
+    json.save(plugin.seenFile);
 }
 
 

--- a/source/kameloso/uda.d
+++ b/source/kameloso/uda.d
@@ -4,7 +4,7 @@
 module kameloso.uda;
 
 /// UDA conveying that a field is not to be saved in configuration files.
-struct Unconfigurable {}
+struct Unconfigurable;
 
 /// UDA conveying that a string is an array with this token as separator.
 struct Separator
@@ -17,10 +17,10 @@ struct Separator
  +  UDA conveying that this member contains sensitive information and should not
  +  be printed in clear text; e.g. passwords.
  +/
-struct Hidden {}
+struct Hidden;
 
 /++
  +  UDA conveying that a string contains characters that could otherwise
  +  indicate a comment.
  +/
-struct CannotContainComments {}
+struct CannotContainComments;


### PR DESCRIPTION
So far we've been saving the configuration files and plugins' resource JSON files in the working directory. There was the command-line flag to manually specify a different configuration file, which in turn had fields for "`seenFile`", "`quotesFile`" and such.

With this change we now try to guess a sane default working directory-independent path to both the configuration `.conf` file, and *separately* for the plugins' resource JSONs. XDG-compliant (Linux/*) systems obey environmental variables first and fall back to hardcoded defaults second, so we're doing that. On Windows we're just guessing we're doing the right thing; testing needed.

New getopt options are in place to allow for manually specifying directories.

**TL;DR**: If Linux and similar, look for your configuration file at `~/.config/kameloso/kameloso.conf`, and your resource files at `~/.local/share/kameloso/networks/*/`. If Windows, look to `%APPDATA%\\Local\\kameloso\\kameloso`.