### PR TITLE
AppVeyor singleFile

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,10 +7,12 @@ environment:
       DVersion: 2.089.1
       DSubversion:
       arch: x64
+      dubArgs: --build-mode=singleFile
     - DC: ldc
       DVersion: 1.19.0
       DSubversion:
       arch: x64
+      dubArgs:
 
 skip_tags: true
 branches:
@@ -105,14 +107,14 @@ test_script:
  - echo %PATH%
  - '%DC% --version'
  - echo Full tests may fail due to https://issues.dlang.org/show_bug.cgi?id=20048
- - dub test           --arch=%Darch% --compiler=%DC% || true
- - dub test  --nodeps --arch=%Darch% --compiler=%DC% -c vanilla
-#- dub build --nodeps --arch=%Darch% --compiler=%DC% -b plain -c dev || true
-#- dub build --nodeps --arch=%Darch% --compiler=%DC% -b plain -c vanilla  || true
- - dub build --nodeps --arch=%Darch% --compiler=%DC% -b debug -c dev
+ - dub test           --arch=%Darch% --compiler=%DC% %dubArgs% || true
+ - dub test  --nodeps --arch=%Darch% --compiler=%DC% %dubArgs% -c vanilla
+ - dub build --nodeps --arch=%Darch% --compiler=%DC% %dubArgs% -b plain -c dev || true
+ - dub build --nodeps --arch=%Darch% --compiler=%DC% %dubArgs% -b plain -c vanilla || true
+ - dub build --nodeps --arch=%Darch% --compiler=%DC% %dubArgs% -b debug -c dev
  - mv kameloso.exe kameloso-dev.exe
- - dub build --nodeps --arch=%Darch% --compiler=%DC% -b debug -c twitch
+ - dub build --nodeps --arch=%Darch% --compiler=%DC% %dubArgs% -b debug -c twitch
  - mv kameloso.exe kameloso-twitch.exe
- - dub build --nodeps --arch=%Darch% --compiler=%DC% -b debug -c vanilla
+ - dub build --nodeps --arch=%Darch% --compiler=%DC% %dubArgs% -b debug -c vanilla
  - mv kameloso.exe kameloso-vanilla.exe
- - dub build --nodeps --arch=%Darch% --compiler=%DC% -b debug -c full
+ - dub build --nodeps --arch=%Darch% --compiler=%DC% %dubArgs% -b debug -c full

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -116,10 +116,10 @@ install:
             popd;
         }
   - ps: SetUpDCompiler
+  - set PATH=%CD%\%binpath%;%CD%\dub;%PATH%
   - dub --version || true
   - ps: Invoke-WebRequest https://code.dlang.org/files/dub-1.11.0-windows-x86.zip -OutFile dub.zip
   - 7z x dub.zip -odub > nul
-  - set PATH=%CD%\%binpath%;%CD%\dub;%PATH%
   - dub --version
 
 before_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -134,13 +134,15 @@ before_build:
             $env:DConf = "m64";
         }
   - ps : if($env:DC -eq "dmd"){
-           $env:PATH += ";C:\dmd2\windows\bin;";
+           $path = $env:PATH;
+           $env:PATH = "C:\dmd2\windows\bin;$($path)";
          }
          elseif($env:DC -eq "ldc"){
            $version = $env:DVersion;
            $subversion = $env:DSubversion;
            $arch = $env:arch;
-           $env:PATH += ";C:\ldc2-$($version)$($subversion)-windows-$($arch)\bin";
+           $path = $env:PATH;
+           $env:PATH = "C:\ldc2-$($version)$($subversion)-windows-$($arch)\bin;$($path)";
            $env:DC = "ldc2";
          }
   - ps: $env:compilersetup = "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall";

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -101,41 +101,19 @@ artifacts:
 install:
   - ps: function SetUpDCompiler
         {
+            $version = $env:DVersion;
+            $subversion = $env:DSubversion;
             if($env:DC -eq "dmd"){
-              if($env:arch -eq "x86"){
-                $env:DConf = "m32";
-              }
-              elseif($env:arch -eq "x64"){
-                $env:DConf = "m64";
-              }
-              echo "downloading ...";
-              $env:toolchain = "msvc";
               $releasetype = $env:DReleaseType;
-              $version = $env:DVersion;
-              $subversion = $env:DSubversion;
-              Invoke-WebRequest "http://downloads.dlang.org/$($releasetype)/2.x/$($version)/dmd.$($version)$($subversion).windows.7z" -OutFile "c:\dmd.7z";
-              echo "finished.";
-              pushd c:\\;
-              7z x dmd.7z > $null;
-              popd;
+              Invoke-WebRequest "http://downloads.dlang.org/$($releasetype)/2.x/$($version)/dmd.$($version)$($subversion).windows.7z" -OutFile "c:\compiler.archive";
             }
             elseif($env:DC -eq "ldc"){
-              echo "downloading ...";
-              if($env:arch -eq "x86"){
-                $env:DConf = "m32";
-              }
-              elseif($env:arch -eq "x64"){
-                $env:DConf = "m64";
-              }
-              $env:toolchain = "msvc";
-              $version = $env:DVersion;
-              $subversion = $env:DSubversion;
-              Invoke-WebRequest "https://github.com/ldc-developers/ldc/releases/download/v$($version)$($subversion)/ldc2-$($version)$($subversion)-windows-x64.7z" -OutFile "c:\ldc.7z";
-              echo "finished.";
-              pushd c:\\;
-              7z x ldc.7z > $null;
-              popd;
+              $arch = $env:arch;
+              Invoke-WebRequest "https://github.com/ldc-developers/ldc/releases/download/v$($version)$($subversion)/ldc2-$($version)$($subversion)-windows-$($arch).7z" -OutFile "c:\compiler.archive";
             }
+            pushd c:\\;
+            7z x compiler.archive > $null;
+            popd;
         }
   - ps: SetUpDCompiler
   - ps: Invoke-WebRequest https://code.dlang.org/files/dub-1.11.0-windows-x86.zip -OutFile dub.zip
