### PR TITLE
Enumtest8525

### DIFF
--- a/source/kameloso/debugging.d
+++ b/source/kameloso/debugging.d
@@ -144,7 +144,8 @@ if (is(QualThing == struct))
 
                     static if (asserts)
                     {
-                        immutable pattern = "%sassert((%s%s == " ~ typename ~ ".%s), %2$s%3$s.to!string);\n";
+                        immutable pattern = "%sassert((%s%s == " ~ typename ~ ".%s), " ~
+                            "Enum!(" ~ typename ~ ").toString(%2$s%3$s));\n";
                     }
                     else
                     {
@@ -228,7 +229,7 @@ assert(sink.data ==
 assert((user == "UUUUUSER"), user);
 assert((server.address == "something.freenode.net"), server.address);
 assert((server.port == 0), server.port.to!string);
-assert((server.daemon == IRCServer.Daemon.unreal), server.daemon.to!string);
+assert((server.daemon == IRCServer.Daemon.unreal), Enum!(IRCServer.Daemon).toString(server.daemon));
 assert((server.aModes == ""), server.aModes);
 `, '\n' ~ sink.data);
 
@@ -272,11 +273,11 @@ assert(!b);
     sink.formatDelta!(Yes.asserts)(IRCEvent.init, event, 2);
 
     assert(sink.data ==
-`        assert((type == IRCEvent.Type.CHAN), type.to!string);
+`        assert((type == IRCEvent.Type.CHAN), Enum!(IRCEvent.Type).toString(type));
         assert((sender.nickname == "zorael"), sender.nickname);
         assert((sender.ident == "~NaN"), sender.ident);
         assert((sender.address == "2001:41d0:2:80b4::"), sender.address);
-        assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+        assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
         assert((channel == "#flerrp"), channel);
         assert((content == "kameloso: 8ball"), content);
 `, '\n' ~ sink.data);
@@ -350,7 +351,7 @@ unittest
     immutable event = parser.toIRCEvent(":zorael!~NaN@2001:41d0:2:80b4:: PRIVMSG #flerrp :kameloso: 8ball");
     with (event)
     {
-        assert((type == IRCEvent.Type.CHAN), type.to!string);
+        assert((type == IRCEvent.Type.CHAN), Enum!(IRCEvent.Type).toString(type));
         assert((sender.nickname == "zorael"), sender.nickname);
         assert((sender.ident == "~NaN"), sender.ident);
         assert((sender.address == "2001:41d0:2:80b4::"), sender.address);

--- a/source/kameloso/irc.d
+++ b/source/kameloso/irc.d
@@ -135,6 +135,7 @@ void parseBasic(ref IRCParser parser, ref IRCEvent event) pure
 ///
 unittest
 {
+    import kameloso.conv : Enum;
     import std.conv : to;
 
     IRCParser parser;
@@ -144,7 +145,7 @@ unittest
     {
         raw = "PING :irc.server.address";
         parser.parseBasic(e1);
-        assert((type == IRCEvent.Type.PING), type.to!string);
+        assert((type == IRCEvent.Type.PING), Enum!(IRCEvent.Type).toString(type));
         assert((sender.address == "irc.server.address"), sender.address);
         assert(!sender.nickname.length, sender.nickname);
     }
@@ -155,7 +156,7 @@ unittest
         // QuakeNet and others not having the sending server as prefix
         raw = "NOTICE AUTH :*** Couldn't look up your hostname";
         parser.parseBasic(e2);
-        assert((type == IRCEvent.Type.NOTICE), type.to!string);
+        assert((type == IRCEvent.Type.NOTICE), Enum!(IRCEvent.Type).toString(type));
         assert(!sender.nickname.length, sender.nickname);
         assert((content == "*** Couldn't look up your hostname"));
     }
@@ -165,7 +166,7 @@ unittest
     {
         raw = "ERROR :Closing Link: 81-233-105-62-no80.tbcn.telia.com (Quit: kameloso^)";
         parser.parseBasic(e3);
-        assert((type == IRCEvent.Type.ERROR), type.to!string);
+        assert((type == IRCEvent.Type.ERROR), Enum!(IRCEvent.Type).toString(type));
         assert(!sender.nickname.length, sender.nickname);
         assert((content == "Closing Link: 81-233-105-62-no80.tbcn.telia.com (Quit: kameloso^)"), content);
     }
@@ -219,6 +220,7 @@ void parsePrefix(ref IRCParser parser, ref IRCEvent event, ref string slice) pur
 ///
 unittest
 {
+    import kameloso.conv : Enum;
     import std.conv : to;
 
     IRCParser parser;
@@ -233,7 +235,7 @@ unittest
         assert((nickname == "zorael"), nickname);
         assert((ident == "~NaN"), ident);
         assert((address == "some.address.org"), address);
-        assert((class_ != IRCUser.Class.special), class_.to!string);
+        assert((class_ != IRCUser.Class.special), Enum!(IRCUser.Class).toString(class_));
     }
 
     IRCEvent e2;
@@ -246,7 +248,7 @@ unittest
         assert((nickname == "NickServ"), nickname);
         assert((ident == "NickServ"), ident);
         assert((address == "services."), address);
-        assert((class_ == IRCUser.Class.special), class_.to!string);
+        assert((class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(class_));
     }
 
     IRCEvent e3;
@@ -259,7 +261,7 @@ unittest
         assert((nickname == "kameloso^^"), nickname);
         assert((ident == "~NaN"), ident);
         assert((address == "C2802314.E23AD7D8.E9841504.IP"), address);
-        assert((class_ != IRCUser.Class.special), class_.to!string);
+        assert((class_ != IRCUser.Class.special), Enum!(IRCUser.Class).toString(class_));
     }
 
     IRCEvent e4;
@@ -273,7 +275,7 @@ unittest
         assert((nickname == "Q"), nickname);
         assert((ident == "TheQBot"), ident);
         assert((address == "CServe.quakenet.org"), address);
-        assert((class_ == IRCUser.Class.special), class_.to!string);
+        assert((class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(class_));
     }
 }
 
@@ -345,6 +347,7 @@ void parseTypestring(ref IRCParser parser, ref IRCEvent event, ref string slice)
 ///
 unittest
 {
+    import kameloso.conv : Enum;
     import std.conv : to;
 
     IRCParser parser;
@@ -355,7 +358,7 @@ unittest
         raw = /*":port80b.se.quakenet.org */"421 kameloso åäö :Unknown command";
         string slice = raw;  // mutable
         parser.parseTypestring(e1, slice);
-        assert((type == IRCEvent.Type.ERR_UNKNOWNCOMMAND), type.to!string);
+        assert((type == IRCEvent.Type.ERR_UNKNOWNCOMMAND), Enum!(IRCEvent.Type).toString(type));
         assert((num == 421), num.to!string);
     }
 
@@ -365,7 +368,7 @@ unittest
         raw = /*":port80b.se.quakenet.org */"353 kameloso = #garderoben :@kameloso'";
         string slice = raw;  // mutable
         parser.parseTypestring(e2, slice);
-        assert((type == IRCEvent.Type.RPL_NAMREPLY), type.to!string);
+        assert((type == IRCEvent.Type.RPL_NAMREPLY), Enum!(IRCEvent.Type).toString(type));
         assert((num == 353), num.to!string);
     }
 
@@ -375,7 +378,7 @@ unittest
         raw = /*":zorael!~NaN@ns3363704.ip-94-23-253.eu */"PRIVMSG kameloso^ :test test content";
         string slice = raw;
         parser.parseTypestring(e3, slice);
-        assert((type == IRCEvent.Type.PRIVMSG), type.to!string);
+        assert((type == IRCEvent.Type.PRIVMSG), Enum!(IRCEvent.Type).toString(type));
     }
 
     IRCEvent e4;
@@ -384,7 +387,7 @@ unittest
         raw = /*`:zorael!~NaN@ns3363704.ip-94-23-253.eu */`PART #flerrp :"WeeChat 1.6"`;
         string slice = raw;
         parser.parseTypestring(e4, slice);
-        assert((type == IRCEvent.Type.PART), type.to!string);
+        assert((type == IRCEvent.Type.PART), Enum!(IRCEvent.Type).toString(type));
     }
 }
 

--- a/source/kameloso/meld.d
+++ b/source/kameloso/meld.d
@@ -355,6 +355,8 @@ unittest
         class_ = User.Class.blacklist;
     }
 
+    import kameloso.conv : Enum;
+
     User twoCopy = two;
 
     one.meldInto!(MeldingStrategy.conservative)(two);
@@ -366,7 +368,7 @@ unittest
         assert((address == "asdf.org"), address);
         assert((login == "kamelusu"), login);
         assert(special);
-        assert((class_ == User.Class.whitelist), class_.to!string);
+        assert((class_ == User.Class.whitelist), Enum!(User.Class).toString(class_));
     }
 
     one.class_ = User.Class.blacklist;
@@ -380,7 +382,7 @@ unittest
         assert((address == "herpderp.net"), address);
         assert((login == "kamelusu"), login);
         assert(!special);
-        assert((class_ == User.Class.blacklist), class_.to!string);
+        assert((class_ == User.Class.blacklist), Enum!(User.Class).toString(class_));
     }
 
     struct EnumThing
