### PR TITLE
Resolve to list hostnames when connecting

### DIFF
--- a/source/kameloso/kameloso.d
+++ b/source/kameloso/kameloso.d
@@ -1303,8 +1303,10 @@ Next tryConnect(ref IRCBot bot)
             immutable pattern = (attempt.ip.addressFamily == AddressFamily.INET6) ?
                 "Connecting to [%s%s%s]:%1$s%4$s%3$s ..." :
                 "Connecting to %s%s%s:%1$s%4$s%3$s ...";
-            logger.logf(pattern, infotint, attempt.ip.toHostNameString,
-                logtint, attempt.ip.toPortString);
+            immutable resolvedHost = attempt.ip.toHostNameString;
+            immutable address = (parser.client.server.address == resolvedHost) ?
+                attempt.ip.toAddrString : resolvedHost;
+            logger.logf(pattern, infotint, address, logtint, attempt.ip.toPortString);
             continue;
 
         case connected:

--- a/source/kameloso/kameloso.d
+++ b/source/kameloso/kameloso.d
@@ -1298,9 +1298,13 @@ Next tryConnect(ref IRCBot bot)
         final switch (attempt.state)
         {
         case preconnect:
-            // Alternative: attempt.ip.toHostNameString
-            logger.logf("Connecting to %s%s%s:%1$s%4$s%3$s ...",
-                infotint, attempt.ip.toAddrString, logtint, attempt.ip.toPortString);
+            import std.socket : AddressFamily;
+
+            immutable pattern = (attempt.ip.addressFamily == AddressFamily.INET6) ?
+                "Connecting to [%s%s%s]:%1$s%4$s%3$s ..." :
+                "Connecting to %s%s%s:%1$s%4$s%3$s ...";
+            logger.logf(pattern, infotint, attempt.ip.toHostNameString,
+                logtint, attempt.ip.toPortString);
             continue;
 
         case connected:


### PR DESCRIPTION
The behaviour so far is to list addresses as IPs when connecting. It looks nicer if it lists hostnames.