@@ -144,13 +122,16 @@ install:
   - dub --version
 
 before_build:
+  - ps: $env:toolchain = "msvc";
   - ps: if($env:arch -eq "x86"){
             $env:compilersetupargs = "x86";
             $env:Darch = "x86";
+            $env:DConf = "m32";
           }
         elseif($env:arch -eq "x64"){
             $env:compilersetupargs = "amd64";
             $env:Darch = "x86_64";
+            $env:DConf = "m64";
         }
   - ps : if($env:DC -eq "dmd"){
            $env:PATH += ";C:\dmd2\windows\bin;";
@@ -158,7 +139,8 @@ before_build:
          elseif($env:DC -eq "ldc"){
            $version = $env:DVersion;
            $subversion = $env:DSubversion;
-           $env:PATH += ";C:\ldc2-$($version)$($subversion)-windows-x64\bin";
+           $arch = $env:arch;
+           $env:PATH += ";C:\ldc2-$($version)$($subversion)-windows-$($arch)\bin";
            $env:DC = "ldc2";
          }
   - ps: $env:compilersetup = "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall";

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,14 +4,81 @@ environment:
   matrix:
     - DC: dmd
       DReleaseType: releases
+      DVersion: 2.090.1
+      DSubversion:
+      arch: x64
+      dubArgs: --build-mode=singleFile
+    - DC: dmd
+      DReleaseType: releases
+      DVersion: 2.090.1
+      DSubversion:
+      arch: x86
+      dubArgs: --build-mode=singleFile
+    - DC: dmd
+      DReleaseType: releases
       DVersion: 2.089.1
       DSubversion:
       arch: x64
       dubArgs: --build-mode=singleFile
+    - DC: dmd
+      DReleaseType: releases
+      DVersion: 2.089.1
+      DSubversion:
+      arch: x86
+      dubArgs: --build-mode=singleFile
+    - DC: dmd
+      DReleaseType: releases
+      DVersion: 2.088.1
+      DSubversion:
+      arch: x64
+      dubArgs:
+    - DC: dmd
+      DReleaseType: releases
+      DVersion: 2.088.1
+      DSubversion:
+      arch: x86
+      dubArgs:
+    - DC: dmd
+      DReleaseType: releases
+      DVersion: 2.084.0
+      DSubversion:
+      arch: x64
+      dubArgs:
+    - DC: dmd
+      DReleaseType: releases
+      DVersion: 2.084.0
+      DSubversion:
+      arch: x86
+      dubArgs:
+    - DC: ldc
+      DVersion: 1.20.0
+      DSubversion:
+      arch: x64
+      dubArgs:
+    - DC: ldc
+      DVersion: 1.20.0
+      DSubversion:
+      arch: x86
+      dubArgs:
     - DC: ldc
       DVersion: 1.19.0
       DSubversion:
       arch: x64
+      dubArgs:
+    - DC: ldc
+      DVersion: 1.19.0
+      DSubversion:
+      arch: x86
+      dubArgs:
+    - DC: ldc
+      DVersion: 1.18.0
+      DSubversion:
+      arch: x64
+      dubArgs:
+    - DC: ldc
+      DVersion: 1.18.0
+      DSubversion:
+      arch: x86
       dubArgs:
 
 skip_tags: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -116,11 +116,10 @@ install:
             popd;
         }
   - ps: SetUpDCompiler