@@ -392,9 +394,9 @@ unittest
     EnumThing e1;
     EnumThing e2;
     e2.enum_ = EnumThing.Enum.three;
-    assert((e1.enum_ == EnumThing.Enum.init), e1.enum_.to!string);
+    assert((e1.enum_ == EnumThing.Enum.init), Enum!(EnumThing.Enum).toString(e1.enum_));
     e2.meldInto(e1);
-    assert((e1.enum_ == EnumThing.Enum.three), e1.enum_.to!string);
+    assert((e1.enum_ == EnumThing.Enum.three), Enum!(EnumThing.Enum).toString(e1.enum_));
 
     struct WithArray
     {

--- a/source/kameloso/messaging.d
+++ b/source/kameloso/messaging.d
@@ -41,6 +41,8 @@ void chan(Flag!"quiet" quiet = No.quiet)(IRCPluginState state, const string chan
 ///
 unittest
 {
+    import kameloso.conv : Enum;
+
     IRCPluginState state;
     state.mainThread = thisTid;
 
@@ -49,7 +51,7 @@ unittest
     immutable event = receiveOnly!IRCEvent;
     with (event)
     {
-        assert((type == IRCEvent.Type.CHAN), type.to!string);
+        assert((type == IRCEvent.Type.CHAN), Enum!(IRCEvent.Type).toString(type));
         assert((channel == "#channel"), channel);
         assert((content == "content"), content);
     }
@@ -74,6 +76,8 @@ void query(Flag!"quiet" quiet = No.quiet)(IRCPluginState state, const string nic
 ///
 unittest
 {
+    import kameloso.conv : Enum;
+
     IRCPluginState state;
     state.mainThread = thisTid;
 
@@ -82,7 +86,7 @@ unittest
     immutable event = receiveOnly!IRCEvent;
     with (event)
     {
-        assert((type == IRCEvent.Type.QUERY), type.to!string);
+        assert((type == IRCEvent.Type.QUERY), Enum!(IRCEvent.Type).toString(type));
         assert((target.nickname == "kameloso"), target.nickname);
         assert((content == "content"), content);
     }
@@ -121,6 +125,8 @@ void privmsg(Flag!"quiet" quiet = No.quiet)(IRCPluginState state, const string c
 ///
 unittest
 {
+    import kameloso.conv : Enum;
+
     IRCPluginState state;
     state.mainThread = thisTid;
 
@@ -129,7 +135,7 @@ unittest
     immutable event1 = receiveOnly!IRCEvent;
     with (event1)
     {
-        assert((type == IRCEvent.Type.CHAN), type.to!string);
+        assert((type == IRCEvent.Type.CHAN), Enum!(IRCEvent.Type).toString(type));
         assert((channel == "#channel"), channel);
         assert((content == "content"), content);
         assert(!target.nickname.length, target.nickname);
@@ -140,7 +146,7 @@ unittest
     immutable event2 = receiveOnly!IRCEvent;
     with (event2)
     {
-        assert((type == IRCEvent.Type.QUERY), type.to!string);
+        assert((type == IRCEvent.Type.QUERY), Enum!(IRCEvent.Type).toString(type));
         assert(!channel.length, channel);
         assert((target.nickname == "kameloso"), target.nickname);
         assert((content == "content"), content);
@@ -174,6 +180,8 @@ void emote(Flag!"quiet" quiet = No.quiet)(IRCPluginState state, const string emo
 ///
 unittest
 {
+    import kameloso.conv : Enum;
+
     IRCPluginState state;
     state.mainThread = thisTid;
 
@@ -182,7 +190,7 @@ unittest
     immutable event1 = receiveOnly!IRCEvent;
     with (event1)
     {
-        assert((type == IRCEvent.Type.EMOTE), type.to!string);
+        assert((type == IRCEvent.Type.EMOTE), Enum!(IRCEvent.Type).toString(type));
         assert((channel == "#channel"), channel);
         assert((content == "content"), content);
         assert(!target.nickname.length, target.nickname);
@@ -193,7 +201,7 @@ unittest
     immutable event2 = receiveOnly!IRCEvent;
     with (event2)
     {
-        assert((type == IRCEvent.Type.EMOTE), type.to!string);
+        assert((type == IRCEvent.Type.EMOTE), Enum!(IRCEvent.Type).toString(type));
         assert(!channel.length, channel);
         assert((target.nickname == "kameloso"), target.nickname);
         assert((content == "content"), content);
@@ -227,6 +235,8 @@ void mode(Flag!"quiet" quiet = No.quiet)(IRCPluginState state, const string chan
 ///
 unittest
 {
+    import kameloso.conv : Enum;
+
     IRCPluginState state;
     state.mainThread = thisTid;
 
@@ -235,7 +245,7 @@ unittest
     immutable event = receiveOnly!IRCEvent;
     with (event)
     {
-        assert((type == IRCEvent.Type.MODE), type.to!string);
+        assert((type == IRCEvent.Type.MODE), Enum!(IRCEvent.Type).toString(type));
         assert((channel == "#channel"), channel);
         assert((content == "content"), content);
         assert((aux == "+o"), aux);
@@ -263,6 +273,8 @@ void topic(Flag!"quiet" quiet = No.quiet)(IRCPluginState state, const string cha
 ///
 unittest
 {
+    import kameloso.conv : Enum;
+
     IRCPluginState state;
     state.mainThread = thisTid;
 
@@ -271,7 +283,7 @@ unittest
     immutable event = receiveOnly!IRCEvent;
     with (event)
     {
-        assert((type == IRCEvent.Type.TOPIC), type.to!string);
+        assert((type == IRCEvent.Type.TOPIC), Enum!(IRCEvent.Type).toString(type));
         assert((channel == "#channel"), channel);
         assert((content == "content"), content);
     }
@@ -298,6 +310,8 @@ void invite(Flag!"quiet" quiet = No.quiet)(IRCPluginState state, const string ch
 ///
 unittest
 {
+    import kameloso.conv : Enum;
+
     IRCPluginState state;
     state.mainThread = thisTid;
 
@@ -306,7 +320,7 @@ unittest
     immutable event = receiveOnly!IRCEvent;
     with (event)
     {
-        assert((type == IRCEvent.Type.INVITE), type.to!string);
+        assert((type == IRCEvent.Type.INVITE), Enum!(IRCEvent.Type).toString(type));
         assert((channel == "#channel"), channel);
         assert((target.nickname == "kameloso"), target.nickname);
     }
@@ -332,6 +346,8 @@ void join(Flag!"quiet" quiet = No.quiet)(IRCPluginState state, const string chan
 ///
 unittest
 {
+    import kameloso.conv : Enum;
+
     IRCPluginState state;
     state.mainThread = thisTid;
 
@@ -340,7 +356,7 @@ unittest
     immutable event = receiveOnly!IRCEvent;
     with (event)
     {
-        assert((type == IRCEvent.Type.JOIN), type.to!string);
+        assert((type == IRCEvent.Type.JOIN), Enum!(IRCEvent.Type).toString(type));
         assert((channel == "#channel"), channel);
     }
 }
@@ -371,6 +387,8 @@ void kick(Flag!"quiet" quiet = No.quiet)(IRCPluginState state, const string chan
 ///
 unittest
 {
+    import kameloso.conv : Enum;
+
     IRCPluginState state;
     state.mainThread = thisTid;
 
@@ -379,7 +397,7 @@ unittest
     immutable event = receiveOnly!IRCEvent;
     with (event)
     {
-        assert((type == IRCEvent.Type.KICK), type.to!string);
+        assert((type == IRCEvent.Type.KICK), Enum!(IRCEvent.Type).toString(type));
         assert((channel == "#channel"), channel);
         assert((content == "content"), content);
         assert((target.nickname == "kameloso"), target.nickname);
@@ -408,6 +426,8 @@ void part(Flag!"quiet" quiet = No.quiet)(IRCPluginState state,
 ///
 unittest
 {
+    import kameloso.conv : Enum;
+
     IRCPluginState state;
     state.mainThread = thisTid;
 
@@ -416,7 +436,7 @@ unittest
     immutable event = receiveOnly!IRCEvent;
     with (event)
     {
-        assert((type == IRCEvent.Type.PART), type.to!string);
+        assert((type == IRCEvent.Type.PART), Enum!(IRCEvent.Type).toString(type));
         assert((channel == "#channel"), channel);
         assert((content == "reason"), content);
     }
@@ -440,6 +460,7 @@ void quit(Flag!"quiet" quiet = No.quiet)(IRCPluginState state, const string reas
 ///
 unittest
 {
+    import kameloso.conv : Enum;
     IRCPluginState state;
     state.mainThread = thisTid;
 
@@ -448,7 +469,7 @@ unittest
     immutable event = receiveOnly!IRCEvent;
     with (event)
     {
-        assert((type == IRCEvent.Type.QUIT), type.to!string);
+        assert((type == IRCEvent.Type.QUIT), Enum!(IRCEvent.Type).toString(type));
         assert((content == "reason"), content);
     }
 }
@@ -474,6 +495,8 @@ void raw(Flag!"quiet" quiet = No.quiet)(IRCPluginState state, const string line)
 ///
 unittest
 {
+    import kameloso.conv : Enum;
+
     IRCPluginState state;
     state.mainThread = thisTid;
 
@@ -482,7 +505,7 @@ unittest
     immutable event = receiveOnly!IRCEvent;
     with (event)
     {
-        assert((type == IRCEvent.Type.UNSET), type.to!string);
+        assert((type == IRCEvent.Type.UNSET), Enum!(IRCEvent.Type).toString(type));
         assert((content == "commands"), content);
     }
 }

--- a/source/kameloso/plugins/ctcp.d
+++ b/source/kameloso/plugins/ctcp.d
@@ -260,7 +260,8 @@ void onCTCPClientinfo(CTCPService service, const IRCEvent event)
             {
                 foreach (type; getUDAs!(fun, IRCEvent.Type))
                 {
-                    enum typestring = type.to!string;
+                    import kameloso.conv : Enum;
+                    enum typestring = Enum!(IRCEvent.Type).toString(type);
 
                     static if (typestring.beginsWith("CTCP_"))
                     {

--- a/tests/events.d
+++ b/tests/events.d
@@ -1,3 +1,4 @@
+import kameloso.conv : Enum;
 import kameloso.irc;
 import std.conv : to;
 
@@ -14,7 +15,7 @@ unittest
     with (e1)
     {
         assert((sender.address == "tepper.freenode.net"), sender.address);
-        assert((type == IRCEvent.Type.NOTICE), type.to!string);
+        assert((type == IRCEvent.Type.NOTICE), Enum!(IRCEvent.Type).toString(type));
         assert((content == "*** Checking Ident"), content);
     }
 
@@ -26,7 +27,7 @@ unittest
     with (e2)
     {
         assert((sender.address == "tepper.freenode.net"), sender.address);
-        assert((type == IRCEvent.Type.ERR_NICKNAMEINUSE), type.to!string);
+        assert((type == IRCEvent.Type.ERR_NICKNAMEINUSE), Enum!(IRCEvent.Type).toString(type));
         assert((content == "Nickname is already in use."), content);
         assert((num == 433), num.to!string);
     }
@@ -41,7 +42,7 @@ unittest
     with (e3)
     {
         assert((sender.address == "tepper.freenode.net"), sender.address);
-        assert((type == IRCEvent.Type.RPL_WELCOME), type.to!string);
+        assert((type == IRCEvent.Type.RPL_WELCOME), Enum!(IRCEvent.Type).toString(type));
         assert((content == "Welcome to the freenode Internet Relay Chat Network kameloso^"),
                content);
         assert((num == 1), num.to!string);
@@ -55,7 +56,7 @@ unittest
     with (e4)
     {
         assert((sender.address == "tepper.freenode.net"), sender.address);
-        assert((type == IRCEvent.Type.RPL_ENDOFMOTD), type.to!string);
+        assert((type == IRCEvent.Type.RPL_ENDOFMOTD), Enum!(IRCEvent.Type).toString(type));
         assert((content == "End of /MOTD command."), content);
         assert((num == 376), num.to!string);
     }
@@ -68,7 +69,7 @@ unittest
     with (e5)
     {
         assert((sender.nickname == "kameloso^"), sender.nickname);
-        assert((type == IRCEvent.Type.SELFMODE), type.to!string);
+        assert((type == IRCEvent.Type.SELFMODE), Enum!(IRCEvent.Type).toString(type));
         assert((aux == "+i"), aux);
     }
 
@@ -80,7 +81,7 @@ unittest
     with (e6)
     {
         assert((sender.nickname == "zorael"), sender.nickname);
-        assert((type == IRCEvent.Type.QUERY), type.to!string); // Will this work?
+        assert((type == IRCEvent.Type.QUERY), Enum!(IRCEvent.Type).toString(type)); // Will this work?
         assert((target.nickname == "kameloso^"), target.nickname);
         assert((content == "sudo privmsg zorael :derp"), content);
     }
@@ -93,7 +94,7 @@ unittest
     with (e7)
     {
         assert((sender.address == "tepper.freenode.net"), sender.address);
-        assert((type == IRCEvent.Type.RPL_WHOISUSER), type.to!string);
+        assert((type == IRCEvent.Type.RPL_WHOISUSER), Enum!(IRCEvent.Type).toString(type));
         assert((target.nickname == "zorael"), target.nickname);
         assert((target.ident == "~NaN"), target.ident);
         assert((target.address == "ns3363704.ip-94-23-253.eu"), target.address);
@@ -109,7 +110,7 @@ unittest
     with (e8)
     {
         assert((sender.address == "tepper.freenode.net"), sender.address);
-        assert((type == IRCEvent.Type.RPL_WHOISACCOUNT), type.to!string);
+        assert((type == IRCEvent.Type.RPL_WHOISACCOUNT), Enum!(IRCEvent.Type).toString(type));
         assert((target.nickname == "zurael"), target.nickname);
         assert((content == "zorael"), content);
         assert((target.account == "zorael"), target.account);
@@ -124,7 +125,7 @@ unittest
     with (e9)
     {
         assert((sender.address == "tepper.freenode.net"), sender.address);
-        assert((type == IRCEvent.Type.PONG), type.to!string);
+        assert((type == IRCEvent.Type.PONG), Enum!(IRCEvent.Type).toString(type));
         assert(!target.nickname.length, target.nickname); // More than the server and type is never parsed
     }
 
@@ -137,7 +138,7 @@ unittest
     with (e10)
     {
         assert((sender.nickname == "wonderworld"), sender.nickname);
-        assert((type == IRCEvent.Type.QUIT), type.to!string);
+        assert((type == IRCEvent.Type.QUIT), Enum!(IRCEvent.Type).toString(type));
         assert(!target.nickname.length, target.nickname);
         assert((content == "Remote host closed the connection"), content);
     }
@@ -150,7 +151,7 @@ unittest
      with (e11)
      {
         assert((sender.nickname == "zorael"), sender.nickname);
-        assert((type == IRCEvent.Type.MODE), type.to!string);
+        assert((type == IRCEvent.Type.MODE), Enum!(IRCEvent.Type).toString(type));
         assert((content == "kameloso^"), content);
         assert((channel == "#flerrp"), channel);
         assert((aux == "+v"), aux);
@@ -164,7 +165,7 @@ unittest
      with (e12)
      {
         assert((sender.address == "irc.uworld.se"), sender.address);
-        assert((type == IRCEvent.Type.ERR_BADPING), type.to!string);
+        assert((type == IRCEvent.Type.ERR_BADPING), Enum!(IRCEvent.Type).toString(type));
         assert((target.nickname == "kameloso"), target.nickname);
         assert((content == "PONG 3705964477"), content);
      }
@@ -177,7 +178,7 @@ unittest
     with (e13)
     {
         assert((sender.address == "karatkievich.freenode.net"), sender.address);
-        assert((type == IRCEvent.Type.ERR_UNKNOWNCOMMAND), type.to!string);
+        assert((type == IRCEvent.Type.ERR_UNKNOWNCOMMAND), Enum!(IRCEvent.Type).toString(type));
         assert((content == "systemd,#kde,#kubuntu,#archlinux ..."), content);
     }
 
@@ -188,7 +189,7 @@ unittest
     with (e14)
     {
         assert((sender.address == "asimov.freenode.net"), sender.address);
-        assert((type == IRCEvent.Type.ERR_UNKNOWNCOMMAND), type.to!string);
+        assert((type == IRCEvent.Type.ERR_UNKNOWNCOMMAND), Enum!(IRCEvent.Type).toString(type));
         assert((content == "Unknown command"), content);
         assert((aux == "sudo"), aux);
     }
@@ -202,7 +203,7 @@ unittest
     with (e15)
     {
         assert((sender.nickname == "wob^2"), sender.nickname);
-        assert((type == IRCEvent.Type.CTCP_PING), type.to!string);
+        assert((type == IRCEvent.Type.CTCP_PING), Enum!(IRCEvent.Type).toString(type));
         assert((content == "1495974267 590878"), content);
         assert((aux == "PING"), aux);
     }
@@ -214,7 +215,7 @@ unittest
     with (e16)
     {
         assert((sender.nickname == "beLAban"), sender.nickname);
-        assert((type == IRCEvent.Type.CHAN), type.to!string);
+        assert((type == IRCEvent.Type.CHAN), Enum!(IRCEvent.Type).toString(type));
         assert((channel == "##networking"), channel);
         assert((content == "start at cpasdcas"), content);
     }
@@ -228,7 +229,7 @@ unittest
     with (e17)
     {
         assert((sender.nickname == "zorael"), sender.nickname);
-        assert((type == IRCEvent.Type.EMOTE), type.to!string);
+        assert((type == IRCEvent.Type.EMOTE), Enum!(IRCEvent.Type).toString(type));
         assert((channel == "#flerrp"), channel);
         assert((content == "123 test test content"), content);
     }
@@ -242,7 +243,7 @@ unittest
         with (e18)
         {
             assert((sender.address == "tmi.twitch.tv"), sender.address);
-            assert((type == IRCEvent.Type.TWITCH_HOSTSTART), type.to!string);
+            assert((type == IRCEvent.Type.TWITCH_HOSTSTART), Enum!(IRCEvent.Type).toString(type));
             assert((channel == "#lirik"), channel);
             assert((content == "h1z1"), content);
             assert(!count, count.to!string);
@@ -256,7 +257,7 @@ unittest
         with (e19)
         {
             assert((sender.address == "tmi.twitch.tv"), sender.address);
-            assert((type == IRCEvent.Type.TWITCH_HOSTEND), type.to!string);
+            assert((type == IRCEvent.Type.TWITCH_HOSTEND), Enum!(IRCEvent.Type).toString(type));
             assert((channel == "#lirik"), channel);
             assert((count == 178), count.to!string);
             assert(!num, num.to!string);
@@ -269,7 +270,7 @@ unittest
         with (e20)
         {
             assert((sender.address == "tmi.twitch.tv"), sender.address);
-            assert((type == IRCEvent.Type.TWITCH_HOSTSTART), type.to!string);
+            assert((type == IRCEvent.Type.TWITCH_HOSTSTART), Enum!(IRCEvent.Type).toString(type));
             assert((channel == "#lirik"), channel);
             assert((content == "chu8"), content);
             assert((count == 270), count.to!string);
@@ -283,7 +284,7 @@ unittest
         assert((sender.nickname == "kameloso_"), sender.nickname);
         assert((sender.ident == "~NaN"), sender.ident);
         assert((sender.address == "81-233-105-62-no80.tbcn.telia.com"), sender.address);
-        assert((type == IRCEvent.Type.NICK), type.to!string);
+        assert((type == IRCEvent.Type.NICK), Enum!(IRCEvent.Type).toString(type));
         assert((target.nickname == "kameloso__"), target.nickname);
     }
 
@@ -293,7 +294,7 @@ unittest
         assert((sender.nickname == "kameloso^"), sender.nickname);
         assert((sender.ident == "~NaN"), sender.ident);
         assert((sender.address == "81-233-105-62-no80.tbcn.telia.com"), sender.address);
-        assert((type == IRCEvent.Type.SELFNICK), type.to!string);
+        assert((type == IRCEvent.Type.SELFNICK), Enum!(IRCEvent.Type).toString(type));
         assert((target.nickname == "kameloso_"), target.nickname);
         assert((parser.bot.nickname == "kameloso_"), parser.bot.nickname);
     }
@@ -305,7 +306,7 @@ unittest
     with (e24)
     {
         assert((sender.address == "like.so"), sender.address);
-        assert((type == IRCEvent.Type.ERR_BADPING), type.to!string);
+        assert((type == IRCEvent.Type.ERR_BADPING), Enum!(IRCEvent.Type).toString(type));
         assert((target.nickname == "kameloso"), target.nickname);
         assert((content == "PONG 3705964477"), content);
     }
@@ -316,7 +317,7 @@ unittest
 
         with (event)
         {
-            assert((type == IRCEvent.Type.SELFKICK), type.to!string);
+            assert((type == IRCEvent.Type.SELFKICK), Enum!(IRCEvent.Type).toString(type));
             assert((sender.nickname == "zorael"), sender.nickname);
             assert((sender.ident == "~NaN"), sender.ident);
             assert((sender.address == "2001:41d0:2:80b4::"), sender.address);
@@ -336,8 +337,8 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == ERROR), type.to!string);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((type == ERROR), Enum!(IRCEvent.Type).toString(type));
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "Closing Link: 81-233-105-62-no80.tbcn.telia.com (Quit: kameloso^)"), content);
         }
     }
@@ -347,11 +348,11 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == CHAN), type.to!string);
+            assert((type == CHAN), Enum!(IRCEvent.Type).toString(type));
             assert((sender.nickname == "asdcsa"), sender.nickname);
             assert((sender.ident == "asdcss"), sender.ident);
             assert((sender.address == "asdcsd.tmi.twitch.tv"), sender.address);
-            assert((sender.class_ != IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ != IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "#lirik"), channel);
             assert((content == "lirikFR lirikFR lirikFR lirikFR :sled: lirikLUL"), content);
             assert((tags == "badges=subscriber/3;color=;display-name=asdcassr;emotes=560489:0-6,8-14,16-22,24-30/560510:39-46;id=4d6bbafb-427d-412a-ae24-4426020a1042;mod=0;room-id=23161357;sent-ts=1510059590512;subscriber=1;tmi-sent-ts=1510059591528;turbo=0;user-id=38772474;user-type="), tags);
@@ -363,8 +364,8 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == NOTICE), type.to!string);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((type == NOTICE), Enum!(IRCEvent.Type).toString(type));
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "*** If you are having problems connecting due to ping timeouts, please type /notice F94828E6 nospoof now."), content);
         }
     }
@@ -374,9 +375,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == ROOMSTATE), type.to!string);
+            assert((type == ROOMSTATE), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "tmi.twitch.tv"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "#zorael"), channel);
             assert((tags == "broadcaster-lang=;emote-only=0;followers-only=-1;mercury=0;r9k=0;room-id=22216721;slow=0;subs-only=0"), tags);
         }
@@ -387,9 +388,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_NAMREPLY), type.to!string);
+            assert((type == RPL_NAMREPLY), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "port80b.se.quakenet.org"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "#garderoben"), channel);
             assert((content == "@kameloso"), content);
             assert((num == 353), num.to!string);
@@ -400,9 +401,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == ERR_NOSUCHCHANNEL), type.to!string);
+            assert((type == ERR_NOSUCHCHANNEL), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "moon.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "archlinux"), channel);
             assert((content == "No such channel"), content);
             assert((num == 403), num.to!string);
@@ -414,9 +415,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_TOPIC), type.to!string);
+            assert((type == RPL_TOPIC), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "asimov.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "#garderoben"), channel);
             assert((content == "Are you employed, sir?"), content);
             assert((num == 332), num.to!string);
@@ -428,9 +429,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_ENDOFNAMES), type.to!string);
+            assert((type == RPL_ENDOFNAMES), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "asimov.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "#flerrp"), channel);
             assert((content == "End of /NAMES list."), content);
             assert((num == 366), num.to!string);
@@ -442,9 +443,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_CHANNEL_URL), type.to!string);
+            assert((type == RPL_CHANNEL_URL), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "services."), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "#ubuntu"), channel);
             assert((content == "http://www.ubuntu.com"), content);
             assert((num == 328), num.to!string);
@@ -456,9 +457,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == ERR_NEEDREGGEDNICK), type.to!string);
+            assert((type == ERR_NEEDREGGEDNICK), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "cherryh.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "#archlinux"), channel);
             assert((content == "Cannot join channel (+r) - you need to be identified with services"), content);
             assert((num == 477), num.to!string);
@@ -470,9 +471,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_NAMREPLY), type.to!string);
+            assert((type == RPL_NAMREPLY), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "asimov.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "#garderoben"), channel);
             assert((content == "kameloso^ ombudsman +kameloso @zorael @maku @klarrt"), content);
             assert((num == 353), num.to!string);
@@ -484,9 +485,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_WHOREPLY), type.to!string);
+            assert((type == RPL_WHOREPLY), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "moon.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "##linux"), channel);
             assert((target.nickname == "Fieldy"), target.nickname);
             assert((target.address == "gentoo/contributor/Fieldy"), target.address);
@@ -500,9 +501,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_WHOREPLY), type.to!string);
+            assert((type == RPL_WHOREPLY), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "moon.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "##linux"), channel);
             assert((target.nickname == "Axton"), target.nickname);
             assert((target.ident == "~rahlff"), target.ident);
@@ -517,9 +518,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_WHOREPLY), type.to!string);
+            assert((type == RPL_WHOREPLY), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "irc.rizon.no"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((target.nickname == "kameloso^^"), target.nickname);
             assert((target.ident == "~NaN"), target.ident);
             assert((target.address == "C2802314.E23AD7D8.E9841504.IP"), target.address);
@@ -533,9 +534,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_ENDOFWHO), type.to!string);
+            assert((type == RPL_ENDOFWHO), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "tolkien.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "##linux"), channel);
             assert((content == "End of /WHO list."), content);
             assert((num == 315), num.to!string);
@@ -548,9 +549,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_AWAY), type.to!string);
+            assert((type == RPL_AWAY), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "tolkien.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((target.nickname == "jcjordyn120"), target.nickname);
             assert((content == "Idle"), content);
             assert((num == 301), num.to!string);
@@ -562,9 +563,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_MOTD), type.to!string);
+            assert((type == RPL_MOTD), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "asimov.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "- In particular we would like to thank the sponsor"), content);
             assert((num == 372), num.to!string);
         }
