### PR TITLE
IRCBot

### DIFF
--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -256,6 +256,9 @@ struct Kameloso
     /// Parser instance.
     IRCParser parser;
 
+    /// IRC bot values.
+    IRCBot bot;
+
     /// Values and state needed to throttle sending messages.
     Throttle throttle;
 

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -104,9 +104,6 @@ struct CoreSettings
         bool monochrome = true;  /// Non-colours version defaults to true.
     }
 
-    /// Default reason given when quitting without specifying one.
-    string quitReason;
-
     /// Flag denoting whether or not the program should reconnect after disconnect.
     bool reconnectOnFailure = true;
 
@@ -153,20 +150,6 @@ struct IRCBot
     /// Username to use as services account login name.
     string account;
 
-    version(TwitchSupport)
-    {
-        /++
-            The Twitch colour to assign to our nickname.
-
-            "Normal users can choose between Blue, Coral, DodgerBlue,
-            SpringGreen, YellowGreen, Green, OrangeRed, Red, GoldenRod,
-            HotPink, CadetBlue, SeaGreen, Chocolate, BlueViolet, and Firebrick.
-            Twitch Turbo users can use any Hex value (i.e: #000000)."
-        +/
-        @CannotContainComments
-        string colour;
-    }
-
     @Hidden
     @CannotContainComments
     {
@@ -191,6 +174,24 @@ struct IRCBot
         @CannotContainComments
         string[] channels;
     }
+
+    version(TwitchSupport)
+    {
+        /++
+            The Twitch colour to assign to our nickname.
+
+            "Normal users can choose between Blue, Coral, DodgerBlue,
+            SpringGreen, YellowGreen, Green, OrangeRed, Red, GoldenRod,
+            HotPink, CadetBlue, SeaGreen, Chocolate, BlueViolet, and Firebrick.
+            Twitch Turbo users can use any Hex value (i.e: #000000)."
+        +/
+        @CannotContainComments
+        string colour;
+    }
+
+    /// Default reason given when quitting without specifying one.
+    @CannotContainComments
+    string quitReason;
 }
 
 

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -192,13 +192,6 @@ struct IRCBot
     /// Default reason given when quitting without specifying one.
     @CannotContainComments
     string quitReason;
-
-    @Hidden
-    @Unconfigurable
-    {
-        /// Whether or not the bot was altered and need propagating.
-        bool updated;
-    }
 }
 
 

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -433,6 +433,7 @@ struct Kameloso
 
         IRCPluginState state;
         state.client = parser.client;
+        state.bot = this.bot;
         state.mainThread = thisTid;
         immutable now = Clock.currTime.toUnixTime;
 

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -145,6 +145,57 @@ struct CoreSettings
 
 // IRCBot
 /++