-  - set PATH=%CD%\%binpath%;%CD%\dub;%PATH%
-  - dub --version || true
   - ps: Invoke-WebRequest https://code.dlang.org/files/dub-1.11.0-windows-x86.zip -OutFile dub.zip
   - 7z x dub.zip -odub > nul
-  - dub --version
+  - set PATH=%CD%\%binpath%;%CD%\dub;%PATH%
+  #- dub --version
 
 before_build:
   - ps: $env:toolchain = "msvc";

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -116,6 +116,7 @@ install:
             popd;
         }
   - ps: SetUpDCompiler
+  - dub --version || true
   - ps: Invoke-WebRequest https://code.dlang.org/files/dub-1.11.0-windows-x86.zip -OutFile dub.zip
   - 7z x dub.zip -odub > nul
   - set PATH=%CD%\%binpath%;%CD%\dub;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,6 +65,11 @@ environment:
       DSubversion:
       arch: x64
       dubArgs:
+    - DC: ldc
+      DVersion: 1.14.0
+      DSubversion:
+      arch: x64
+      dubArgs:
 
 skip_tags: true
 branches:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,29 +56,14 @@ environment:
       arch: x64
       dubArgs:
     - DC: ldc
-      DVersion: 1.20.0
-      DSubversion:
-      arch: x86
-      dubArgs:
-    - DC: ldc
       DVersion: 1.19.0
-      DSubversion:
-      arch: x64
-      dubArgs:
-    - DC: ldc
-      DVersion: 1.19.0
-      DSubversion:
-      arch: x86
-      dubArgs:
-    - DC: ldc
-      DVersion: 1.18.0
       DSubversion:
       arch: x64
       dubArgs:
     - DC: ldc
       DVersion: 1.18.0
       DSubversion:
-      arch: x86
+      arch: x64
       dubArgs:
 
 skip_tags: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -106,10 +106,6 @@ install:
             popd;
         }
   - ps: SetUpDCompiler
-  - ps: Invoke-WebRequest https://code.dlang.org/files/dub-1.11.0-windows-x86.zip -OutFile dub.zip
-  - 7z x dub.zip -odub > nul
-  - set PATH=%CD%\%binpath%;%CD%\dub;%PATH%
-  #- dub --version
 
 before_build:
   - ps: $env:toolchain = "msvc";

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -157,7 +157,7 @@ test_script:
  - echo %PATH%
  - '%DC% --version'
  - echo Full tests may fail due to https://issues.dlang.org/show_bug.cgi?id=20048
- - dub test           --arch=%Darch% --compiler=%DC% %dubArgs% || true
+ - dub test           --arch=%Darch% --compiler=%DC% %dubArgs%
  - dub test  --nodeps --arch=%Darch% --compiler=%DC% %dubArgs% -c vanilla
  - dub build --nodeps --arch=%Darch% --compiler=%DC% %dubArgs% -b plain -c dev || true
  - dub build --nodeps --arch=%Darch% --compiler=%DC% %dubArgs% -b plain -c vanilla || true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -157,6 +157,7 @@ test_script:
  - echo %DC%
  - echo %PATH%
  - '%DC% --version'
+ - dub --version
  - echo Full tests may fail due to https://issues.dlang.org/show_bug.cgi?id=20048
  - dub test           --arch=%Darch% --compiler=%DC% %dubArgs%
  - dub test  --nodeps --arch=%Darch% --compiler=%DC% %dubArgs% -c vanilla

--- a/dub.sdl
+++ b/dub.sdl
@@ -43,6 +43,15 @@ configuration "posix" {
     buildRequirements "silenceDeprecations"
 }
 