@@ -575,9 +576,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_ISUPPORT), type.to!string);
+            assert((type == RPL_ISUPPORT), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "cherryh.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "EXCEPTS INVEX MODES=eIbq,k,flj,CFLMPQScgimnprstz CHANLIMIT=#:120 PREFIX=(ov)@+ MAXLIST=bqeI:100 MODES=4 NETWORK=freenode STATUSMSG=@+ CALLERID=g CASEMAPPING=rfc1459"), content);
             assert((num == 5), num.to!string);
         }
@@ -589,9 +590,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_MYINFO), type.to!string);
+            assert((type == RPL_MYINFO), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "asimov.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "DOQRSZaghilopswz CFILMPQSbcefgijklmnopqrstvz bkloveqjfI"), content);
             assert((aux == "ircd-seven-1.1.4"), aux);
             assert((num == 4), num.to!string);
@@ -607,9 +608,9 @@ unittest
             with (IRCEvent.Type)
             with (event)
             {
-                assert((type == RPL_MYINFO), type.to!string);
+                assert((type == RPL_MYINFO), Enum!(IRCEvent.Type).toString(type));
                 assert((sender.address == "tmi.twitch.tv"), sender.address);
-                assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+                assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
                 assert((num == 4), num.to!string);
             }
             assert((parser.bot.server.network == "Twitch"), parser.bot.server.network);
@@ -623,9 +624,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_TOPICWHOTIME), type.to!string);
+            assert((type == RPL_TOPICWHOTIME), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "asimov.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "#garderoben"), channel);
             assert((content == "klarrt!~bsdrouter@h150n13-aahm-a11.ias.bredband.telia.com"), content);
             assert((aux == "1476294377"), aux);
@@ -639,9 +640,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_WHOISHOST), type.to!string);
+            assert((type == RPL_WHOISHOST), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "wilhelm.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "81-233-105-62-no80.tbcn.telia.com"), content);
             assert((aux == "81.233.105.62"), aux);
             assert((num == 378), num.to!string);
@@ -653,9 +654,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == ERR_UNKNOWNCOMMAND), type.to!string);
+            assert((type == ERR_UNKNOWNCOMMAND), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "karatkievich.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "systemd,#kde,#kubuntu,..."), content);
             assert((num == 421), num.to!string);
         }