+ +  Aggregate of information relevant for an IRC *bot* that goes beyond what is
+ +  needed for a mere IRC *client*.
+ +/
+struct IRCBot
+{
+    /// Username to use as services account login name.
+    string account;
+
+    version(TwitchSupport)
+    {
+        /++
+            The Twitch colour to assign to our nickname.
+
+            "Normal users can choose between Blue, Coral, DodgerBlue,
+            SpringGreen, YellowGreen, Green, OrangeRed, Red, GoldenRod,
+            HotPink, CadetBlue, SeaGreen, Chocolate, BlueViolet, and Firebrick.
+            Twitch Turbo users can use any Hex value (i.e: #000000)."
+        +/
+        @CannotContainComments
+        string colour;
+    }
+
+    @Hidden
+    @CannotContainComments
+    {
+        /// Password for services account.
+        string password;
+
+        /// Login `PASS`, different from `SASL` and services.
+        string pass;
+    }
+
+    @Separator(",")
+    @Separator(" ")
+    {
+        /// The nickname services accounts of *administrators*, in a bot-like context.
+        string[] admins;
+
+        /// List of homes, in a bot-like context.
+        @CannotContainComments
+        string[] homes;
+
+        /// Currently inhabited non-home channels.
+        @CannotContainComments
+        string[] channels;
+    }
+}
+
+
+// Kameloso
+/++
  +  State needed for the kameloso bot, aggregated in a struct for easier passing
  +  by reference.
  +/

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -681,14 +681,14 @@ void writeConfigurationFile(ref Kameloso instance, const string filename) @syste
     Appender!string sink;
     sink.reserve(4096);  // ~2234
 
-    with (instance.parser)
+    with (instance)
     {
-        if (client.password.length && !client.password.beginsWith("base64:"))
+        if (bot.password.length && !bot.password.beginsWith("base64:"))
         {
-            client.password = "base64:" ~ encode64(client.password);
+            bot.password = "base64:" ~ encode64(bot.password);
         }
 
-        sink.serialise(client, client.server, settings);
+        sink.serialise(parser.client, bot, parser.client.server, settings);
 
         foreach (plugin; instance.plugins)
         {

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -589,6 +589,27 @@ struct Kameloso
             plugin.state.client = client;
         }
     }
+
+
+    // propagateBot
+    /++
+     +  Takes a `kameloso.common.IRCBot` and passes it out to all plugins.
+     +
+     +  This is called when a change to the bot has occurred and we want to
+     +  update all plugins to have a current copy of it.
+     +
+     +  Params:
+     +      bot = `kameloso.common.IRCBot` to propagate to all plugins.
+     +/
+    void propagateBot(IRCBot bot) pure nothrow @nogc
+    {
+        this.bot = bot;
+
+        foreach (plugin; plugins)
+        {
+            plugin.state.bot = bot;
+        }
+    }
 }
 
 

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -192,6 +192,13 @@ struct IRCBot
     /// Default reason given when quitting without specifying one.
     @CannotContainComments
     string quitReason;
+
+    @Hidden
+    @Unconfigurable
+    {
+        /// Whether or not the bot was altered and need propagating.
+        bool updated;
+    }
 }
 
 

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -199,7 +199,7 @@ struct IRCBot
  +  State needed for the kameloso bot, aggregated in a struct for easier passing
  +  by reference.
  +/
