### PR TITLE
Twitch regulars

### DIFF
--- a/source/kameloso/plugins/persistence.d
+++ b/source/kameloso/plugins/persistence.d
@@ -63,7 +63,14 @@ void postprocess(PersistenceService service, ref IRCEvent event)
                 if (stored)
                 {
                     import kameloso.meld : MeldingStrategy, meldInto;
+
+                    // Twitch bot postprocess is run before this postprocess is.
+                    // If it changes the user class, have it persist past our
+                    // own melding here.
+
+                    immutable origClass = user.class_;
                     (*user).meldInto!(MeldingStrategy.aggressive)(*stored);
+                    if (origClass > stored.class_) stored.class_ = origClass;
                 }
                 else
                 {


### PR DESCRIPTION
This renames Twitch "administrators" to regulars, and reworks the way it does user access control.

So far we've been hijacking `IRCPluginImpl.allowImpl` and inserting our own logic to make users that are moderators or were Twitch-whitelisted to enjoy extra privileges. The problem with that is that it's plugin-local; even if we set a user to be a Twitch channel regular, it wouldn't be able to trigger `PrivilegeLevel.whitelist'-gated functions in other plugins.

Luckily we have `postprocess` just for this kind of thing; modifying `IRCEvent`s after parsing but before handing them over to plugins. So compare senders and targets with the list of regulars and moderators (by inspecting `IRCEvent.badges`), and set their user classes accordingly. We add some extra bits to Persistence to make these changes persist and not get overwritten with stored users'.

It seems to work but more testing needed.