@@ -666,9 +667,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == ERR_UNKNOWNCOMMAND), type.to!string);
+            assert((type == ERR_UNKNOWNCOMMAND), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "asimov.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((aux == "sudo"), aux);
             assert((content == "Unknown command"), content);
             assert((num == 421), num.to!string);
@@ -680,9 +681,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_WHOISIDLE), type.to!string);
+            assert((type == RPL_WHOISIDLE), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "rajaniemi.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((target.nickname == "zorael"), target.nickname);
             assert((content == "0"), content);
             assert((aux == "1510219961"), aux);
@@ -695,9 +696,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_LUSEROP), type.to!string);
+            assert((type == RPL_LUSEROP), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "asimov.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "IRC Operators online"), content);
             assert((aux == "31"), aux);
             assert((num == 252), num.to!string);
@@ -709,9 +710,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_LUSERUNKNOWN), type.to!string);
+            assert((type == RPL_LUSERUNKNOWN), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "asimov.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "unknown connection(s)"), content);
             assert((aux == "13"), aux);
             assert((num == 253), num.to!string);
@@ -723,9 +724,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_LUSERCHANNELS), type.to!string);
+            assert((type == RPL_LUSERCHANNELS), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "asimov.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "channels formed"), content);
             assert((aux == "54541"), aux);
             assert((num == 254), num.to!string);
@@ -737,9 +738,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == ERR_ERRONEOUSNICKNAME), type.to!string);
+            assert((type == ERR_ERRONEOUSNICKNAME), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "asimov.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "Erroneous Nickname"), content);
             assert((aux == "@nickname"), aux);
             assert((num == 432), num.to!string);
@@ -751,9 +752,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == ERR_NEEDMOREPARAMS), type.to!string);
+            assert((type == ERR_NEEDMOREPARAMS), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "asimov.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "Not enough parameters"), content);
             assert((aux == "JOIN"), aux);
             assert((num == 461), num.to!string);
@@ -765,9 +766,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_LOCALUSERS), type.to!string);
+            assert((type == RPL_LOCALUSERS), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "asimov.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "Current local users 6500, max 11061"), content);
             assert((aux == "6500 11061"), aux);
             assert((num == 265), num.to!string);
@@ -779,9 +780,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_GLOBALUSERS), type.to!string);
+            assert((type == RPL_GLOBALUSERS), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "asimov.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "Current global users 85267, max 92341"), content);
             assert((aux == "85267 92341"), aux);
             assert((num == 266), num.to!string);
@@ -793,9 +794,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_LOCALUSERS), type.to!string);
+            assert((type == RPL_LOCALUSERS), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "irc.uworld.se"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "Current local users: 14552  Max: 19744"), content);
             assert((num == 265), num.to!string);
         }
