### PR TITLE
Windows console mode and codepage handling

### DIFF
--- a/source/kameloso/kameloso.d
+++ b/source/kameloso/kameloso.d
@@ -72,15 +72,15 @@ version (Windows)
         SetConsoleCP(CP_UTF8);
         SetConsoleOutputCP(CP_UTF8);
 
-        immutable stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+        auto stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
         assert((stdoutHandle != INVALID_HANDLE_VALUE), "Failed to get standard output handle");
 
-        bool success = GetConsoleMode(stdoutHandle, &originalConsoleMode);
-        assert(success, "Failed to get console mode");
+        immutable getConRetval = GetConsoleMode(stdoutHandle, &originalConsoleMode);
+        assert((getConRetval != 0), "Failed to get console mode");
 
-        success = SetConsoleMode(stdoutHandle,
+        immutable setConRetval = SetConsoleMode(stdoutHandle,
             originalConsoleMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
-        assert(success, "Failed to set console mode");
+        assert((setConRetval != 0), "Failed to set console mode");
 
         // atexit handlers are also called when exiting via exit() etc.;
         // that's the reason this isn't a RAII struct.
@@ -94,12 +94,15 @@ version (Windows)
     extern(C)
     void resetConsoleModeAndCodepage()
     {
-        immutable stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+        import core.sys.windows.winbase : GetStdHandle, INVALID_HANDLE_VALUE, STD_OUTPUT_HANDLE;
+        import core.sys.windows.wincon : SetConsoleMode;
+
+        auto stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
         assert((stdoutHandle != INVALID_HANDLE_VALUE), "Failed to get standard output handle");
 
         SetConsoleCP(originalCP);
         SetConsoleOutputCP(originalOutputCP);
-        SetConsoleMode(stdoutHandle, originalMode);
+        SetConsoleMode(stdoutHandle, originalConsoleMode);
     }
 }
 

--- a/source/kameloso/main.d
+++ b/source/kameloso/main.d
@@ -11,6 +11,15 @@ void main()
 {
     import kameloso.common : logger;
 
+    version(Windows)
+    {
+        import kameloso.terminal : setConsoleModeAndCodepage;
+
+        // Set up the console to display text and colours properly.
+        // It will only affect the below "All tests passed" line however...
+        setConsoleModeAndCodepage();
+    }
+
     // Compiled with -b unittest, so run the tests and exit.
     // Logger is initialised in a module constructor, don't re-init here.
     logger.info("All tests passed successfully!");

--- a/source/kameloso/terminal.d
+++ b/source/kameloso/terminal.d
@@ -30,7 +30,7 @@ version (Windows)
     // Taken from LDC: https://github.com/ldc-developers/ldc/pull/3086/commits/9626213a
     // https://github.com/ldc-developers/ldc/pull/3086/commits/9626213a
 
-    import core.sys.windows.wincon : SetConsoleCP, SetConsoleOutputCP;
+    import core.sys.windows.wincon : SetConsoleCP, SetConsoleMode, SetConsoleOutputCP;
 
     /// Original codepage at program start.
     __gshared uint originalCP;
@@ -50,7 +50,7 @@ version (Windows)
         import core.stdc.stdlib : atexit;
         import core.sys.windows.winbase : GetStdHandle, INVALID_HANDLE_VALUE, STD_OUTPUT_HANDLE;
         import core.sys.windows.wincon : ENABLE_VIRTUAL_TERMINAL_PROCESSING,
-            GetConsoleCP, GetConsoleMode, GetConsoleOutputCP, SetConsoleMode;
+            GetConsoleCP, GetConsoleMode, GetConsoleOutputCP;
         import core.sys.windows.winnls : CP_UTF8;
 
         originalCP = GetConsoleCP();
@@ -83,7 +83,6 @@ version (Windows)
     private void resetConsoleModeAndCodepage() @system
     {
         import core.sys.windows.winbase : GetStdHandle, INVALID_HANDLE_VALUE, STD_OUTPUT_HANDLE;
-        import core.sys.windows.wincon : SetConsoleMode;
 
         auto stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
         assert((stdoutHandle != INVALID_HANDLE_VALUE), "Failed to get standard output handle");

--- a/source/kameloso/terminal.d
+++ b/source/kameloso/terminal.d
@@ -62,12 +62,13 @@ version (Windows)
         auto stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
         assert((stdoutHandle != INVALID_HANDLE_VALUE), "Failed to get standard output handle");
 
-        immutable getConRetval = GetConsoleMode(stdoutHandle, &originalConsoleMode);
-        assert((getConRetval != 0), "Failed to get console mode");
+        immutable getModeRetval = GetConsoleMode(stdoutHandle, &originalConsoleMode);
 
-        immutable setConRetval = SetConsoleMode(stdoutHandle,
-            originalConsoleMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
-        assert((setConRetval != 0), "Failed to set console mode");
+        if (getModeRetval != 0)
+        {
+            // The console is a real terminal, not a pager (or Cygwin mintty)
+            SetConsoleMode(stdoutHandle, originalConsoleMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+        }
 
         // atexit handlers are also called when exiting via exit() etc.;
         // that's the reason this isn't a RAII struct.


### PR DESCRIPTION
This changes how we set codepages from setting it once persistently (lasting after program finishes) to resetting it as the program exits. We basically copy/paste how ldc does it.

It also adds changing the console mode to temporarily display terminal colours in Windows cmd consoles, without making the permanent registry change.