-struct IRCBot
+struct Kameloso
 {
     import kameloso.common : OutgoingLine;
     import lu.common : Buffer;
@@ -653,15 +653,15 @@ void printVersionInfo(const string pre = string.init, const string post = string
  +
  +  Example:
  +  ---
- +  IRCBot bot;
- +  bot.writeConfigurationFile(bot.settings.configFile);
+ +  Kameloso instance;
+ +  instance.writeConfigurationFile(instance.settings.configFile);
  +  ---
  +
  +  Params:
- +      bot = Reference to the current `IRCBot`, with all its settings.
+ +      instance = Reference to the current `Kameloso`, with all its settings.
  +      filename = String filename of the file to write to.
  +/
-void writeConfigurationFile(ref IRCBot bot, const string filename) @system
+void writeConfigurationFile(ref Kameloso instance, const string filename) @system
 {
     import lu.serialisation : justifiedConfigurationText, serialise;
     import lu.string : beginsWith, encode64;
@@ -670,7 +670,7 @@ void writeConfigurationFile(ref IRCBot bot, const string filename) @system
     Appender!string sink;
     sink.reserve(4096);  // ~2234
 
-    with (bot.parser)
+    with (instance.parser)
     {
         if (client.password.length && !client.password.beginsWith("base64:"))
         {
@@ -679,7 +679,7 @@ void writeConfigurationFile(ref IRCBot bot, const string filename) @system
 
         sink.serialise(client, client.server, settings);
 
-        foreach (plugin; bot.plugins)
+        foreach (plugin; instance.plugins)
         {
             plugin.serialiseConfigInto(sink);
         }

--- a/source/kameloso/debugging.d
+++ b/source/kameloso/debugging.d
@@ -4,7 +4,7 @@
  +/
 module kameloso.debugging;
 
-import kameloso.common : IRCBot;
+import kameloso.common : Kameloso;
 import dialect.defs;
 
 import std.range.primitives : isOutputRange;
@@ -394,14 +394,14 @@ unittest
  +
  +  Example:
  +  ---
- +  IRCBot bot;
- +  bot.generateAsserts();
+ +  Kameloso instance;
+ +  instance.generateAsserts();
  +  ---
  +
  +  Params:
- +      bot = Reference to the current `kameloso.common.IRCBot`, with all its settings.
+ +      instance = Reference to the current `kameloso.common.Kameloso`, with all its settings.
  +/
-void generateAsserts(ref IRCBot bot) @system
+void generateAsserts(ref Kameloso instance) @system
 {
     import kameloso.common : logger;
     import kameloso.printing : printObjects;
@@ -414,9 +414,9 @@ void generateAsserts(ref IRCBot bot) @system
     import std.typecons : No, Yes;
 
     with (IRCServer)
-    with (bot)
+    with (instance)
     {
-        import dialect.parsing : IRCParser;  // Must be here or shadows IRCBot : IRCParser
+        import dialect.parsing : IRCParser;  // Must be here or shadows Kameloso : IRCParser
 
         parser = IRCParser.init;
 

--- a/source/kameloso/debugging.d
+++ b/source/kameloso/debugging.d
@@ -439,7 +439,7 @@ void generateAsserts(ref Kameloso instance) @system
             parser.typenums = typenumsOf(daemon);
             parser.client.server.daemon = daemon;
             parser.client.server.daemonstring = version_;
-            parser.client.updated = true;
+            parser.clientUpdated = true;
         }
         catch (ConvException e)
         {
@@ -471,7 +471,7 @@ void generateAsserts(ref Kameloso instance) @system
         printObjects!(Yes.printAll)(parser.client, parser.client.server);
         writeln();
 
-        parser.client.updated = false;
+        parser.clientUpdated = false;
         stdout.lockingTextWriter.formatClientAssignment(parser.client);
         writeln();
         writeln("parser.typenums = typenumsOf(parser.client.server.daemon);");
@@ -537,9 +537,9 @@ void generateAsserts(ref Kameloso instance) @system
                 stdout.lockingTextWriter.formatEventAssertBlock(event);
                 writeln();
 
-                if (parser.client.updated)
+                if (parser.clientUpdated)
                 {
-                    parser.client.updated = false;
+                    parser.clientUpdated = false;
                     foreach (plugin; plugins) plugin.state.client = parser.client;
 
                     /+writeln("/*");

--- a/source/kameloso/getopt.d
+++ b/source/kameloso/getopt.d
@@ -250,6 +250,7 @@ void printHelp(GetoptResult results) @system
  +  Params:
  +      instance = Reference to the current `kameloso.common.Kameloso`.
  +      client = Reference to the current `dialect.defs.IRCClient`.
+ +      bot = Reference to the current `kameloso.common.IRCBot`.
  +      customSettings = Reference string array to all the custom settings set
  +          via `getopt`, to apply to things before saving to disk.
  +

--- a/source/kameloso/getopt.d
+++ b/source/kameloso/getopt.d
@@ -3,7 +3,7 @@
  +/
 module kameloso.getopt;
 
-import kameloso.common : CoreSettings, IRCBot;
+import kameloso.common : CoreSettings, Kameloso;
 import lu.common : Next;
 import dialect.defs : IRCClient;
 import std.typecons : No, Yes;
@@ -243,7 +243,7 @@ void printHelp(GetoptResult results) @system
  +  The filename is read from `kameloso.common.settings`.
  +
  +  Params:
- +      bot = Reference to the current `kameloso.common.IRCBot`.
+ +      instance = Reference to the current `kameloso.common.Kameloso`.
  +      client = Reference to the current `dialect.defs.IRCClient`.
  +      customSettings = Reference string array to all the custom settings set
  +          via `getopt`, to apply to things before saving to disk.
@@ -251,7 +251,7 @@ void printHelp(GetoptResult results) @system
  +  Returns:
  +      `kameloso.common.Next.returnSuccess` so the caller knows to return and exit.
  +/
-Next writeConfig(ref IRCBot bot, ref IRCClient client, ref string[] customSettings) @system
+Next writeConfig(ref Kameloso instance, ref IRCClient client, ref string[] customSettings) @system
 {
     import kameloso.common : logger, printVersionInfo, settings, writeConfigurationFile;
     import kameloso.printing : printObjects;
@@ -281,9 +281,9 @@ Next writeConfig(ref IRCBot bot, ref IRCClient client, ref string[] customSettin
     writeln();
 
     // If we don't initialise the plugins there'll be no plugins array
-    bot.initPlugins(customSettings);
+    instance.initPlugins(customSettings);
 
-    bot.writeConfigurationFile(settings.configFile);
+    instance.writeConfigurationFile(settings.configFile);
 
     // Reload saved file
     meldSettingsFromFile(client, settings);
@@ -314,15 +314,15 @@ public:
  +
  +  Example:
  +  ---
- +  IRCBot bot;
- +  Next next = bot.handleGetopt(args);
+ +  Kameloso instance;
+ +  Next next = instance.handleGetopt(args);
  +
  +  if (next == Next.returnSuccess) return 0;
  +  // ...
  +  ---
  +
  +  Params:
- +      bot = Reference to the current `kameloso.common.IRCBot`.
+ +      instance = Reference to the current `kameloso.common.Kameloso`.
  +      args = The `string[]` args the program was called with.
  +      customSettings = Reference array of custom settings to apply on top of
  +          the settings read from the configuration file.
@@ -335,7 +335,7 @@ public:
  +  Throws:
  +      `std.getopt.GetOptException` if `--asserts`/`--gen` is passed in non-debug builds.
  +/
-Next handleGetopt(ref IRCBot bot, string[] args, ref string[] customSettings) @system
+Next handleGetopt(ref Kameloso instance, string[] args, ref string[] customSettings) @system
 {
     import kameloso.common : completeClient, printVersionInfo, settings;
     import std.format : format;
@@ -366,7 +366,7 @@ Next handleGetopt(ref IRCBot bot, string[] args, ref string[] customSettings) @s
 
     arraySep = ",";
 
-    with (bot.parser)
+    with (instance.parser)
     {
         auto results = args.getopt(
             config.caseSensitive,
@@ -499,7 +499,7 @@ Next handleGetopt(ref IRCBot bot, string[] args, ref string[] customSettings) @s
         if (shouldWriteConfig)
         {
             // --writeconfig was passed; write configuration to file and quit
-            return writeConfig(bot, client, customSettings);
+            return writeConfig(instance, client, customSettings);
         }
 
         if (shouldShowSettings)
@@ -528,9 +528,9 @@ Next handleGetopt(ref IRCBot bot, string[] args, ref string[] customSettings) @s
 
             printObjects!(No.printAll)(client, client.server, settings);
 
-            bot.initPlugins(customSettings);
+            instance.initPlugins(customSettings);
 
-            foreach (plugin; bot.plugins) plugin.printSettings();
+            foreach (plugin; instance.plugins) plugin.printSettings();
 
             return Next.returnSuccess;
         }
@@ -541,7 +541,7 @@ Next handleGetopt(ref IRCBot bot, string[] args, ref string[] customSettings) @s
             {
                 // --gen|--generate was passed, enter assert generation
                 import kameloso.debugging : generateAsserts;
-                bot.generateAsserts();
+                instance.generateAsserts();
                 return Next.returnSuccess;
             }
             else
@@ -552,7 +552,7 @@ Next handleGetopt(ref IRCBot bot, string[] args, ref string[] customSettings) @s
         }
 
         // 10. `client` finished; inherit into `client`
-        bot.parser.client = client;
+        instance.parser.client = client;
 
         return Next.continue_;
     }

--- a/source/kameloso/getopt.d
+++ b/source/kameloso/getopt.d
@@ -499,11 +499,11 @@ Next handleGetopt(ref Kameloso instance, string[] args, ref string[] customSetti
         import std.array : array;
         import std.uni : toLower;
 
-        parser.client.homes = parser.client.homes
+        bot.homes = bot.homes
             .map!(channelName => channelName.toLower)
             .array;
 
-        parser.client.channels = parser.client.channels
+        bot.channels = bot.channels
             .map!(channelName => channelName.toLower)
             .array;
 

--- a/source/kameloso/kameloso.d
+++ b/source/kameloso/kameloso.d
@@ -699,10 +699,10 @@ Next mainLoop(ref Kameloso instance)
                     throw e;
                 }
 
-                if (instance.parser.client.updated)
+                if (instance.parser.clientUpdated)
                 {
                     // Parsing changed the client; propagate
-                    instance.parser.client.updated = false;
+                    instance.parser.clientUpdated = false;
                     instance.propagateClient(instance.parser.client);
                 }
 
@@ -720,12 +720,18 @@ Next mainLoop(ref Kameloso instance)
                         version(PrintStacktraces) logger.trace(e.toString);
                     }
 
-                    if (plugin.state.client.updated)
+                    if (plugin.state.botUpdated)
+                    {
+                        // Postprocessing changed the bot; propagate
+                        plugin.state.botUpdated = false;
+                        instance.propagateBot(plugin.state.bot);
+                    }
+
+                    if (plugin.state.clientUpdated)
                     {
                         // Postprocessing changed the client; propagate
-                        instance.parser.client = plugin.state.client;
-                        instance.parser.client.updated = false;
-                        instance.propagateClient(instance.parser.client);
+                        plugin.state.clientUpdated = false;
+                        instance.propagateClient(plugin.state.client);
                     }
                 }
 
@@ -742,17 +748,25 @@ Next mainLoop(ref Kameloso instance)
                         // Fetch any queued `WHOIS` requests and handle
                         instance.whoisForTriggerRequestQueue(plugin.state.triggerRequestQueue);
 
-                        if (plugin.state.client.updated)
+                        if (plugin.state.botUpdated)
                         {
                             /*  Plugin `onEvent` or `WHOIS` reaction updated the
-                                client. There's no need to check for both
+                                bot. There's no need to check for both
                                 separately since this is just a single plugin
                                 processing; it keeps its update internally
                                 between both passes.
                             */
-                            instance.parser.client = plugin.state.client;
-                            instance.parser.client.updated = false;
-                            instance.propagateClient(instance.parser.client);
+                            plugin.state.botUpdated = false;
+                            instance.propagateBot(plugin.state.bot);
+                        }
+
+                        if (plugin.state.clientUpdated)
+                        {
+                            /*  Plugin `onEvent` or `WHOIS` reaction updated the
+                                client. As above.
+                            */
+                            plugin.state.clientUpdated = false;
+                            instance.propagateClient(plugin.state.client);
                         }
                     }
                     catch (UTFException e)

--- a/source/kameloso/kameloso.d
+++ b/source/kameloso/kameloso.d
@@ -154,7 +154,7 @@ void messageFiber(ref Kameloso instance)
         {
             // This will automatically close the connection.
             // Set quit to yes to propagate the decision up the stack.
-            immutable reason = givenReason.length ? givenReason : settings.quitReason;
+            immutable reason = givenReason.length ? givenReason : instance.bot.quitReason;
             instance.priorityBuffer.put(OutgoingLine("QUIT :" ~ reason, hideOutgoing));
             next = Next.returnSuccess;
         }
@@ -1652,14 +1652,14 @@ int initBot(string[] args)
     }
 
     // Apply some defaults, as stored in `kameloso.constants`.
-    with (instance.parser.client)
+    with (instance)
     {
         import kameloso.constants : KamelosoDefaultIntegers, KamelosoDefaultStrings;
 
-        if (!realName.length) realName = KamelosoDefaultStrings.realName;
-        if (!settings.quitReason.length) settings.quitReason = KamelosoDefaultStrings.quitReason;
-        if (!server.address.length) server.address = KamelosoDefaultStrings.serverAddress;
-        if (server.port == 0) server.port = KamelosoDefaultIntegers.port;
+        if (!parser.client.realName.length) parser.client.realName = KamelosoDefaultStrings.realName;
+        if (!bot.quitReason.length) bot.quitReason = KamelosoDefaultStrings.quitReason;
+        if (!parser.client.server.address.length) parser.client.server.address = KamelosoDefaultStrings.serverAddress;
+        if (parser.client.server.port == 0) parser.client.server.port = KamelosoDefaultIntegers.port;
     }
 
     string pre, post, infotint, logtint, warningtint, errortint;
@@ -1692,9 +1692,9 @@ int initBot(string[] args)
     import lu.string : contains;
 
     // Print the current settings to show what's going on.
-    printObjects(instance.parser.client, instance.parser.client.server);
+    printObjects(instance.parser.client, instance.bot, instance.parser.client.server);
 
-    if (!instance.parser.client.homes.length && !instance.parser.client.admins.length)
+    if (!instance.bot.homes.length && !instance.bot.admins.length)
     {
         complainAboutMissingConfiguration(args);
     }
@@ -1812,8 +1812,6 @@ int initBot(string[] args)
 
             // Carry some values but otherwise restore the pristine client backup
             backupClient.nickname = instance.parser.client.nickname;
-            backupClient.homes = instance.parser.client.homes;
-            backupClient.channels = instance.parser.client.channels;
             //instance.parser.client = backupClient;  // Initialised below
 
             // Exhaust leftover queued messages
@@ -1974,16 +1972,16 @@ int initBot(string[] args)
             version(Colours)
             {
                 import kameloso.irccolours : mapEffects;
-                logger.trace("--> QUIT :", settings.quitReason.mapEffects);
+                logger.trace("--> QUIT :", instance.bot.quitReason.mapEffects);
             }
             else
             {
                 import kameloso.irccolours : stripEffects;
-                logger.trace("--> QUIT :", settings.quitReason.stripEffects);
+                logger.trace("--> QUIT :", instance.bot.quitReason.stripEffects);
             }
         }
 
-        instance.conn.sendline("QUIT :" ~ settings.quitReason);
+        instance.conn.sendline("QUIT :" ~ instance.bot.quitReason);
     }
     else if (!*instance.abort && (next == Next.returnFailure) && !settings.reconnectOnFailure)
     {

--- a/source/kameloso/plugins/admin.d
+++ b/source/kameloso/plugins/admin.d
@@ -319,7 +319,7 @@ void onCommandAddHome(AdminPlugin plugin, const IRCEvent event)
         return;
     }
 
-    if (plugin.state.client.homes.canFind(channelToAdd))
+    if (plugin.state.bot.homes.canFind(channelToAdd))
     {
         privmsg(plugin.state, event.channel, event.sender.nickname, "We are already in that home channel.");
         return;
@@ -327,8 +327,8 @@ void onCommandAddHome(AdminPlugin plugin, const IRCEvent event)
 
     // We need to add it to the homes array so as to get ChannelPolicy.home
     // ChannelAwareness to pick up the SELFJOIN.
-    plugin.state.client.homes ~= channelToAdd;
-    plugin.state.client.updated = true;
+    plugin.state.bot.homes ~= channelToAdd;
+    plugin.state.bot.updated = true;
     join(plugin.state, channelToAdd);
     privmsg(plugin.state, event.channel, event.sender.nickname, "Home added.");
 
@@ -365,7 +365,7 @@ void onCommandAddHome(AdminPlugin plugin, const IRCEvent event)
         case ERR_LINKCHANNEL:
             // We were redirected. Still assume we wanted to add this one?
             logger.log("Redirected!");
-            plugin.state.client.homes ~= followupEvent.content.toLower;
+            plugin.state.bot.homes ~= followupEvent.content.toLower;
             // Drop down and undo original addition
             break;
 
@@ -378,12 +378,12 @@ void onCommandAddHome(AdminPlugin plugin, const IRCEvent event)
         import std.algorithm.mutation : SwapStrategy, remove;
         import std.algorithm.searching : countUntil;
 
-        immutable homeIndex = plugin.state.client.homes.countUntil(followupEvent.channel);
+        immutable homeIndex = plugin.state.bot.homes.countUntil(followupEvent.channel);
         if (homeIndex != -1)
         {
-            plugin.state.client.homes = plugin.state.client.homes
+            plugin.state.bot.homes = plugin.state.bot.homes
                 .remove!(SwapStrategy.unstable)(homeIndex);
-            plugin.state.client.updated = true;
+            plugin.state.bot.updated = true;
         }
         else
         {
@@ -437,7 +437,7 @@ void onCommandDelHome(AdminPlugin plugin, const IRCEvent event)
     import std.algorithm.mutation : SwapStrategy, remove;
 
     immutable channel = event.content.stripped;
-    immutable homeIndex = plugin.state.client.homes.countUntil(channel);
+    immutable homeIndex = plugin.state.bot.homes.countUntil(channel);
 
     if (homeIndex == -1)
     {
@@ -453,9 +453,9 @@ void onCommandDelHome(AdminPlugin plugin, const IRCEvent event)
         return;
     }
 
-    plugin.state.client.homes = plugin.state.client.homes
+    plugin.state.bot.homes = plugin.state.bot.homes
         .remove!(SwapStrategy.unstable)(homeIndex);
-    plugin.state.client.updated = true;
+    plugin.state.bot.updated = true;
     part(plugin.state, channel);
     privmsg(plugin.state, event.channel, event.sender.nickname, "Home removed.");
 }

--- a/source/kameloso/plugins/admin.d
+++ b/source/kameloso/plugins/admin.d
@@ -328,7 +328,7 @@ void onCommandAddHome(AdminPlugin plugin, const IRCEvent event)
     // We need to add it to the homes array so as to get ChannelPolicy.home
     // ChannelAwareness to pick up the SELFJOIN.
     plugin.state.bot.homes ~= channelToAdd;
-    plugin.state.bot.updated = true;
+    plugin.state.botUpdated = true;
     join(plugin.state, channelToAdd);
     privmsg(plugin.state, event.channel, event.sender.nickname, "Home added.");
 
@@ -358,8 +358,8 @@ void onCommandAddHome(AdminPlugin plugin, const IRCEvent event)
         {
         case SELFJOIN:
             // Success!
-            /*client.homes ~= followupChannel;
-            client.updated = true;*/
+            /*plugin.state.bot.homes ~= followupChannel;
+            plugin.state.botUpdated = true;*/
             return;
 
         case ERR_LINKCHANNEL:
@@ -383,7 +383,7 @@ void onCommandAddHome(AdminPlugin plugin, const IRCEvent event)
         {
             plugin.state.bot.homes = plugin.state.bot.homes
                 .remove!(SwapStrategy.unstable)(homeIndex);
-            plugin.state.bot.updated = true;
+            plugin.state.botUpdated = true;
         }
         else
         {
@@ -455,7 +455,7 @@ void onCommandDelHome(AdminPlugin plugin, const IRCEvent event)
 
     plugin.state.bot.homes = plugin.state.bot.homes
         .remove!(SwapStrategy.unstable)(homeIndex);
-    plugin.state.bot.updated = true;
+    plugin.state.botUpdated = true;
     part(plugin.state, channel);
     privmsg(plugin.state, event.channel, event.sender.nickname, "Home removed.");
 }

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -1278,7 +1278,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                     {
                         // it is a non-channel event, like a `dialect.defs.IRCEvent.Type.QUERY`
                     }
-                    else if (!privateState.client.homes.canFind(event.channel))
+                    else if (!privateState.bot.homes.canFind(event.channel))
                     {
                         static if (verbose)
                         {

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -399,6 +399,12 @@ struct IRCPluginState
 
     /// The next (Unix time) timestamp at which to call `periodically`.
     long nextPeriodical;
+
+    /// Whether or not `bot` was altered. Must be reset manually.
+    bool botUpdated;
+
+    /// Whether or not `client` was altered. Must be reset manually.
+    bool clientUpdated;
 }
 
 

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -352,15 +352,22 @@ unittest
  +/
 struct IRCPluginState
 {
+    import kameloso.common : IRCBot;
     import lu.common : Labeled;
     import core.thread : Fiber;
     import std.concurrency : Tid;
 
     /++
      +  The current `dialect.defs.IRCClient`, containing information pertaining
-     +  to the bot in the context of the current (alive) connection.
+     +  to the bot in the context of a client connected to an IRC server.
      +/
     IRCClient client;
+
+    /++
+     +  The current `kameloso.common.IRCBot`, containing information pertaining
+     +  to the bot in the context of an IRC bot.
+     +/
+    IRCBot bot;
 
     /// Thread ID to the main thread.
     Tid mainThread;

--- a/source/kameloso/plugins/connect.d
+++ b/source/kameloso/plugins/connect.d
@@ -80,7 +80,7 @@ void onSelfpart(ConnectService service, const IRCEvent event)
         if (index != -1)
         {
             bot.channels = bot.channels.remove!(SwapStrategy.unstable)(index);
-            client.updated = true;
+            botUpdated = true;
         }
         else
         {
@@ -117,7 +117,7 @@ void onSelfjoin(ConnectService service, const IRCEvent event)
         {
             // Track new channel in the channels array
             bot.channels ~= event.channel;
-            client.updated = true;
+            botUpdated = true;
         }
     }
 }
@@ -543,7 +543,7 @@ void onNickInUse(ConnectService service)
             service.renamedDuringRegistration = true;
         }
 
-        service.state.client.updated = true;
+        service.state.clientUpdated = true;
         raw(service.state, "NICK " ~ service.state.client.nickname);
     }
 }
@@ -899,7 +899,7 @@ void onWelcome(ConnectService service, const IRCEvent event)
     if (event.target.nickname.length && (service.state.client.nickname != event.target.nickname))
     {
         service.state.client.nickname = event.target.nickname;
-        service.state.client.updated = true;
+        service.state.clientUpdated = true;
     }
 
     version(TwitchSupport) {}

--- a/source/kameloso/plugins/persistence.d
+++ b/source/kameloso/plugins/persistence.d
@@ -43,7 +43,7 @@ void postprocess(PersistenceService service, ref IRCEvent event)
         {
             import std.algorithm.searching : canFind;
 
-            if (service.state.client.admins.canFind(userToClassify.account))
+            if (service.state.bot.admins.canFind(userToClassify.account))
             {
                 // Admins are (currently) stored in an array IRCClient.admins
                 userToClassify.class_ = IRCUser.Class.admin;

--- a/source/kameloso/plugins/printer.d
+++ b/source/kameloso/plugins/printer.d
@@ -1034,6 +1034,8 @@ if (isOutputRange!(Sink, char[]))
                         case SELFJOIN:
                         case PART:
                         case SELFPART:
+                        case QUERY:
+                        //case SELFQUERY:  // Doesn't seem to happen
                             break;
 
                         default:

--- a/source/kameloso/plugins/printer.d
+++ b/source/kameloso/plugins/printer.d
@@ -415,7 +415,7 @@ void onLoggableEvent(PrinterPlugin plugin, const IRCEvent event)
     import std.algorithm.searching : canFind;
 
     if (!plugin.printerSettings.logAllChannels &&
-        event.channel.length && !plugin.state.client.homes.canFind(event.channel))
+        event.channel.length && !plugin.state.bot.homes.canFind(event.channel))
     {
         // Not logging all channels and this is not a home.
         return;
@@ -616,7 +616,7 @@ void onLoggableEvent(PrinterPlugin plugin, const IRCEvent event)
         // channels this user is in (that the bot is also in)
         foreach (immutable channelName, const foreachChannel; state.channels)
         {
-            if (!printerSettings.logAllChannels && !state.client.homes.canFind(channelName))
+            if (!printerSettings.logAllChannels && !state.bot.homes.canFind(channelName))
             {
                 // Not logging all channels and this is not a home.
                 continue;

--- a/source/kameloso/plugins/twitchbot.d
+++ b/source/kameloso/plugins/twitchbot.d
@@ -99,7 +99,7 @@ void onAnyMessage(TwitchBotPlugin plugin, const IRCEvent event)
         }
 
         if ((event.sender.nickname == plugin.state.client.nickname) ||
-            plugin.state.client.admins.canFind(event.sender.nickname) ||
+            plugin.state.bot.admins.canFind(event.sender.nickname) ||
             event.sender.badges.contains("mode"/*rator*/))
         {
             return;
@@ -1708,7 +1708,7 @@ void postprocess(TwitchBotPlugin plugin, ref IRCEvent event)
             {
                 if ((*channelRegulars).canFind(user.nickname))
                 {
-                    user.class_ = plugin.state.client.admins.canFind(user.nickname) ?
+                    user.class_ = plugin.state.bot.admins.canFind(user.nickname) ?
                         IRCUser.Class.admin : IRCUser.Class.whitelist;
                 }
             }


### PR DESCRIPTION
This moves some members out of `dialect.defs.IRCClient` into a new `kameloso.common.IRCBot`.

These are values that relate to an IRC bot more than it does to an IRC client. They rightfully have no place in `dialect`, so make room for them here instead.