@@ -806,9 +807,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_GLOBALUSERS), type.to!string);
+            assert((type == RPL_GLOBALUSERS), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "irc.uworld.se"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "Current global users: 14552  Max: 19744"), content);
             assert((num == 266), num.to!string);
         }
@@ -819,9 +820,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_LOCALUSERS), type.to!string);
+            assert((type == RPL_LOCALUSERS), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "weber.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "Current local users 3385, max 6820"), content);
             assert((aux == "3385 6820"), aux);
             assert((num == 265), num.to!string);
@@ -833,9 +834,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_GLOBALUSERS), type.to!string);
+            assert((type == RPL_GLOBALUSERS), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "weber.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "Current global users 87056, max 93012"), content);
             assert((aux == "87056 93012"), aux);
             assert((num == 266), num.to!string);
@@ -847,9 +848,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_LOCALUSERS), type.to!string);
+            assert((type == RPL_LOCALUSERS), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "irc.rizon.no"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "Current local users: 16115  Max: 17360"), content);
             assert((num == 265), num.to!string);
         }
@@ -860,9 +861,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_WHOISUSER), type.to!string);
+            assert((type == RPL_WHOISUSER), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "orwell.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((target.ident == "~NaN"), target.ident);
             assert((target.address == "ns3363704.ip-94-23-253.eu"), target.address);
             assert((content == "kameloso"), content);
@@ -875,9 +876,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_WHOISSECURE), type.to!string);
+            assert((type == RPL_WHOISSECURE), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "asimov.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((target.nickname == "zorael"), target.nickname);
             assert((content == "is using a secure connection"), content);
             assert((num == 671), num.to!string);
@@ -889,9 +890,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_ENDOFWHOIS), type.to!string);
+            assert((type == RPL_ENDOFWHOIS), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "asimov.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((target.nickname == "zorael"), target.nickname);
             assert((content == "End of /WHOIS list."), content);
             assert((num == 318), num.to!string);
@@ -904,9 +905,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == ERR_NICKNAMEINUSE), type.to!string);
+            assert((type == ERR_NICKNAMEINUSE), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "asimov.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "Nickname is already in use."), content);
             assert((num == 433), num.to!string);
         }
@@ -917,9 +918,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == ERR_NOSUCHNICK), type.to!string);
+            assert((type == ERR_NOSUCHNICK), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "cherryh.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((aux == "cherryh.freenode.net"), aux);
             assert((content == "No such nick/channel"), content);
             assert((num == 401), num.to!string);
@@ -932,9 +933,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_WHOISOPERATOR), type.to!string);
+            assert((type == RPL_WHOISOPERATOR), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "lightning.ircstorm.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((target.nickname == "NickServ"), target.nickname);
             assert((content == "is a Network Service"), content);
             assert((num == 313), num.to!string);
@@ -946,9 +947,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_WHOISACCOUNT), type.to!string);
+            assert((type == RPL_WHOISACCOUNT), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "asimov.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((target.nickname == "xurael"), target.nickname);
             assert((target.account == "zorael"), target.account);
             assert((content == "zorael"), content);
@@ -961,9 +962,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_WHOISREGNICK), type.to!string);
+            assert((type == RPL_WHOISREGNICK), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "irc.x2x.cc"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((target.nickname == "py-ctcp"), target.nickname);
             assert((content == "py-ctcp"), content);
             assert((num == 307), num.to!string);
@@ -975,9 +976,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_WHOISREGNICK), type.to!string);
+            assert((type == RPL_WHOISREGNICK), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "irc.x2x.cc"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((target.nickname == "wob^2"), target.nickname);
             assert((content == "wob^2"), content);
             assert((num == 307), num.to!string);
@@ -989,9 +990,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_WELCOME), type.to!string);
+            assert((type == RPL_WELCOME), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "adams.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "Welcome to the freenode Internet Relay Chat Network kameloso^"), content);
             assert((num == 1), num.to!string);
         }
@@ -1002,9 +1003,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == ERR_BADPING), type.to!string);
+            assert((type == ERR_BADPING), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "irc.uworld.se"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((target.nickname == "kameloso"), target.nickname);
             assert((content == "PONG 3705964477"), content);
             assert((num == 513), num.to!string);
@@ -1016,9 +1017,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_HELPSTART), type.to!string);
+            assert((type == RPL_HELPSTART), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "leguin.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "Help topics available to users:"), content);
             assert((aux == "index"), aux);
             assert((num == 704), num.to!string);
@@ -1030,9 +1031,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_HELPTXT), type.to!string);
+            assert((type == RPL_HELPTXT), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "leguin.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "ACCEPT\tADMIN\tAWAY\tCHALLENGE"), content);
             assert((aux == "index"), aux);
             assert((num == 705), num.to!string);
@@ -1044,9 +1045,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_ENDOFHELP), type.to!string);
+            assert((type == RPL_ENDOFHELP), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "leguin.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "End of /HELP.// :leguin.freenode.net 706 kameloso^ index :End of /HELP."), content);
             assert((aux == "index"), aux);
             assert((num == 706), num.to!string);
@@ -1058,9 +1059,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == ERR_BANONCHAN), type.to!string);
+            assert((type == ERR_BANONCHAN), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "cherryh.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "#d3d9"), channel);
             assert((content == "Cannot change nickname while banned on channel"), content);
             assert((aux == "kameloso^^"), aux);
@@ -1073,9 +1074,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == CAP), type.to!string);
+            assert((type == CAP), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "tmi.twitch.tv"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "twitch.tv/tags twitch.tv/commands twitch.tv/membership"), content);
             assert((aux == "LS"), aux);
         }
