### PR TITLE
Connection summary on exit

### DIFF
--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -645,6 +645,21 @@ struct Kameloso
             plugin.state.bot = bot;
         }
     }
+
+    /++
+     +  A record of a successful connection.
+     +/
+    struct ConnectionHistoryEntry
+    {
+        /// UNIX time when a conection was established.
+        long startTime;
+
+        /// UNIX time when a connection was lost.
+        long stopTime;
+    }
+
+    /// History records of established connections this execution run.
+    ConnectionHistoryEntry[] connectionHistory;
 }
 
 

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -661,6 +661,9 @@ struct Kameloso
 
         /// UNIX time when a connection was lost.
         long stopTime;
+
+        /// How many events fired during a connection.
+        long numEvents;
     }
 
     /// History records of established connections this execution run.

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -125,6 +125,9 @@ struct CoreSettings
     /// Whether to endlessly connect or whether to give up after a while.
     bool endlesslyConnect = true;
 
+    /// Whether or not to display a connection summary on program exit.
+    bool exitSummary = false;
+
     /// Character(s) that prefix a bot chat command.
     @Quoted string prefix = "!";
 

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -646,6 +646,8 @@ struct Kameloso
         }
     }
 
+
+    // ConnectionHistoryEntry
     /++
      +  A record of a successful connection.
      +/

--- a/source/kameloso/getopt.d
+++ b/source/kameloso/getopt.d
@@ -436,6 +436,8 @@ Next handleGetopt(ref Kameloso instance, string[] args, ref string[] customSetti
             "r|resourceDir","Specify a different resource directory [%s]"
                             .format(settings.resourceDirectory),
                             &settings.resourceDirectory,
+            "summary",      "Show a connection summary on program exit",
+                            &settings.exitSummary,
             "force",        "Force connect (skips some sanity checks)",
                             &settings.force,
             "w|writeconfig","Write configuration to file",

--- a/source/kameloso/kameloso.d
+++ b/source/kameloso/kameloso.d
@@ -565,10 +565,17 @@ Next mainLoop(ref Kameloso instance)
         }
     }
 
+    /++
+     +  A snapshot of `settings.exitSummary` to use instead of it, so that
+     +  toggling it mid-execution does nothing. It would not know the connection
+     +  established timestamp and so would give an invalid connection duration.
+     +/
+    immutable exitSummary = settings.exitSummary;
+
     /// The index of the current `ConnectionHistoryIndex` in `instance.connectionHistory`.
     size_t historyEntryIndex;
 
-    if (settings.exitSummary)
+    if (exitSummary)
     {
         historyEntryIndex = instance.connectionHistory.length;  // snapshot index, 0 at first
         instance.connectionHistory ~= Kameloso.ConnectionHistoryEntry.init;
@@ -642,7 +649,7 @@ Next mainLoop(ref Kameloso instance)
                 return Next.returnFailure;
             }
 
-            if (settings.exitSummary)
+            if (exitSummary)
             {
                 // Successful read; record as such
                 instance.connectionHistory[historyEntryIndex].stopTime = nowInUnix;
@@ -729,7 +736,7 @@ Next mainLoop(ref Kameloso instance)
 
                 event.time = Clock.currTime.toUnixTime;
 
-                if (settings.exitSummary)
+                if (exitSummary)
                 {
                     // Successful parse
                     ++instance.connectionHistory[historyEntryIndex].numEvents;

--- a/source/kameloso/kameloso.d
+++ b/source/kameloso/kameloso.d
@@ -2311,6 +2311,35 @@ int initBot(string[] args)
         instance.writeConfigurationFile(settings.configFile);
     }
 
+    // The connection history may be empty if exitSummary was set mid-execution.
+    if (settings.exitSummary && instance.connectionHistory.length)
+    {
+        import std.stdio : writefln;
+        import core.time : Duration;
+
+        Duration totalTime;
+
+        logger.info("Connection summary");
+
+        foreach (immutable i, const entry; instance.connectionHistory)
+        {
+            import std.datetime.systime : SysTime;
+            import core.time : msecs;
+
+            auto start = SysTime.fromUnixTime(entry.startTime);
+            start.fracSecs = 0.msecs;
+            auto stop = SysTime.fromUnixTime(entry.stopTime);
+            stop.fracSecs = 0.msecs;
+            immutable duration = (stop - start);
+            totalTime += duration;
+
+            writefln("%2d: %s, %d events parsed (%s to %s)",
+                i+1, duration, entry.numEvents, start, stop);
+        }
+
+        logger.info("Total time connected: ", logtint, totalTime);
+    }
+
     if (*instance.abort)
     {
         // Ctrl+C


### PR DESCRIPTION
Adds a summary report of connection statistics on program exit, enabled by a new getopt flag `--summary` and/or by setting `Core.exitSummary` in the configuration file.