### PR TITLE
AppVeyor: Disable selected dmd versions

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,14 +36,14 @@ environment:
       DSubversion:
       arch: x64
       dubArgs: --build-mode=singleFile
-      Ddflags:
+      Ddflags: -lowmem
     - DC: dmd
       DReleaseType: releases
       DVersion: 2.089.1
       DSubversion:
       arch: x86
       dubArgs: --build-mode=singleFile
-      Ddflags:
+      Ddflags: -lowmem
     - DC: dmd
       DReleaseType: releases
       DVersion: 2.084.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,13 +30,13 @@ environment:
       arch: x86
       dubArgs: --build-mode=singleFile
       Ddflags: -lowmem
-    - DC: dmd
-      DReleaseType: releases
-      DVersion: 2.089.1
-      DSubversion:
-      arch: x64
-      dubArgs: --build-mode=singleFile
-      Ddflags: -lowmem
+    #- DC: dmd
+      #DReleaseType: releases
+      #DVersion: 2.089.1
+      #DSubversion:
+      #arch: x64
+      #dubArgs: --build-mode=singleFile
+      #Ddflags: -lowmem
     - DC: dmd
       DReleaseType: releases
       DVersion: 2.089.1


### PR DESCRIPTION
Because of OutOfMemoryErrors.