@@ -1086,9 +1087,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == CAP), type.to!string);
+            assert((type == CAP), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "genesis.ks.us.irchighway.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "away-notify extended-join account-notify multi-prefix sasl tls userhost-in-names"), content);
             assert((aux == "LS"), aux);
         }
@@ -1099,11 +1100,11 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == TOPIC), type.to!string);
+            assert((type == TOPIC), Enum!(IRCEvent.Type).toString(type));
             assert((sender.nickname == "zorael"), sender.nickname);
             assert((sender.ident == "~NaN"), sender.ident);
             assert((sender.address == "2001:41d0:2:80b4::"), sender.address);
-            assert((sender.class_ != IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ != IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "#garderoben"), channel);
             assert((content == "en greps av hybris, sen var de bara fyra"), content);
         }
@@ -1116,9 +1117,9 @@ unittest
             with (IRCEvent.Type)
             with (event)
             {
-                assert((type == USERSTATE), type.to!string);
+                assert((type == USERSTATE), Enum!(IRCEvent.Type).toString(type));
                 assert((sender.address == "tmi.twitch.tv"), sender.address);
-                assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+                assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
                 assert(!content.length, content);
                 assert((channel == "#zorael"), channel);
             }
@@ -1129,9 +1130,9 @@ unittest
             with (IRCEvent.Type)
             with (event)
             {
-                assert((type == ROOMSTATE), type.to!string);
+                assert((type == ROOMSTATE), Enum!(IRCEvent.Type).toString(type));
                 assert((sender.address == "tmi.twitch.tv"), sender.address);
-                assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+                assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
                 assert(!content.length, content);
                 assert((channel == "#zorael"), channel);
             }
@@ -1142,9 +1143,9 @@ unittest
             with (IRCEvent.Type)
             with (event)
             {
-                assert((type == TWITCH_HOSTSTART), type.to!string);
+                assert((type == TWITCH_HOSTSTART), Enum!(IRCEvent.Type).toString(type));
                 assert((sender.address == "tmi.twitch.tv"), sender.address);
-                assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+                assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
                 assert((channel == "#andymilonakis"), channel);
                 assert((content == "zombie_barricades"), content);
             }
@@ -1155,9 +1156,9 @@ unittest
             with (IRCEvent.Type)
             with (event)
             {
-                assert((type == USERNOTICE), type.to!string);
+                assert((type == USERNOTICE), Enum!(IRCEvent.Type).toString(type));
                 assert((sender.address == "tmi.twitch.tv"), sender.address);
-                assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+                assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
                 assert((channel == "#drdisrespectlive"), channel);
                 assert((content == "ooooo weee, it's a meeeee, Moweee!"), content);
             }
@@ -1168,9 +1169,9 @@ unittest
             with (IRCEvent.Type)
             with (event)
             {
-                assert((type == USERNOTICE), type.to!string);
+                assert((type == USERNOTICE), Enum!(IRCEvent.Type).toString(type));
                 assert((sender.address == "tmi.twitch.tv"), sender.address);
-                assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+                assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
                 assert((channel == "#lirik"), channel);
             }
         }
@@ -1180,9 +1181,9 @@ unittest
             with (IRCEvent.Type)
             with (event)
             {
-                assert((type == CLEARCHAT), type.to!string);
+                assert((type == CLEARCHAT), Enum!(IRCEvent.Type).toString(type));
                 assert((sender.address == "tmi.twitch.tv"), sender.address);
-                assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+                assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
                 assert((channel == "#channel"), channel);
                 assert((target.nickname == "user"), target.nickname);
             }
@@ -1194,9 +1195,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_LOGGEDIN), type.to!string);
+            assert((type == RPL_LOGGEDIN), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "weber.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((target.nickname == "kameloso"), target.nickname);
             assert((target.ident == "NaN"), target.ident);
             assert((target.address == "194.117.188.126"), target.address);
@@ -1211,12 +1212,12 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == ACCOUNT), type.to!string);
+            assert((type == ACCOUNT), Enum!(IRCEvent.Type).toString(type));
             assert((sender.nickname == "ski7777"), sender.nickname);
             assert((sender.ident == "~quassel"), sender.ident);
             assert((sender.address == "ip5b435007.dynamic.kabel-deutschland.de"), sender.address);
             assert((sender.account == "ski7777"), sender.account);
-            assert((sender.class_ != IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ != IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((aux == "ski7777"), aux);
         }
     }
@@ -1226,9 +1227,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_VERSION), type.to!string);
+            assert((type == RPL_VERSION), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "irc.rizon.no"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "plexus-4(hybrid-8.1.20)(20170821_0-607). irc.rizon.no"), content);
             assert((aux == "TS6ow"), aux);
             assert((num == 351), num.to!string);
@@ -1242,9 +1243,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_HOSTHIDDEN), type.to!string);
+            assert((type == RPL_HOSTHIDDEN), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "TAL.DE.EU.GameSurge.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "~NaN@1b24f4a7.243f02a4.5cd6f3e3.IP4"), content);
             assert((aux == "is now your hidden host"), aux);
             assert((num == 396), num.to!string);
@@ -1256,9 +1257,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_YOURID), type.to!string);
+            assert((type == RPL_YOURID), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "caliburn.pa.us.irchighway.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "your unique ID"), content);
             assert((aux == "132AAMJT5"), aux);
             assert((num == 42), num.to!string);
@@ -1270,9 +1271,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == ERR_HELPNOTFOUND), type.to!string);
+            assert((type == ERR_HELPNOTFOUND), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "irc.rizon.no"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "Help not found"), content);
             assert((aux == "502"), aux);
             assert((num == 524), num.to!string);
@@ -1284,9 +1285,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == ERR_UNKNOWNMODE), type.to!string);
+            assert((type == ERR_UNKNOWNMODE), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "irc.rizon.no"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "is unknown mode char to me"), content);
             assert((aux == "X"), aux);
             assert((num == 472), num.to!string);
@@ -1298,9 +1299,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == ERR_YOUREBANNEDCREEP), type.to!string);
+            assert((type == ERR_YOUREBANNEDCREEP), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "miranda.chathispano.com"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "[1511000504768] G-Lined by ChatHispano Network. Para mas informacion visite http://chathispano.com/gline/?id=<id> (expires at Dom, 19/11/2017 11:21:48 +0100)."), content);
             assert((aux == "1511086908"), aux);
             assert((num == 465), num.to!string);
@@ -1312,9 +1313,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_LIST), type.to!string);
+            assert((type == RPL_LIST), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "irc.RomaniaChat.eu"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "#GameOfThrones"), channel);
             assert((content == "[+ntTGfB]"), content);
             assert((aux == "1"), aux);
@@ -1327,9 +1328,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_LIST), type.to!string);
+            assert((type == RPL_LIST), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "irc.RomaniaChat.eu"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "#radioclick"), channel);
             assert((content == "[+ntr]  Bun venit pe #Radioclick! Site oficial www.radioclick.ro sau servere irc.romaniachat.eu, irc.radioclick.ro"), content);
             assert((aux == "63"), aux);
@@ -1342,9 +1343,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_LISTSTART), type.to!string);
+            assert((type == RPL_LISTSTART), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "cherryh.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((num == 321), num.to!string);
         }
     }
@@ -1355,9 +1356,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == ERR_LINKCHANNEL), type.to!string);
+            assert((type == ERR_LINKCHANNEL), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "wolfe.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "#linux"), channel);
             assert((content == "##linux"), content);
             assert((num == 470), num.to!string);
@@ -1369,9 +1370,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_WHOISMODES), type.to!string);
+            assert((type == RPL_WHOISMODES), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "cadance.canternet.org"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((aux == "+ix"), aux);
             assert((num == 379), num.to!string);
         }
@@ -1382,9 +1383,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_WHOWASUSER), type.to!string);
+            assert((type == RPL_WHOWASUSER), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "irc.uworld.se"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "~NaN C2802314.E23AD7D8.E9841504.IP *"), content);
             assert((aux == "kameloso!"), aux);
             assert((num == 314), num.to!string);
@@ -1397,9 +1398,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == ERR_USERONCHANNEL), type.to!string);
+            assert((type == ERR_USERONCHANNEL), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "orwell.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "#flerrp"), channel);
             assert((content == "is already on channel"), content);
             assert((num == 443), num.to!string);
@@ -1411,9 +1412,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_UMODEIS), type.to!string);
+            assert((type == RPL_UMODEIS), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "port80b.se.quakenet.org"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((aux == "+i"), aux);
             assert((num == 221), num.to!string);
         }
@@ -1424,11 +1425,11 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == NOTICE), type.to!string);
+            assert((type == NOTICE), Enum!(IRCEvent.Type).toString(type));
             assert((sender.nickname == "ChanServ"), sender.nickname);
             assert((sender.ident == "ChanServ"), sender.ident);
             assert((sender.address == "services."), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "[##linux-overflohomeOnlyw] Make sure your nick is registered, then please try again to join ##linux."), content);
         }
     }
