### PR TITLE
Banphrase

### DIFF
--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -1172,7 +1172,8 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                 else static if (!hasUDA!(fun, Chainable) &&
                     !hasUDA!(fun, Terminating) &&
                     ((eventTypeUDA == IRCEvent.Type.CHAN) ||
-                    (eventTypeUDA == IRCEvent.Type.QUERY)))
+                    (eventTypeUDA == IRCEvent.Type.QUERY) ||
+                    (eventTypeUDA == IRCEvent.Type.WHISPER)))
                 {
                     import kameloso.conv : Enum;
                     import std.format : format;
@@ -1196,6 +1197,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
 
                         static assert(!((U == CHAN) ||
                             (U == QUERY) ||
+                            (U == WHISPER) ||
                             (U == EMOTE) ||
                             (U == JOIN) ||
                             (U == PART) ||

--- a/source/kameloso/plugins/help.d
+++ b/source/kameloso/plugins/help.d
@@ -43,7 +43,7 @@ struct HelpSettings
  +  Once we have the list we format it nicely and send it back to the requester,
  +  which we remember since we saved the original `kameloso.irc.defs.IRCEvent`.
  +/
-@(IRCEvent.Type.QUERY)
+@(IRCEvent.Type.WHISPER)
 @(IRCEvent.Type.CHAN)
 @(PrivilegeLevel.whitelist)
 @BotCommand(PrefixPolicy.nickname, "help")

--- a/source/kameloso/plugins/twitchbot.d
+++ b/source/kameloso/plugins/twitchbot.d
@@ -39,6 +39,9 @@ struct TwitchBotSettings
     /// Whether or not to do reminders at the end of vote durations.
     bool voteReminders = true;
 
+    /// Whether or not to match ban phrases case-sensitively.
+    bool bannedPhrasesObeyCase = true;
+
     /// How long a user should be timed out if they send a banned phrase.
     int bannedPhraseTimeout = 60;
 }

--- a/source/kameloso/plugins/twitchbot.d
+++ b/source/kameloso/plugins/twitchbot.d
@@ -38,6 +38,9 @@ struct TwitchBotSettings
 
     /// Whether or not to do reminders at the end of vote durations.
     bool voteReminders = true;
+
+    /// How long a user should be timed out if they send a banned phrase.
+    int bannedPhraseTimeout = 60;
 }
 
 

--- a/source/kameloso/plugins/twitchbot.d
+++ b/source/kameloso/plugins/twitchbot.d
@@ -91,7 +91,15 @@ void onAnyMessage(TwitchBotPlugin plugin, const IRCEvent event)
 
         foreach (immutable phrase; *bannedPhrases)
         {
-            if (event.content.contains(phrase))
+            import std.algorithm.comparison : equal;
+            import std.uni : asLowerCase;
+
+            // Try not to allocate two whole new strings
+            immutable match = plugin.twitchBotSettings.bannedPhrasesObeyCase ?
+                event.content.contains(phrase) :
+                event.content.asLowerCase.equal(phrase.asLowerCase);
+
+            if (match)
             {
                 import std.format : format;
 

--- a/source/kameloso/plugins/twitchbot.d
+++ b/source/kameloso/plugins/twitchbot.d
@@ -798,6 +798,11 @@ void onEndOfMotd(TwitchBotPlugin plugin)
         adminsByChannel.populateFromJSON!(Yes.lowercaseValues)(channelAdminsJSON);
         adminsByChannel.rehash();
 
+        JSONStorage channelBannedPhrasesJSON;
+        channelBannedPhrasesJSON.load(bannedPhrasesFile);
+        //bannedPhrasesByChannel.clear();
+        bannedPhrasesByChannel.populateFromJSON(channelBannedPhrasesJSON);
+        bannedPhrasesByChannel.rehash();
     }
 }
 
@@ -863,10 +868,22 @@ void initResources(TwitchBotPlugin plugin)
         throw new IRCPluginInitialisationException(plugin.adminsFile.baseName ~ " may be malformed.");
     }
 
+    JSONStorage bannedPhrasesJSON;
+
+    try
+    {
+        bannedPhrasesJSON.load(plugin.bannedPhrasesFile);
+    }
+    catch (JSONException e)
+    {
+        throw new IRCPluginInitialisationException(plugin.bannedPhrasesFile.baseName ~ " may be malformed.");
+    }
+
     // Let other Exceptions pass.
 
     onelinerJSON.save(plugin.onelinerFile);
     adminsJSON.save(plugin.adminsFile);
+    bannedPhrasesJSON.save(plugin.bannedPhrasesFile);
 }
 
 
@@ -913,6 +930,12 @@ private:
 
     /// Filename of file with administrators.
     @Resource string adminsFile = "twitchadmins.json";
+
+    /// Associative array of banned phrases; phrases array keyed by channel.
+    string[][string] bannedPhrasesByChannel;
+
+    /// Filename of file with banned phrases.
+    @Resource string bannedPhrasesFile = "twitchphrases.json";
 
     /// All Twitch Bot plugin settings.
     @Settings TwitchBotSettings twitchBotSettings;

