### PR TITLE
Timed Fiber accuracy

### DIFF
--- a/source/kameloso/kameloso.d
+++ b/source/kameloso/kameloso.d
@@ -768,7 +768,7 @@ Next mainLoop(ref IRCBot bot)
                         plugin.onEvent(event);
 
                         // Go through Fibers awaiting IRCEvent.Types
-                        plugin.handleFibers(event);
+                        plugin.handleAwaitingFibers(event);
 
                         // Fetch any queued `WHOIS` requests and handle
                         bot.whoisForTriggerRequestQueue(plugin.state.triggerRequestQueue);
@@ -857,7 +857,7 @@ Next mainLoop(ref IRCBot bot)
 
 import kameloso.plugins.common : IRCPlugin;
 
-// handleFibers
+// handleAwaitingFibers
 /++
  +  Processes the awaiting `core.thread.Fiber`s of an
  +  `kameloso.plugins.common.IRCPlugin`.
@@ -868,7 +868,7 @@ import kameloso.plugins.common : IRCPlugin;
  +          iterate and process.
  +      event = The triggering `kameloso.irc.defs.IRCEvent`.
  +/
-void handleFibers(IRCPlugin plugin, const IRCEvent event)
+void handleAwaitingFibers(IRCPlugin plugin, const IRCEvent event)
 {
     import core.thread : Fiber;
 

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -3609,9 +3609,8 @@ version(unittest)
  +  Queues a `core.thread.Fiber` to be called at a point n seconds later, by
  +  appending it to `timedFibers`.
  +
- +  It only supports a precision of a *worst* case of
- +  `kameloso.constants.Timeout.receive` * 3 + 1 seconds, but generally less
- +  than that. See the main loop for more information.
+ +  Updates the `nextFiberTimestamp` UNIX timestamp so that the main loop knows
+ +  when to process the array of `core.thread.Fiber`s.
  +
  +  Params:
  +      plugin = The current `IRCPlugin`.
@@ -3625,6 +3624,7 @@ void delayFiber(IRCPlugin plugin, Fiber fiber, const long secs)
 
     immutable time = Clock.currTime.toUnixTime + secs;
     plugin.state.timedFibers ~= labeled(fiber, time);
+    plugin.updateNextFiberTimestamp();
 }
 
 


### PR DESCRIPTION
This changes the way timed Fibers are iterated, from being done on an "occasional" basis to a by-need basis.

The previous behaviour was to stagger checking for timed Fibers once every 3 reads, with some extra logic thrown in to improve accuracy somewhat. It was a hack to prevent the foreach over the plugins from being too prominent when profiling.

This new approach adds two extra functions to `IRCPlugin`; `nextFiberTimestamp()` and `updateNextFiberTimestamp()`. Assuming the proper functions are used to enqueue the Fibers, it will now keep track of when the next Fiber is scheduled per plugin, and only then iterate the Fiber array.

It may be that the best solution is a mix of the two. For now, try this and revisit if need be.