### PR TITLE
Concurrency message Fiber

### DIFF
--- a/source/kameloso/kameloso.d
+++ b/source/kameloso/kameloso.d
@@ -523,7 +523,7 @@ void messageFiber(ref IRCBot bot)
                 (Variant v) scope
                 {
                     // Caught an unhandled message
-                    logger.warning("Main thread received unknown Variant: ", v);
+                    logger.warning("Main thread message fiber received unknown Variant: ", v);
                 }
             );
         }

--- a/source/kameloso/kameloso.d
+++ b/source/kameloso/kameloso.d
@@ -532,6 +532,8 @@ void messageFiber(ref IRCBot bot)
 
         yield(next);
     }
+
+    assert(0, "while (true) loop break in messageFiber");
 }
 
 

--- a/source/kameloso/kameloso.d
+++ b/source/kameloso/kameloso.d
@@ -152,7 +152,7 @@ void throttleline(Strings...)(ref IRCBot bot, const Strings strings)
  +  A Generator Fiber function that checks for concurrency messages and performs
  +  action based on what was received.
  +
- +  The return value yielded to the caller tels it whether the received action
+ +  The return value yielded to the caller tells it whether the received action
  +  means the bot should exit or not.
  +
  +  Params:


### PR DESCRIPTION
Move our concurrency message-checking into a Fiber. This way we work around the lack of a Tid.hasMessages and avoid the current state of one closure allocation per second minimum.

This isn't to say we wouldn't benefit from a Tid.hasMessages.