+configuration "windows-dmd-needs-singlefile" {
+    platforms "windows"
+    toolchainRequirements dmd="yes" ldc="no" gdc="no" frontend=">=2.088.0"
+    versions "WithPlugins" "Colours" "Web" "WindowsDMDNeedsSingleFile"
+    dependency "requests" version="~>1.0.9"
+    dependency "arsd-official:dom" version="~>4.0.3"
+    buildRequirements "silenceDeprecations"
+}
+
 configuration "windows" {
     platforms "windows"
     versions "WithPlugins" "Colours" "Web"

--- a/dub.sdl
+++ b/dub.sdl
@@ -43,15 +43,6 @@ configuration "posix" {
     buildRequirements "silenceDeprecations"
 }
 
-configuration "windows-dmd-needs-singlefile" {
-    platforms "windows"
-    toolchainRequirements dmd="yes" ldc="no" gdc="no" frontend=">=2.088.0"
-    versions "WithPlugins" "Colours" "Web" "WindowsDMDNeedsSingleFile"
-    dependency "requests" version="~>1.0.9"
-    dependency "arsd-official:dom" version="~>4.0.3"
-    buildRequirements "silenceDeprecations"
-}
-
 configuration "windows" {
     platforms "windows"
     versions "WithPlugins" "Colours" "Web"

--- a/source/kameloso/kameloso.d
+++ b/source/kameloso/kameloso.d
@@ -63,6 +63,22 @@ static if (__VERSION__ <= 2088L)
 }
 
 
+/*
+    Warn about bug #20562: [dmd] Memory allocation failed (ERROR: This is a compiler bug)
+
+    It only affects Windows on build modes other than `singleFile`. Defer to dub.sdl
+    for setting the `WindowsBrokenDMD` version for signaling such cases, limiting
+    it to one place.
+ */
+version(WindowsDMDNeedsSingleFile)
+{
+    pragma(msg, "NOTE: Compilation might not succeed on Windows outside of " ~
+        "single-file build mode. If building fails with an `OutOfMemoryError` " ~
+        "compiler error, rebuild with `dub build --build-mode=singleFile`.");
+    pragma(msg, "See bug #20562 at https://issues.dlang.org/show_bug.cgi?id=20562");
+}
+
+
 // signalHandler
 /++
  +  Called when a signal is raised, usually `SIGINT`.

--- a/source/kameloso/kameloso.d
+++ b/source/kameloso/kameloso.d
@@ -37,53 +37,6 @@ __gshared bool abort;
 
 private:
 
-/+
-    Warn about bug #18026; Stack overflow in ddmd/dtemplate.d:6241, TemplateInstance::needsCodegen()
-
-    It may have been fixed in versions in the future at time of writing, so
-    limit it to 2.086 and earlier. Update this condition as compilers are released.
-
-    Exempt DDoc generation, as it doesn't seem to trigger the segfaults.
- +/
-static if (__VERSION__ <= 2088L)
-{
-    debug
-    {
-        // Everything is fine in debug mode
-    }
-    else version(D_Ddoc)
-    {
-        // Also fine
-    }
-    else
-    {
-        pragma(msg, "NOTE: Compilation might not succeed outside of debug mode.");
-        pragma(msg, "See bug #18026 at https://issues.dlang.org/show_bug.cgi?id=18026");
-    }
-}
-
-
-/*
-    Warn about bug #20562: [dmd] Memory allocation failed (ERROR: This is a compiler bug)
-
-    It only affects Windows with DMD 2.089.0 or later, on build modes other than
-    `singleFile`. Constrain with an upper major version as the issue is fixed.
- */
-version(Windows)
-{
-    version(DigitalMars)
-    {
-        static if (__VERSION__ >= 2089L)
-        {
-            pragma(msg, "NOTE: Compilation might not succeed on Windows outside " ~
-                "of single-file build mode.");
-            pragma(msg, "If building fails with an `OutOfMemoryError` compiler " ~
-                "error, rebuild with `dub build --build-mode=singleFile`.");
-            pragma(msg, "See bug #20562 at https://issues.dlang.org/show_bug.cgi?id=20562");
-        }
-    }
-}
-
 
 // signalHandler
 /++

--- a/source/kameloso/kameloso.d
+++ b/source/kameloso/kameloso.d
@@ -66,16 +66,22 @@ static if (__VERSION__ <= 2088L)
 /*
     Warn about bug #20562: [dmd] Memory allocation failed (ERROR: This is a compiler bug)
 
-    It only affects Windows on build modes other than `singleFile`. Defer to dub.sdl
-    for setting the `WindowsBrokenDMD` version for signaling such cases, limiting
-    it to one place.
+    It only affects Windows with DMD 2.089.0 or later, on build modes other than
+    `singleFile`. Constrain with an upper major version as the issue is fixed.
  */
-version(WindowsDMDNeedsSingleFile)
+version(Windows)
 {
-    pragma(msg, "NOTE: Compilation might not succeed on Windows outside of " ~
-        "single-file build mode. If building fails with an `OutOfMemoryError` " ~
-        "compiler error, rebuild with `dub build --build-mode=singleFile`.");
-    pragma(msg, "See bug #20562 at https://issues.dlang.org/show_bug.cgi?id=20562");
+    version(DigitalMars)
+    {
+        static if (__VERSION__ >= 2089L)
+        {
+            pragma(msg, "NOTE: Compilation might not succeed on Windows outside " ~
+                "of single-file build mode.");
+            pragma(msg, "If building fails with an `OutOfMemoryError` compiler " ~
+                "error, rebuild with `dub build --build-mode=singleFile`.");
+            pragma(msg, "See bug #20562 at https://issues.dlang.org/show_bug.cgi?id=20562");
+        }
+    }
 }
 
 

--- a/source/kameloso/kameloso.d
+++ b/source/kameloso/kameloso.d
@@ -11,16 +11,32 @@ import lu.common : Next;
 
 version(ProfileGC)
 {
-    /++
-     +  Set some flags to tune the garbage collector and have it print profiling
-     +  information at program exit, iff version `ProfileGC`.
-     +/
-    extern(C)
-    __gshared string[] rt_options =
-    [
-        "gcopt=profile:1 gc:precise",
-        "scanDataSeg=precise",
-    ];
+    static if (__VERSION__ >= 2085L)
+    {
+        /++
+         +  Set some flags to tune the garbage collector and have it print
+         +  profiling information at program exit, iff version `ProfileGC`.
+         +  Enables the precise garbage collector.
+         +/
+        extern(C)
+        __gshared string[] rt_options =
+        [
+            "gcopt=profile:1 gc:precise",
+            "scanDataSeg=precise",
+        ];
+    }
+    else
+    {
+        /++
+         +  Set some flags to tune the garbage collector and have it print
+         +  profiling information at program exit, iff version `ProfileGC`.
+         +/
+        extern(C)
+        __gshared string[] rt_options =
+        [
+            "gcopt=profile:1",
+        ];
+    }
 }
 
 

--- a/source/kameloso/main.d
+++ b/source/kameloso/main.d
@@ -3,6 +3,55 @@
  +/
 module kameloso.main;
 
+
+/+
+    Warn about bug #18026; Stack overflow in ddmd/dtemplate.d:6241, TemplateInstance::needsCodegen()
+
+    It may have been fixed in versions in the future at time of writing, so
+    limit it to 2.086 and earlier. Update this condition as compilers are released.
+
+    Exempt DDoc generation, as it doesn't seem to trigger the segfaults.
+ +/
+static if (__VERSION__ <= 2088L)
+{
+    debug
+    {
+        // Everything is fine in debug mode
+    }
+    else version(D_Ddoc)
+    {
+        // Also fine
+    }
+    else
+    {
+        pragma(msg, "NOTE: Compilation might not succeed outside of debug mode.");
+        pragma(msg, "See bug #18026 at https://issues.dlang.org/show_bug.cgi?id=18026");
+    }
+}
+
+
+/*
+    Warn about bug #20562: [dmd] Memory allocation failed (ERROR: This is a compiler bug)
+
+    It only affects Windows with DMD 2.089.0 or later, on build modes other than
+    `singleFile`. Constrain with an upper major version as the issue is fixed.
+ */
+version(Windows)
+{
+    version(DigitalMars)
+    {
+        static if (__VERSION__ >= 2089L)
+        {
+            pragma(msg, "NOTE: Compilation might not succeed on Windows outside " ~
+                "of single-file build mode.");
+            pragma(msg, "If building fails with an `OutOfMemoryError` compiler " ~
+                "error, rebuild with `dub build --build-mode=singleFile`.");
+            pragma(msg, "See bug #20562 at https://issues.dlang.org/show_bug.cgi?id=20562");
+        }
+    }
+}
+
+
 version(unittest)
 /++
  +  Unit-testing main; does nothing.


### PR DESCRIPTION
This "fixes" compile errors on Windows with dmd 2.089 and higher by suggesting use of `--build-mode=singleFile` in the terminal, on building. It is up to the user to use this, or not. AppVeyor unit tests are altered to build with this flag.

As an addition, `appveyor.yml` is changed to now build the project under the latest 3 compiler versions, as well as with the earliest possible version based on 2.084.