@@ -1438,11 +1439,11 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == NOTICE), type.to!string);
+            assert((type == NOTICE), Enum!(IRCEvent.Type).toString(type));
             assert((sender.nickname == "ChanServ"), sender.nickname);
             assert((sender.ident == "ChanServ"), sender.ident);
             assert((sender.address == "services."), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "[#ubuntu] Welcome to #ubuntu! Please read the channel topic."), content);
         }
     }
@@ -1452,9 +1453,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == NOTICE), type.to!string);
+            assert((type == NOTICE), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "tolkien.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "*** Checking Ident"), content);
         }
     }
@@ -1464,11 +1465,11 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == CHAN), type.to!string);
+            assert((type == CHAN), Enum!(IRCEvent.Type).toString(type));
             assert((sender.nickname == "zorael"), sender.nickname);
             assert((sender.ident == "~NaN"), sender.ident);
             assert((sender.address == "ns3363704.ip-94-23-253.eu"), sender.address);
-            assert((sender.class_ != IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ != IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "#flerrp"), channel);
             assert((content == "test test content"), content);
         }
@@ -1479,11 +1480,11 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == QUERY), type.to!string);
+            assert((type == QUERY), Enum!(IRCEvent.Type).toString(type));
             assert((sender.nickname == "zorael"), sender.nickname);
             assert((sender.ident == "~NaN"), sender.ident);
             assert((sender.address == "ns3363704.ip-94-23-253.eu"), sender.address);
-            assert((sender.class_ != IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ != IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((target.nickname == "kameloso^"), target.nickname);
             assert((content == "test test content"), content);
         }
@@ -1494,11 +1495,11 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == MODE), type.to!string);
+            assert((type == MODE), Enum!(IRCEvent.Type).toString(type));
             assert((sender.nickname == "zorael"), sender.nickname);
             assert((sender.ident == "~NaN"), sender.ident);
             assert((sender.address == "ns3363704.ip-94-23-253.eu"), sender.address);
-            assert((sender.class_ != IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ != IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "#flerrp"), channel);
             assert((content == "kameloso^"), content);
             assert((aux == "+v"), aux);
@@ -1511,11 +1512,11 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == MODE), type.to!string);
+            assert((type == MODE), Enum!(IRCEvent.Type).toString(type));
             assert((sender.nickname == "zorael"), sender.nickname);
             assert((sender.ident == "~NaN"), sender.ident);
             assert((sender.address == "ns3363704.ip-94-23-253.eu"), sender.address);
-            assert((sender.class_ != IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ != IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "#flerrp"), channel);
             assert((aux == "+i"), aux);
         }
@@ -1526,9 +1527,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == MODE), type.to!string);
+            assert((type == MODE), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "niven.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "#sklabjoier"), channel);
             assert((aux == "+ns"), aux);
         }
@@ -1541,9 +1542,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == SELFMODE), type.to!string);
+            assert((type == SELFMODE), Enum!(IRCEvent.Type).toString(type));
             assert((sender.nickname == "kameloso^"), sender.nickname);
-            assert((sender.class_ != IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ != IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((aux == "+i"), aux);
         }
     }
@@ -1553,9 +1554,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_ISUPPORT), type.to!string);
+            assert((type == RPL_ISUPPORT), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "cherryh.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "NICKLEN=16 CHANNELLEN=50 TOPICLEN=390 DEAF=D FNC TARGMAX=NAMES:1,LIST:1,KICK:1,WHOIS:1,PRIVMSG:4,NOTICE:4,ACCEPT:,MONITOR: EXTBAN=$,ajrxz CLIENTVER=3.0 CPRIVMSG CNOTICE SAFELIST"), content);
             assert((num == 5), num.to!string);
         }
@@ -1566,9 +1567,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == ERR_YOUREBANNEDCREEP), type.to!string);
+            assert((type == ERR_YOUREBANNEDCREEP), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "server.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "You are banned from this server- Your irc client seems broken and is flooding lots of channels. Banned for 240 min, if in error, please contact kline@freenode.net. (2017/12/1 21.08)"), content);
             assert((num == 465), num.to!string);
         }
@@ -1579,11 +1580,11 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == CHAN), type.to!string);
+            assert((type == CHAN), Enum!(IRCEvent.Type).toString(type));
             assert((sender.nickname == "ASDphBa|zzZ"), sender.nickname);
             assert((sender.ident == "~ASDphBa"), sender.ident);
             assert((sender.address == "a.asdphs-tech.com"), sender.address);
-            assert((sender.class_ != IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ != IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "#d"), channel);
             assert((content == "does anyone know how the unittest stuff is working with cmake-d?"), content);
         }
@@ -1594,9 +1595,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_CHANNELMODEIS), type.to!string);
+            assert((type == RPL_CHANNELMODEIS), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "kornbluth.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "#flerrp"), channel);
             assert((aux == "+ns"), aux);
             assert((num == 324), num.to!string);
@@ -1608,9 +1609,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_CREATIONTIME), type.to!string);
+            assert((type == RPL_CREATIONTIME), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "kornbluth.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "#flerrp"), channel);
             assert((aux == "1512995737"), aux);
             assert((num == 329), num.to!string);
@@ -1623,9 +1624,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_BANLIST), type.to!string);
+            assert((type == RPL_BANLIST), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "kornbluth.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "#flerrp"), "channel is " ~ channel);
             assert((content == "harbl!harbl@snarbl.com"), content);
             assert((aux == "zorael!~NaN@2001:41d0:2:80b4:: 1513899521"), aux);
@@ -1638,9 +1639,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == ENDOFSPAMFILTERLIST), type.to!string);
+            assert((type == ENDOFSPAMFILTERLIST), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "lamia.ca.SpotChat.org"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "#garderoben"), channel);
             //assert((target.nickname == "kameloso"), target.nickname);
             assert((content == "End of channel spamfilter list"), content);
@@ -1653,9 +1654,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_UMODEIS), type.to!string);
+            assert((type == RPL_UMODEIS), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "lamia.ca.SpotChat.org"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((aux == "+ix"), aux);
             assert((num == 221), num.to!string);
         }
@@ -1666,11 +1667,11 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == AWAY), type.to!string);
+            assert((type == AWAY), Enum!(IRCEvent.Type).toString(type));
             assert((sender.nickname == "Halcy0n"), sender.nickname);
             assert((sender.ident == "~Halcy0n"), sender.ident);
             assert((sender.address == "SpotChat-rauo6p.dyn.suddenlink.net"), sender.address);
-            assert((sender.class_ != IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ != IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "I'm busy"), content);
         }
     }
@@ -1680,11 +1681,11 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == BACK), type.to!string);
+            assert((type == BACK), Enum!(IRCEvent.Type).toString(type));
             assert((sender.nickname == "Halcy0n"), sender.nickname);
             assert((sender.ident == "~Halcy0n"), sender.ident);
             assert((sender.address == "SpotChat-rauo6p.dyn.suddenlink.net"), sender.address);
-            assert((sender.class_ != IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ != IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
         }
     }
 
@@ -1693,9 +1694,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_INVITED), type.to!string);
+            assert((type == RPL_INVITED), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "irc.oftc.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "#garderoben"), channel);
             //assert((target.nickname == "kameloso"), target.nickname);
             assert((content == "End of Channel Quiet List"), content);
@@ -1708,9 +1709,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_CHANNELMODEIS), type.to!string);
+            assert((type == RPL_CHANNELMODEIS), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "niven.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "##linux"), channel);
             assert((content == "##linux-overflow"), content);
             assert((aux == "+CLPcnprtf"), aux);
@@ -1723,9 +1724,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_YOURID), type.to!string);
+            assert((type == RPL_YOURID), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "caliburn.pa.us.irchighway.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "your unique ID"), content);
             assert((aux == "132AAMJT5"), aux);
             assert((num == 42), num.to!string);
@@ -1737,9 +1738,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_WHOISACTUALLY), type.to!string);
+            assert((type == RPL_WHOISACTUALLY), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "kinetic.oftc.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((target.nickname == "wh00nix"), target.nickname);
             assert((target.address == "255.255.255.255"), target.address);
             assert((content == "actually using host"), content);
@@ -1753,9 +1754,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_INVITELIST), type.to!string);
+            assert((type == RPL_INVITELIST), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "niven.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "#flerrp"), channel);
             assert((content == "asdf!fdas@asdf.net"), content);
             assert((aux == "zorael!~NaN@2001:41d0:2:80b4:: 1514405089"), aux);
@@ -1768,9 +1769,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_QUIETLIST), type.to!string);
+            assert((type == RPL_QUIETLIST), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "niven.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "#flerrp"), channel);
             assert((content == "qqqq!*@asdf.net"), content);
             assert((aux == "zorael!~NaN@2001:41d0:2:80b4:: 1514405101"), aux);
@@ -1783,11 +1784,11 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == CHGHOST), type.to!string);
+            assert((type == CHGHOST), Enum!(IRCEvent.Type).toString(type));
             assert((sender.nickname == "Miyabro"), sender.nickname);
             assert((sender.ident == "~Miyabro"), sender.ident);
             assert((sender.address == "Miyako.is.mai.waifu"), sender.address);
-            assert((sender.class_ != IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ != IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
         }
     }
 
