### PR TITLE
IRCPluginState as ref parameter (in more places)

### DIFF
--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -976,7 +976,7 @@ struct Enabler;
  +  and deny use.
  +
  +  Params:
- +      state = The `IRCPluginState` of the invoking plugin.
+ +      state = Reference to the `IRCPluginState` of the invoking plugin.
  +      event = `dialect.defs.IRCEvent` to filter.
  +      level = The `PrivilegeLevel` context in which this user should be filtered.
  +
@@ -984,7 +984,7 @@ struct Enabler;
  +      A `FilterResult` saying the event should `pass`, `fail`, or that more
  +      information about the sender is needed via a `WHOIS` call.
  +/
-FilterResult filterSender(IRCPluginState state, const IRCEvent event,
+FilterResult filterSender(const ref IRCPluginState state, const IRCEvent event,
     const PrivilegeLevel level) @safe
 {
     import kameloso.constants : Timeout;
@@ -1102,7 +1102,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
         static if (getSymbolsByUDA!(typeof(this), Settings).length)
         {
             top:
-            foreach (immutable i, immutable member; this.tupleof)
+            foreach (immutable i, const ref member; this.tupleof)
             {
                 static if (hasUDA!(this.tupleof[i], Settings))
                 {
@@ -1881,7 +1881,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
 
         string[][string] invalidEntries;
 
-        foreach (immutable i, ref symbol; this.tupleof)
+        foreach (immutable i, const ref symbol; this.tupleof)
         {
             static if (hasUDA!(this.tupleof[i], Settings) &&
                 (is(typeof(this.tupleof[i]) == struct)))
@@ -1973,7 +1973,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
         import std.traits : hasUDA;
         import std.typecons : No, Yes;
 
-        foreach (immutable i, symbol; this.tupleof)
+        foreach (immutable i, const ref symbol; this.tupleof)
         {
             static if (hasUDA!(this.tupleof[i], Settings) &&
                 (is(typeof(this.tupleof[i]) == struct)))
@@ -2007,7 +2007,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
         import lu.serialisation : serialise;
         import std.traits : hasUDA;
 
-        foreach (immutable i, symbol; this.tupleof)
+        foreach (immutable i, ref symbol; this.tupleof)
         {
             static if (hasUDA!(this.tupleof[i], Settings) &&
                 (is(typeof(this.tupleof[i]) == struct)))

--- a/source/kameloso/plugins/ctcp.d
+++ b/source/kameloso/plugins/ctcp.d
@@ -216,7 +216,8 @@ unittest
     // `dialect.defs.IRCEvent.Type`s.
     import std.traits : getUDAs;
 
-    auto service = new CTCPService(IRCPluginState.init);
+    IRCPluginState state;
+    auto service = new CTCPService(state);
 
     foreach (immutable type; getUDAs!(onCTCPs, IRCEvent.Type))
     {

--- a/source/kameloso/printing.d
+++ b/source/kameloso/printing.d
@@ -67,7 +67,8 @@ public:
  +      widthArg = The width with which to pad output columns.
  +      things = Variadic list of struct objects to enumerate.
  +/
-void printObjects(Flag!"printAll" printAll = No.printAll, uint widthArg = 0, Things...)(Things things) @trusted
+void printObjects(Flag!"printAll" printAll = No.printAll, uint widthArg = 0, Things...)
+    (auto ref Things things) @trusted
 {
     import kameloso.common : settings;
     import std.stdio : stdout;
@@ -136,7 +137,7 @@ alias printObject = printObjects;
  +/
 void formatObjects(Flag!"printAll" printAll = No.printAll,
     Flag!"coloured" coloured = Yes.coloured, uint widthArg = 0, Sink, Things...)
-    (auto ref Sink sink, const bool bright, Things things)
+    (auto ref Sink sink, const bool bright, auto ref Things things)
 if (isOutputRange!(Sink, char[]))
 {
     import std.algorithm.comparison : max;
@@ -175,7 +176,7 @@ if (isOutputRange!(Sink, char[]))
         (initialWidth - typewidth + minimumTypeWidth) : initialWidth;
     enum ptrdiff_t namewidth = max(minimumNameWidth, compensatedWidth);
 
-    foreach (immutable n, thing; things)
+    foreach (immutable n, const ref thing; things)
     {
         import lu.string : stripSuffix;
         import std.format : formattedWrite;


### PR DESCRIPTION
It's huge so we really don't want to copy it more than is absolutely
necessary. We can't `@disable this(this)` as this breaks making easy
copies of it for concurrency messages. It's possible to create a `.dup`
member function that returns by value, but there's little gain to be had
and more complexity.

Just pass by (const) ref wherever appropriate.