--- a/source/kameloso/plugins/twitchbot.d
+++ b/source/kameloso/plugins/twitchbot.d
@@ -553,7 +553,7 @@ void onCommandModifyOneliner(TwitchBotPlugin plugin, const IRCEvent event)
             immutable trigger = slice.nom!(Yes.decode)(' ');
 
             plugin.onelinersByChannel[event.channel][trigger] = slice;
-            saveOneliners(plugin.onelinersByChannel, plugin.onelinerFile);
+            saveResourceToDisk(plugin.onelinersByChannel, plugin.onelinerFile);
 
             chan(plugin.state, event.channel, "Oneliner %s%s added."
                 .format(settings.prefix, trigger));
@@ -569,7 +569,7 @@ void onCommandModifyOneliner(TwitchBotPlugin plugin, const IRCEvent event)
         if (slice.length)
         {
             plugin.onelinersByChannel[event.channel].remove(slice);
-            saveOneliners(plugin.onelinersByChannel, plugin.onelinerFile);
+            saveResourceToDisk(plugin.onelinersByChannel, plugin.onelinerFile);
 
             chan(plugin.state, event.channel, "Oneliner %s%s removed."
                 .format(settings.prefix, slice));
@@ -679,7 +679,7 @@ void onCommandAdmin(TwitchBotPlugin plugin, const IRCEvent event)
                 // Drop down for report
             }
 
-            saveAdmins(plugin.adminsByChannel, plugin.adminsFile);
+            saveResourceToDisk(plugin.adminsByChannel, plugin.adminsFile);
             chan(plugin.state, event.channel, slice ~ " is now an administrator.");
         }
         else
@@ -704,7 +704,7 @@ void onCommandAdmin(TwitchBotPlugin plugin, const IRCEvent event)
                 if (index != -1)
                 {
                     *adminArray = (*adminArray).remove!(SwapStrategy.unstable)(index);
-                    saveAdmins(plugin.adminsByChannel, plugin.adminsFile);
+                    saveResourceToDisk(plugin.adminsByChannel, plugin.adminsFile);
                     chan(plugin.state, event.channel, "Administrator removed.");
                 }
                 else
@@ -797,65 +797,36 @@ void onEndOfMotd(TwitchBotPlugin plugin)
         //adminsByChannel.clear();
         adminsByChannel.populateFromJSON!(Yes.lowercaseValues)(channelAdminsJSON);
         adminsByChannel.rehash();
+
     }
 }
 
 
-// saveOneliners
+// saveResourceToDisk
 /++
- +  Saves the passed oneliner associative array to disk, but in `JSON` format.
+ +  Saves the passed resource to disk, but in `JSON` format.
  +
- +  This is a convenient way to serialise the array.
- +
- +  Example:
- +  ---
- +  plugin.onelinersByChannel["#channel"]["adl"] = "I thought what I'd do " ~
- +      "was, I'd pretend I was one of those deaf-mutes.";
- +
- +  saveOneliners(plugin.onelinersByChannel, plugin.onelinerFile);
- +  ---
- +
- +  Params:
- +      onelinersByChannel = The associative array of oneliners to save.
- +      filename = Filename of the file to write to.
- +/
-void saveOneliners(const string[string][string] onelinersByChannel, const string filename)
-{
-    import std.json : JSONValue;
-    import std.stdio : File, writeln;
-
-    auto file = File(filename, "w");
-
-    file.writeln(JSONValue(onelinersByChannel).toPrettyString);
-}
-
-
-// saveAdmins
-/++
- +  Saves the passed admins associative array to disk, but in `JSON` format.
- +
- +  This is a convenient way to serialise the array.
+ +  This is used with the associative arrays for administrators, oneliners and
+ +  banned phrases.
  +
  +  Example:
  +  ---
  +  plugin.adminsByChannel["#channel"] ~= "kameloso";
  +  plugin.adminsByChannel["#channel"] ~= "hirrsteff";
  +
- +  saveAdmins(plugin.adminsByChannel, plugin.adminsFile);
+ +  saveResource(plugin.adminsByChannel, plugin.adminsFile);
  +  ---
  +
  +  Params:
- +      adminsByChannel = The associative array of admins to save.
+ +      resource = The `JSON`-convertible resource to save.
  +      filename = Filename of the file to write to.
  +/
-void saveAdmins(const string[][string] adminsByChannel, const string filename)
+void saveResourceToDisk(Resource)(const Resource resource, const string filename)
 {
     import std.json : JSONValue;
     import std.stdio : File, writeln;
 
-    auto file = File(filename, "w");
-
-    file.writeln(JSONValue(adminsByChannel).toPrettyString);
+    File(filename, "w").writeln(JSONValue(resource).toPrettyString);
 }
 
 

--- a/source/kameloso/plugins/twitchbot.d
+++ b/source/kameloso/plugins/twitchbot.d
@@ -67,6 +67,9 @@ void onAnyMessage(TwitchBotPlugin plugin, const IRCEvent event)
         stdout.flush();
     }
 
+    // Don't trigger on whispers
+    if (event.type == IRCEvent.Type.WHISPER) return;
+
     if (const bannedPhrases = event.channel in plugin.bannedPhrasesByChannel)
     {
         import kameloso.string : contains;


### PR DESCRIPTION
Adds dead simple Twitch phrase-banning.

It only looks for substrings in the message bodies, ignoring word boundaries. As such, there's a big chance of "clbuttic" false positives if the banned phrase is just a single word.