@@ -1797,7 +1798,7 @@ unittest
         with (IRCUser.Class)
         with (event)
         {
-            assert((type == CHAN), type.to!string);
+            assert((type == CHAN), Enum!(IRCEvent.Type).toString(type));
             assert((sender.nickname == "Iasdf666"), sender.nickname);
             assert((sender.ident == "~Iasdf666"), sender.ident);
             assert((sender.address == "The.Breakfast.Club"), sender.address);
@@ -1812,7 +1813,7 @@ unittest
         with (IRCUser.Class)
         with (event)
         {
-            assert((type == PART), type.to!string);
+            assert((type == PART), Enum!(IRCEvent.Type).toString(type));
             assert((sender.nickname == "gallon"), sender.nickname);
             assert((sender.ident == "~MO.11063"), sender.ident);
             assert((sender.address == "482c29a5.e510bf75.97653814.IP4"), sender.address);
@@ -1831,9 +1832,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == RPL_QUIETLIST), type.to!string);
+            assert((type == RPL_QUIETLIST), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "irc.oftc.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "#garderoben"), channel);
             assert((content == "harbl!snarbl@*"), content);
             assert((aux == "kameloso!~NaN@194.117.188.126 1515418362"), aux);
@@ -1852,9 +1853,9 @@ unittest
         with (IRCEvent.Type)
         with (event)
         {
-            assert((type == ENDOFEXEMPTOPSLIST), type.to!string);
+            assert((type == ENDOFEXEMPTOPSLIST), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "cadance.canternet.org"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "#flerrp"), channel);
             assert((content == "End of channel exemptchanops list"), content);
              assert((num == 953), num.to!string);
@@ -1873,9 +1874,9 @@ unittest
         with (IRCUser.Class)
         with (event)
         {
-            assert((type == RPL_REOPLIST), type.to!string);
+            assert((type == RPL_REOPLIST), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "irc.atw-inter.net"), sender.address);
-            assert((sender.class_ == special), sender.class_.to!string);
+            assert((sender.class_ == special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "#debian.de"), channel);
             assert((content == "towo!towo@littlelamb.szaf.org"), content);
             assert((num == 344), num.to!string);
@@ -1887,9 +1888,9 @@ unittest
         with (IRCUser.Class)
         with (event)
         {
-            assert((type == RPL_ENDOFREOPLIST), type.to!string);
+            assert((type == RPL_ENDOFREOPLIST), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "irc.atw-inter.net"), sender.address);
-            assert((sender.class_ == special), sender.class_.to!string);
+            assert((sender.class_ == special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((channel == "#debian.de"), channel);
             assert((content == "End of Channel Reop List"), content);
             assert((num == 345), num.to!string);
@@ -1909,9 +1910,9 @@ unittest
         with (IRCUser.Class)
         with (event)
         {
-            assert((type == RPL_STATSDEBUG), type.to!string);
+            assert((type == RPL_STATSDEBUG), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "livingstone.freenode.net"), sender.address);
-            assert((sender.class_ == special), sender.class_.to!string);
+            assert((sender.class_ == special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "dax (dax@freenode/staff/dax)"), content);
             assert((aux == "p"), aux);
             assert((num == 249), num.to!string);
@@ -1923,9 +1924,9 @@ unittest
         with (IRCUser.Class)
         with (event)
         {
-            assert((type == RPL_ENDOFSTATS), type.to!string);
+            assert((type == RPL_ENDOFSTATS), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "livingstone.freenode.net"), sender.address);
-            assert((sender.class_ == special), sender.class_.to!string);
+            assert((sender.class_ == special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "End of /STATS report"), content);
             assert((aux == "p"), aux);
             assert((num == 219), num.to!string);
@@ -1940,9 +1941,9 @@ unittest
         with (IRCUser.Class)
         with (event)
         {
-            assert((type == RPL_STATSLINKINFO), type.to!string);
+            assert((type == RPL_STATSLINKINFO), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "verne.freenode.net"), sender.address);
-            assert((sender.class_ == special), sender.class_.to!string);
+            assert((sender.class_ == special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "40 0 -"), content);
             assert((aux == "kameloso^[~NaN@194.117.188.126] 0 109 8 15 0"), aux);
             assert((num == 211), num.to!string);
@@ -1954,9 +1955,9 @@ unittest
         with (IRCUser.Class)
         with (event)
         {
-            assert((type == RPL_TRYAGAIN), type.to!string);
+            assert((type == RPL_TRYAGAIN), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "verne.freenode.net"), sender.address);
-            assert((sender.class_ == special), sender.class_.to!string);
+            assert((sender.class_ == special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "This command could not be completed because it has been used recently, and is rate-limited"), content);
             assert((aux == "STATS"), aux);
             assert((num == 263), num.to!string);
@@ -1968,9 +1969,9 @@ unittest
         with (IRCUser.Class)
         with (event)
         {
-            assert((type == RPL_TRACEEND), type.to!string);
+            assert((type == RPL_TRACEEND), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "verne.freenode.net"), sender.address);
-            assert((sender.class_ == special), sender.class_.to!string);
+            assert((sender.class_ == special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "End of TRACE"), content);
             assert((aux == "verne.freenode.net"), aux);
             assert((num == 262), num.to!string);
@@ -1982,9 +1983,9 @@ unittest
         with (IRCUser.Class)
         with (event)
         {
-            assert((type == RPL_TRACEUSER), type.to!string);
+            assert((type == RPL_TRACEUSER), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "wolfe.freenode.net"), sender.address);
-            assert((sender.class_ == special), sender.class_.to!string);
+            assert((sender.class_ == special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "536"), content);
             assert((aux == "User v6users zorael[~NaN@2001:41d0:2:80b4::] (255.255.255.255) 16"), aux);
             assert((num == 205), num.to!string);
@@ -1996,9 +1997,9 @@ unittest
         with (IRCUser.Class)
         with (event)
         {
-            assert((type == RPL_LINKS), type.to!string);
+            assert((type == RPL_LINKS), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "rajaniemi.freenode.net"), sender.address);
-            assert((sender.class_ == special), sender.class_.to!string);
+            assert((sender.class_ == special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "0 Helsinki, FI, EU"), content);
             assert((aux == "rajaniemi.freenode.net rajaniemi.freenode.net"), aux);
             assert((num == 364), num.to!string);
@@ -2008,9 +2009,9 @@ unittest
         immutable event = parser.toIRCEvent(":rajaniemi.freenode.net 718 kameloso Freyjaun ~FREYJAUN@41.39.229.6 :is messaging you, and you have umode +g.");
         with (event)
         {
-            assert((type == IRCEvent.Type.RPL_UMODEGMSG), type.to!string);
+            assert((type == IRCEvent.Type.RPL_UMODEGMSG), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "rajaniemi.freenode.net"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((target.nickname == "Freyjaun"), target.nickname);
             assert((target.ident == "~FREYJAUN"), target.ident);
             assert((target.address == "41.39.229.6"), target.address);
@@ -2031,9 +2032,9 @@ unittest
         with (IRCUser.Class)
         with (event)
         {
-            assert((type == RPL_CODEPAGE), type.to!string);
+            assert((type == RPL_CODEPAGE), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "irc.run.net"), sender.address);
-            assert((sender.class_ == special), sender.class_.to!string);
+            assert((sender.class_ == special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "is your charset now"), content);
             assert((aux == "KOI8-U"), aux);
             assert((num == 222), num.to!string);
@@ -2051,9 +2052,9 @@ unittest
         with (IRCUser.Class)
         with (event)
         {
-            assert((type == RPL_HELLO), type.to!string);
+            assert((type == RPL_HELLO), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "irc.portlane.se"), sender.address);
-            assert((sender.class_ == special), sender.class_.to!string);
+            assert((sender.class_ == special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "Please wait while we process your connection."), content);
             assert((num == 20), num.to!string);
         }
@@ -2083,9 +2084,9 @@ unittest
         with (IRCUser.Class)
         with (event)
         {
-            assert((type == RPL_ISUPPORT), type.to!string);
+            assert((type == RPL_ISUPPORT), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "medusa.us.SpotChat.org"), sender.address);
-            assert((sender.class_ == special), sender.class_.to!string);
+            assert((sender.class_ == special), Enum!(IRCUser.Class).toString(sender.class_));
             assert((content == "AWAYLEN=200 CALLERID=g CASEMAPPING=rfc1459 CHANMODES=Ibeg,k,Jl,ACKMNOPQRSTcimnprstz CHANNELLEN=64 CHANTYPES=# CHARSET=ascii ELIST=MU EXCEPTS=e EXTBAN=,ACNOQRSTUcmz FNC INVEX=I KICKLEN=255"), content);
             assert((num == 5), num.to!string);
         }
@@ -2129,9 +2130,9 @@ unittest
         immutable event = parser.toIRCEvent(":tmi.twitch.tv RECONNECT");
         with (event)
         {
-            assert((type == IRCEvent.Type.RECONNECT), type.to!string);
+            assert((type == IRCEvent.Type.RECONNECT), Enum!(IRCEvent.Type).toString(type));
             assert((sender.address == "tmi.twitch.tv"), sender.address);
-            assert((sender.class_ == IRCUser.Class.special), sender.class_.to!string);
+            assert((sender.class_ == IRCUser.Class.special), Enum!(IRCUser.Class).toString(sender.class_));
         }
     }
 }


### PR DESCRIPTION
Change all use of `std.conv.to` on enums to use of `kameloso.conv.Enum`, primarily in unit tests.

Lowers unittest compilation memory usage from ~8525mb to ~7679mb.