### PR TITLE
Twitch timers

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ $ dub build -c twitch
 $ ./kameloso --set twitchbot.enabled=false --writeconfig
 ```
 
-Assuming a prefix of "`!`", commands to test are: `!uptime`, `!start`, `!stop`, `!oneliner`, `!commands`, `!vote`/`!poll`, `!abortvote`/`!abortpoll`, `!admin`, `!enable`, `!disable`, `!phrase`
+Assuming a prefix of "`!`", commands to test are: `!uptime`, `!start`, `!stop`, `!oneliner`, `!commands`, `!vote`/`!poll`, `!abortvote`/`!abortpoll`, `!admin`, `!enable`, `!disable`, `!phrase`, `!timer`
 
 Note: a dot "`.`" prefix will not work on Twitch, as it conflicts with Twitch's own commands.
 

--- a/source/kameloso/plugins/printer.d
+++ b/source/kameloso/plugins/printer.d
@@ -2232,6 +2232,7 @@ void highlightEmotes(ref IRCEvent event, const bool colourful)
 
     case CHAN:
     case SELFCHAN:
+    case TWITCH_RITUAL:
         if (!colourful && event.tags.contains("emote-only=1"))
         {
             // Emote only channel message, treat the same as an emote-only emote

--- a/source/kameloso/plugins/printer.d
+++ b/source/kameloso/plugins/printer.d
@@ -1083,8 +1083,7 @@ if (isOutputRange!(Sink, char[]))
             if (sender.isServer || sender.nickname.length)
             {
                 immutable isEmote = (event.type == IRCEvent.Type.EMOTE) ||
-                    (event.type == IRCEvent.Type.SELFEMOTE) ||
-                    (event.type == IRCEvent.Type.TWITCH_CHEER);
+                    (event.type == IRCEvent.Type.SELFEMOTE);
 
                 if (isEmote)
                 {
@@ -1100,7 +1099,6 @@ if (isOutputRange!(Sink, char[]))
                 {
                 case CHAN:
                 case EMOTE:
-                case TWITCH_CHEER:
                 case TWITCH_SUBGIFT:
                     import kameloso.irc.common : containsNickname;
                     if (content.containsNickname(plugin.state.client.nickname))
@@ -1166,7 +1164,6 @@ if (isOutputRange!(Sink, char[]))
 
         shouldBell = shouldBell || ((target.nickname == plugin.state.client.nickname) &&
             ((event.type == IRCEvent.Type.QUERY) ||
-            (event.type == IRCEvent.Type.TWITCH_CHEER) ||
             (event.type == IRCEvent.Type.TWITCH_SUBGIFT)));
         shouldBell = shouldBell || (errors.length && bellOnError &&
             !plugin.printerSettings.silentErrors);
@@ -1479,8 +1476,7 @@ if (isOutputRange!(Sink, char[]))
             immutable FG emoteFgBase = bright ? Bright.emote : Dark.emote;
 
             immutable fgBase = ((event.type == IRCEvent.Type.EMOTE) ||
-                (event.type == IRCEvent.Type.SELFEMOTE) ||
-                (event.type == IRCEvent.Type.TWITCH_CHEER)) ? emoteFgBase : contentFgBase;
+                (event.type == IRCEvent.Type.SELFEMOTE)) ? emoteFgBase : contentFgBase;
             immutable isEmote = (fgBase == emoteFgBase);
 
             sink.colourWith(fgBase);  // Always grey colon and SASL +, prepare for emote
@@ -1515,7 +1511,6 @@ if (isOutputRange!(Sink, char[]))
                 {
                 case CHAN:
                 case EMOTE:
-                case TWITCH_CHEER:
                 case TWITCH_SUBGIFT:
                 //case SELFCHAN:
                     import kameloso.terminal : invert;
@@ -1648,7 +1643,6 @@ if (isOutputRange!(Sink, char[]))
 
         shouldBell = shouldBell || ((target.nickname == plugin.state.client.nickname) &&
             ((event.type == IRCEvent.Type.QUERY) ||
-            (event.type == IRCEvent.Type.TWITCH_CHEER) ||
             (event.type == IRCEvent.Type.TWITCH_SUBGIFT)));
         shouldBell = shouldBell || (errors.length && bellOnError &&
             !plugin.printerSettings.silentErrors);
@@ -2214,7 +2208,6 @@ void highlightEmotes(ref IRCEvent event, const bool colourful)
     {
     case EMOTE:
     case SELFEMOTE:
-    case TWITCH_CHEER:
         if (!colourful && event.tags.contains("emote-only=1"))
         {
             // Just highlight the whole line, don't worry about resetting to fgBase

--- a/source/kameloso/plugins/printer.d
+++ b/source/kameloso/plugins/printer.d
@@ -1101,6 +1101,7 @@ if (isOutputRange!(Sink, char[]))
                 case CHAN:
                 case EMOTE:
                 case TWITCH_CHEER:
+                case TWITCH_SUBGIFT:
                     import kameloso.irc.common : containsNickname;
                     if (content.containsNickname(plugin.state.client.nickname))
                     {

--- a/source/kameloso/plugins/printer.d
+++ b/source/kameloso/plugins/printer.d
@@ -1510,6 +1510,7 @@ if (isOutputRange!(Sink, char[]))
                 case CHAN:
                 case EMOTE:
                 case TWITCH_CHEER:
+                case TWITCH_SUBGIFT:
                 //case SELFCHAN:
                     import kameloso.terminal : invert;
                     import kameloso.irc.common : containsNickname;

--- a/source/kameloso/plugins/printer.d
+++ b/source/kameloso/plugins/printer.d
@@ -1163,9 +1163,14 @@ if (isOutputRange!(Sink, char[]))
             .put(sink, " ! ", errors, " !");
         }
 
-        if (shouldBell || (errors.length && bellOnError &&
-            !plugin.printerSettings.silentErrors) ||
-            ((type == IRCEvent.Type.QUERY) && (target.nickname == plugin.state.client.nickname)))
+        shouldBell = shouldBell || ((target.nickname == plugin.state.client.nickname) &&
+            ((event.type == IRCEvent.Type.QUERY) ||
+            (event.type == IRCEvent.Type.TWITCH_CHEER) ||
+            (event.type == IRCEvent.Type.TWITCH_SUBGIFT)));
+        shouldBell = shouldBell || (errors.length && bellOnError &&
+            !plugin.printerSettings.silentErrors);
+
+        if (shouldBell)
         {
             import kameloso.terminal : TerminalToken;
             sink.put(TerminalToken.bell);
@@ -1640,9 +1645,14 @@ if (isOutputRange!(Sink, char[]))
 
         sink.colourWith(FG.default_);  // same for bright and dark
 
-        if (shouldBell || (errors.length && bellOnError &&
-            !plugin.printerSettings.silentErrors) ||
-            ((type == IRCEvent.Type.QUERY) && (target.nickname == plugin.state.client.nickname)))
+        shouldBell = shouldBell || ((target.nickname == plugin.state.client.nickname) &&
+            ((event.type == IRCEvent.Type.QUERY) ||
+            (event.type == IRCEvent.Type.TWITCH_CHEER) ||
+            (event.type == IRCEvent.Type.TWITCH_SUBGIFT)));
+        shouldBell = shouldBell || (errors.length && bellOnError &&
+            !plugin.printerSettings.silentErrors);
+
+        if (shouldBell)
         {
             import kameloso.terminal : TerminalToken;
             sink.put(TerminalToken.bell);

--- a/source/kameloso/plugins/twitchbot.d
+++ b/source/kameloso/plugins/twitchbot.d
@@ -801,7 +801,7 @@ void onCommandUptime(TwitchBotPlugin plugin, const IRCEvent event)
 
         immutable delta = now - SysTime.fromUnixTime(broadcastStart);
 
-        chan(plugin.state, event.channel, "%s has been streaming for %s."
+        chan(plugin.state, event.channel, "%s has been live for %s."
             .format(nickname, delta));
     }
     else
@@ -841,7 +841,7 @@ void onCommandStart(TwitchBotPlugin plugin, const IRCEvent event)
             if (streamer.alias_.length) nickname = streamer.alias_;
         }
 
-        chan(plugin.state, event.channel, nickname ~ " is already streaming.");
+        chan(plugin.state, event.channel, nickname ~ " is already live.");
         return;
     }
 

--- a/source/kameloso/plugins/twitchbot.d
+++ b/source/kameloso/plugins/twitchbot.d
@@ -271,7 +271,7 @@ void onSelfpart(TwitchBotPlugin plugin, const IRCEvent event)
  +  Bans, unbans, lists or clears banned phrases for the current channel.
  +  `kameloso.irc.defs.IRCEvent.Type.CHAN` wrapper.
  +
- +  Changes are persistently saved to the `twitchphrases.json` file.
+ +  Changes are persistently saved to the `TwitchBotPlugin.bannedPhrasesFile` file.
  +/
 @(IRCEvent.Type.CHAN)
 @(IRCEvent.Type.SELFCHAN)
@@ -291,7 +291,7 @@ void onCommandPhraseChan(TwitchBotPlugin plugin, const IRCEvent event)
  +  Bans, unbans, lists or clears banned phrases for the specified target channel.
  +  `kameloso.irc.defs.IRCEvent.Type.QUERY` wrapper.
  +
- +  Changes are persistently saved to the `twitchphrases.json` file.
+ +  Changes are persistently saved to the `TwitchBotPlugin.bannedPhrasesFile` file.
  +/
 @(IRCEvent.Type.QUERY)
 @(PrivilegeLevel.admin)

--- a/source/kameloso/plugins/twitchbot.d
+++ b/source/kameloso/plugins/twitchbot.d
@@ -1664,7 +1664,7 @@ private:
      +  How often to check whether timers should fire, in seconds. A smaller
      +  number means better precision.
      +/
-    enum timerPeriodicity = 30;
+    enum timerPeriodicity = 10;
 
     mixin IRCPluginImpl;
 

--- a/source/kameloso/plugins/twitchbot.d
+++ b/source/kameloso/plugins/twitchbot.d
@@ -1461,7 +1461,7 @@ void periodically(TwitchBotPlugin plugin)
         {
             if (!timer || (timer.state != Fiber.State.HOLD))
             {
-                logger.error("Dead or busy announcer Fiber in channel ", channelName);
+                logger.error("Dead or busy timer Fiber in channel ", channelName);
                 continue;
             }
 

--- a/source/kameloso/plugins/twitchbot.d
+++ b/source/kameloso/plugins/twitchbot.d
@@ -370,10 +370,7 @@ void handlePhraseCommand(TwitchBotPlugin plugin, const IRCEvent event, const str
 
             if (slice == "*")
             {
-                plugin.bannedPhrasesByChannel.remove(targetChannel);
-                privmsg(plugin.state, event.channel, event.sender.nickname,
-                    "All banned phrases removed.");
-                return;
+                goto case "clear";
             }
 
             size_t[] garbage;
@@ -626,11 +623,7 @@ void handleTimerCommand(TwitchBotPlugin plugin, const IRCEvent event, const stri
 
             if (slice == "*")
             {
-                plugin.timerDefsByChannel.remove(targetChannel);
-                channel.timers = typeof(channel.timers).init;
-                privmsg(plugin.state, event.channel, event.sender.nickname,
-                    "All timers removed.");
-                return;
+                goto case "clear";
             }
 
             import std.conv : ConvException, to;

--- a/source/kameloso/plugins/twitchbot.d
+++ b/source/kameloso/plugins/twitchbot.d
@@ -1470,30 +1470,23 @@ void start(TwitchBotPlugin plugin)
  +/
 struct TimerDefinition
 {
+    /// The timered line to send to the channel.
     string line;
 
-    uint messageCountThreshold;
+    /++
+     +  How many messages must have been sent since the last announce before we
+     +  will allow another one.
+     +/
+    int messageCountThreshold;
 
-    long timeThreshold;
+    /++
+     +  How many seconds must have passed since the last announce before we will
+     +  allow another one.
+     +/
+    int timeThreshold;
 
-    this(const string stringForm)
-    {
-        import kameloso.string : nom;
-        import std.conv : ConvException, to;
-
-        string slice = stringForm;  // mutable
-
-        try
-        {
-            messageCountThreshold = slice.nom(' ').to!uint;
-            timeThreshold = slice.nom(' ').to!long;
-            line = slice;
-        }
-        catch (ConvException e)
-        {
-            logger.error(e.msg);
-        }
-    }
+    /// Delay in seconds before the timer comes into effect.
+    int stagger;
 }
 
 

--- a/source/kameloso/plugins/twitchbot.d
+++ b/source/kameloso/plugins/twitchbot.d
@@ -210,21 +210,22 @@ Fiber createTimerFiber(TwitchBotPlugin plugin, const TimerDefinition timerDef,
 
     void dg()
     {
-        ulong lastMessageCount;
-        long lastTimestamp;
+        import std.datetime.systime : Clock;
+
+        const channel = channelName in plugin.activeChannels;
+
+        immutable creation = Clock.currTime.toUnixTime;
+        ulong lastMessageCount = channel.messageCount;
+        long lastTimestamp = creation;
 
         while (true)
         {
-            const channel = channelName in plugin.activeChannels;
-            assert(channel, "Orphan timer Fiber for channel " ~ channelName);
-
             if (channel.messageCount < (lastMessageCount + timerDef.messageCountThreshold))
             {
                 Fiber.yield();
                 continue;
             }
 
-            import std.datetime.systime : Clock;
             immutable now = Clock.currTime.toUnixTime;
 
             if (((now - lastTimestamp) < timerDef.timeThreshold) ||

--- a/source/kameloso/plugins/twitchbot.d
+++ b/source/kameloso/plugins/twitchbot.d
@@ -304,7 +304,7 @@ void handlePhraseCommand(TwitchBotPlugin plugin, const IRCEvent event, const str
                 {
                     ptrdiff_t i = istr.to!size_t - 1;
 
-                    if ((i > 0) && (i < phrases.length))
+                    if ((i > 0) && (i <= phrases.length))
                     {
                         garbage ~= i;
                     }

--- a/source/kameloso/plugins/twitchbot.d
+++ b/source/kameloso/plugins/twitchbot.d
@@ -1525,7 +1525,7 @@ void populateTimers(TwitchBotPlugin plugin, const string filename)
 
     foreach (immutable channel, const channelTimersJSON; timersJSON.object)
     {
-        assert((channelTimersJSON.type == JSONType.object),
+        assert((channelTimersJSON.type == JSONType.array),
             "Invalid channel timers list type for %s: %s"
             .format(channel, channelTimersJSON.type));
 

--- a/source/kameloso/plugins/twitchbot.d
+++ b/source/kameloso/plugins/twitchbot.d
@@ -235,12 +235,17 @@ Fiber createTimerFiber(TwitchBotPlugin plugin, const TimerDefinition timerDef,
                 continue;
             }
 
-            import std.array : replace;
+            if (channel.enabled)
+            {
+                import std.array : replace;
 
-            immutable line = timerDef.line
-                .replace("$streamer", nickname)
-                .replace("$channel", channelName[1..$]);
-            chan(plugin.state, channelName, line);
+                immutable line = timerDef.line
+                    .replace("$streamer", nickname)
+                    .replace("$channel", channelName[1..$]);
+                chan(plugin.state, channelName, line);
+            }
+
+            // If channel is disabled, silently fizzle but keep updating counts
 
             lastMessageCount = channel.messageCount;
             lastTimestamp = now;

--- a/source/kameloso/plugins/twitchbot.d
+++ b/source/kameloso/plugins/twitchbot.d
@@ -720,10 +720,11 @@ void handleTimerCommand(TwitchBotPlugin plugin, const IRCEvent event, const stri
 
             foreach (immutable i, const timer; (*timers)[start..end])
             {
-                immutable maxLen = min(timers.length, maxLineLength);
+                immutable maxLen = min(timer.line.length, maxLineLength);
                 privmsg(plugin.state, event.channel, event.sender.nickname,
-                    "%d: %s%s".format(start+i+1, timers[0..maxLen],
-                    (timers.length > maxLen) ? " ...  [truncated]" : string.init));
+                    "%d: %s%s (%d:%d:%d)".format(start+i+1, timer.line[0..maxLen],
+                    (timer.line.length > maxLen) ? " ...  [truncated]" : string.init,
+                    timer.messageCountThreshold, timer.timeThreshold, timer.stagger));
             }
         }
         else

--- a/source/kameloso/plugins/twitchbot.d
+++ b/source/kameloso/plugins/twitchbot.d
@@ -382,7 +382,7 @@ void handlePhraseCommand(TwitchBotPlugin plugin, const IRCEvent event, const str
 
                 try
                 {
-                    ptrdiff_t i = istr.to!size_t - 1;
+                    ptrdiff_t i = istr.to!ptrdiff_t - 1;
 
                     if ((i >= 0) && (i < phrases.length))
                     {
@@ -641,9 +641,9 @@ void handleTimerCommand(TwitchBotPlugin plugin, const IRCEvent event, const stri
 
             try
             {
-                ptrdiff_t i = slice.to!size_t - 1;
+                ptrdiff_t i = slice.to!ptrdiff_t - 1;
 
-                if ((i > 0) && (i <= channel.timers.length))
+                if ((i >= 0) && (i < channel.timers.length))
                 {
                     import std.algorithm.mutation : SwapStrategy, remove;
                     *timerDefs = (*timerDefs).remove!(SwapStrategy.unstable)(i);

--- a/source/kameloso/plugins/twitchbot.d
+++ b/source/kameloso/plugins/twitchbot.d
@@ -2,7 +2,9 @@
  +  This is an example Twitch streamer bot. It supports basic authentication,
  +  allowing for channel-specific administrators that are not necessarily in the
  +  whitelist nor are Twitch moderators, querying uptime or how long a streamer
- +  has been streaming, and banned phrases.
+ +  has been live, banned phrases and timered announcements. If run in a
+ +  local terminal it can also emit some terminal bells on certain events, to
+ +  draw attention.
  +
  +  One immediately obvious venue of expansion is expression bans, such as if a
  +  message has too many capital letters, etc. There is no protection from spam yet.

--- a/source/kameloso/plugins/twitchbot.d
+++ b/source/kameloso/plugins/twitchbot.d
@@ -216,8 +216,13 @@ Fiber createTimerFiber(TwitchBotPlugin plugin, const TimerDefinition timerDef,
 
         const channel = channelName in plugin.activeChannels;
 
+        /// When this timer Fiber was created.
         immutable creation = Clock.currTime.toUnixTime;
+
+        /// The channel message count at last successful trigger.
         ulong lastMessageCount = channel.messageCount;
+
+        /// The timestamp at the last successful trigger.
         long lastTimestamp = creation;
 
         while (true)

--- a/source/kameloso/plugins/twitchbot.d
+++ b/source/kameloso/plugins/twitchbot.d
@@ -386,7 +386,7 @@ void handlePhraseCommand(TwitchBotPlugin plugin, const IRCEvent event, const str
                 {
                     ptrdiff_t i = istr.to!size_t - 1;
 
-                    if ((i > 0) && (i <= phrases.length))
+                    if ((i >= 0) && (i < phrases.length))
                     {
                         garbage ~= i;
                     }

--- a/source/kameloso/plugins/twitchbot.d
+++ b/source/kameloso/plugins/twitchbot.d
@@ -1445,6 +1445,14 @@ void periodically(TwitchBotPlugin plugin)
 
     immutable now = Clock.currTime.toUnixTime;
 
+    if ((plugin.state.client.server.daemon != IRCServer.Daemon.unset) &&
+        (plugin.state.client.server.daemon != IRCServer.Daemon.twitch))
+    {
+        // Known to not be a Twitch server
+        plugin.state.nextPeriodical = now + 315_569_260L;
+        return;
+    }
+
     foreach (immutable channelName, channel; plugin.activeChannels)
     {
         if (!channel.timers.length) continue;

--- a/source/kameloso/plugins/twitchbot.d
+++ b/source/kameloso/plugins/twitchbot.d
@@ -730,6 +730,7 @@ void handleTimerCommand(TwitchBotPlugin plugin, const IRCEvent event, const stri
         break;
 
     case "clear":
+        plugin.activeChannels[targetChannel].timers.length = 0;
         plugin.timerDefsByChannel.remove(targetChannel);
         plugin.timersToJSON.save(plugin.timersFile);
         privmsg(plugin.state, event.channel, event.sender.nickname, "All timers cleared.");

--- a/source/kameloso/plugins/twitchsupport.d
+++ b/source/kameloso/plugins/twitchsupport.d
@@ -57,6 +57,13 @@ void postprocess(TwitchSupportService service, ref IRCEvent event)
         // displayed name/alias is sent separately as a "display-name" IRCv3 tag
         event.sender.account = event.sender.nickname;
     }
+    else if (event.sender.alias_.length)
+    {
+        // If no nickname yet an alias, it may be an anonymous subgift/bulkgift
+        // where the msg-id appeared before the display-name in the tags.
+        // Clear it.
+        event.sender.alias_ = string.init;
+    }
 }
 
 

--- a/source/kameloso/plugins/twitchsupport.d
+++ b/source/kameloso/plugins/twitchsupport.d
@@ -967,8 +967,11 @@ user-type
         case "login":
             // RAID; real sender nickname and thus raiding channel lowercased
             // CLEARMSG, SUBGIFT, lots
-            event.sender.nickname = value;
-            resetUser(event.sender);
+            if (value != "ananonymousgifter")
+            {
+                event.sender.nickname = value;
+                resetUser(event.sender);
+            }
             break;
 
         case "color":


### PR DESCRIPTION
This adds timered announcements, a la Nightbot.

An announcement can be added as a line of text to be spammed once every n messages once every m seconds, delayed/staggered by once every l seconds.

`!timer add 100 300 60 I thought what I'd do was, I'd pretend I was one of those deaf-mutes.`

This message will be sent once 100 channel messages/emotes have been observed *and* 300 seconds have passed, starting at 60 seconds after channel selfjoin.