### PR TITLE
mixin constraints

### DIFF
--- a/source/kameloso/plugins/chanqueries.d
+++ b/source/kameloso/plugins/chanqueries.d
@@ -128,7 +128,7 @@ void startChannelQueries(ChanQueriesService service)
                         "printer", busMessage(squelchMessage));
                 }
 
-                raw(service.state, command ~ ' ' ~ channelName);
+                raw(service.state, command ~ ' ' ~ channelName, service.hideOutgoingQueries);
                 Fiber.yield();  // Awaiting specified types
 
                 while (thisFiber.payload.channel != channelName) Fiber.yield();
@@ -181,7 +181,8 @@ void startChannelQueries(ChanQueriesService service)
                 }
 
                 import kameloso.messaging : mode;
-                mode(service.state, channelName, "+%c".format((cast(char)modechar)));
+                mode(service.state, channelName, "+%c".format((cast(char)modechar)),
+                    string.init, service.hideOutgoingQueries);
             }
 
             if (channelName !in service.channelStates) continue;
@@ -267,7 +268,7 @@ void startChannelQueries(ChanQueriesService service)
                     "printer", busMessage("squelch " ~ nickname));
             }
 
-            whois(service.state, nickname, false);
+            whois(service.state, nickname, false, service.hideOutgoingQueries);
             Fiber.yield();  // Await whois types registered above
 
             while (true)

--- a/source/kameloso/plugins/chanqueries.d
+++ b/source/kameloso/plugins/chanqueries.d
@@ -20,9 +20,16 @@ private:
 
 import kameloso.plugins.common;
 import dialect.defs;
-
 import std.typecons : No, Yes;
 
+version(OmniscientQueries)
+{
+    enum omniscientChannelPolicy = ChannelPolicy.any;
+}
+else
+{
+    enum omniscientChannelPolicy = ChannelPolicy.home;
+}
 
 // ChannelState
 /++
@@ -333,7 +340,7 @@ void startChannelQueries(ChanQueriesService service)
  +  channel states.
  +/
 @(IRCEvent.Type.SELFJOIN)
-@(ChannelPolicy.any)
+@omniscientChannelPolicy
 void onSelfjoin(ChanQueriesService service, const IRCEvent event)
 {
     service.channelStates[event.channel] = ChannelState.unset;
@@ -347,7 +354,7 @@ void onSelfjoin(ChanQueriesService service, const IRCEvent event)
  +/
 @(IRCEvent.Type.SELFPART)
 @(IRCEvent.Type.SELFKICK)
-@(ChannelPolicy.any)
+@omniscientChannelPolicy
 void onSelfpart(ChanQueriesService service, const IRCEvent event)
 {
     service.channelStates.remove(event.channel);

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -1175,17 +1175,53 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
 {
     private import core.thread : Fiber;
 
-    /*static assert (__traits(compiles, is(typeof(this))),
-        module_ ~ " mixes in IRCPluginImpl but it is supposed to be mixed in " ~
-        "inside an IRCPlugin subclass");*/
-
     static if (__traits(compiles, this.hasIRCPluginImpl))
     {
-        static assert(0, "Double mixin of IRCPluginImpl in " ~ typeof(this.stringof));
+        import std.format : format;
+        static assert(0, "Double mixin of `%s` in `%s`"
+            .format("IRCPluginImpl", typeof(this).stringof));
     }
     else
     {
         private enum hasIRCPluginImpl = true;
+    }
+
+    static if(!is(__traits(parent, hasIRCPluginImpl) : IRCPlugin))
+    {
+        import std.format : format;
+        import std.traits : isSomeFunction;
+
+        alias parent = __traits(parent, hasIRCPluginImpl);
+
+        static if (isSomeFunction!parent)
+        {
+            enum parentType = "function";
+            enum parentName = __FUNCTION__;
+        }
+        else static if (__traits(isModule, parent))
+        {
+            enum parentType = "module";
+            enum parentName = module_;
+        }
+        else static if (is(parent == class))
+        {
+            enum parentType = "class";
+            enum parentName = parent.stringof;
+        }
+        else static if (is(parent == struct))
+        {
+            enum parentType = "struct";
+            enum parentName = parent.stringof;
+        }
+        else
+        {
+            enum parentType = "(unknown)";
+            enum parentName = __traits(identifier, parent);
+        }
+
+        static assert(0, ("%s `%s` mixes in `%s` but it is only supposed to be " ~
+            "mixed into an `IRCPlugin` subclass")
+            .format(parentType, parentName, "IRCPluginImpl"));
     }
 
     @safe:
@@ -2504,21 +2540,54 @@ public:
     import std.functional : partial;
     import std.typecons : Flag, No, Yes;
 
-    /*static assert (__traits(compiles, typeof(this)),
-        module_ ~ " mixes in MessagingProxy but it is supposed to be mixed in " ~
-        "inside an IRCPlugin subclass");*/
-
     static if (__traits(compiles, this.hasMessagingProxy))
     {
-        static assert(0, "Double mixin of MessagingProxy in " ~ typeof(this.stringof));
+        import std.format : format;
+        static assert(0, "Double mixin of `%s` in `%s`"
+            .format("MessagingProxy", typeof(this).stringof));
     }
     else
     {
         private enum hasMessagingProxy = true;
     }
 
-    static assert(is(typeof(this) : IRCPlugin), "MessagingProxy should be " ~
-        "mixed into the context of a plugin or service.");
+    static if(!is(__traits(parent, hasMessagingProxy) : IRCPlugin))
+    {
+        import std.format : format;
+        import std.traits : isSomeFunction;
+
+        alias parent = __traits(parent, chan);
+
+        static if (isSomeFunction!parent)
+        {
+            enum parentType = "function";
+            enum parentName = __FUNCTION__;
+        }
+        else static if (__traits(isModule, parent))
+        {
+            enum parentType = "module";
+            enum parentName = module_;
+        }
+        else static if (is(parent == class))
+        {
+            enum parentType = "class";
+            enum parentName = parent.stringof;
+        }
+        else static if (is(parent == struct))
+        {
+            enum parentType = "struct";
+            enum parentName = parent.stringof;
+        }
+        else
+        {
+            enum parentType = "(unknown)";
+            enum parentName = __traits(identifier, parent);
+        }
+
+        static assert(0, ("%s `%s` mixes in `%s` but it is only supposed to be " ~
+            "mixed into an `IRCPlugin` subclass")
+            .format(parentType, parentName, "MessagingProxy"));
+    }
 
     pragma(inline):
 
@@ -2752,17 +2821,47 @@ public:
 version(WithPlugins)
 mixin template MinimalAuthentication(bool debug_ = false, string module_ = __MODULE__)
 {
-    static assert (!__traits(compiles, typeof(this).stringof),
-        module_ ~ '.' ~ typeof(this).stringof ~ " mixes in MinimalAuthentication " ~
-        "but it is supposed to be mixed in at module scope");
-
     static if (__traits(compiles, .hasMinimalAuthentication))
     {
-        static assert(0, "Double mixin of MinimalAuthentication in module " ~ module_);
+        import std.format : format;
+        static assert(0, "Double mixin of `%s` in `%s`"
+            .format("MinimalAuthentication", module_));
     }
     else
     {
         private enum hasMinimalAuthentication = true;
+    }
+
+    static if(!__traits(isModule, __traits(parent, hasMinimalAuthentication)))
+    {
+        import std.format : format;
+
+        alias parent = __traits(parent, hasMinimalAuthentication);
+
+        static if (isSomeFunction!parent)
+        {
+            enum parentType = "function";
+            enum parentName = __FUNCTION__;
+        }
+        else static if (is(parent == class))
+        {
+            enum parentType = "class";
+            enum parentName = parent.stringof;
+        }
+        else static if (is(parent == struct))
+        {
+            enum parentType = "struct";
+            enum parentName = parent.stringof;
+        }
+        else
+        {
+            enum parentType = "(unknown)";
+            enum parentName = __traits(identifier, parent);
+        }
+
+        static assert(0, ("%s `%s` mixes in `%s` but it is only supposed to be " ~
+            "mixed into a module-level scope")
+            .format(parentType, parentName, "MinimalAuthentication"));
     }
 
 
@@ -2881,12 +2980,53 @@ mixin template MinimalAuthentication(bool debug_ = false, string module_ = __MOD
  +      debug_ = Whether or not to print debug output to the terminal.
  +/
 version(WithPlugins)
-mixin template Replayer(bool debug_ = false)
+mixin template Replayer(bool debug_ = false, string module_ = __MODULE__)
 {
     import std.conv : text;
+    import std.traits : isSomeFunction;
 
-    private enum requestVariableName = text("_request", hashOf(__FUNCTION__) % 100);
-    mixin("TriggerRequest " ~ requestVariableName ~ ';');
+    static if (__traits(compiles, hasReplayer))
+    {
+        import std.format : format;
+        static assert(0, "Double mixin of `%s` in `%s`"
+            .format("Replayer", __FUNCTION__));
+    }
+    else
+    {
+        enum hasReplayer = true;
+    }
+
+    static if(!isSomeFunction!(__traits(parent, hasReplayer)))
+    {
+        import std.format : format;
+
+        alias parent = __traits(parent, hasReplayer);
+
+        static if (__traits(isModule, parent))
+        {
+            enum parentType = "module";
+            enum parentName = module_;
+        }
+        else static if (is(parent == class))
+        {
+            enum parentType = "class";
+            enum parentName = parent.stringof;
+        }
+        else static if (is(parent == struct))
+        {
+            enum parentType = "struct";
+            enum parentName = parent.stringof;
+        }
+        else
+        {
+            enum parentType = "(unknown)";
+            enum parentName = __traits(identifier, parent);
+        }
+
+        static assert(0, ("%s `%s` mixes in `%s` but it is only supposed to be " ~
+            "mixed into a function")
+            .format(parentType, parentName, "Replayer"));
+    }
 
     static if (__traits(compiles, plugin))
     {
@@ -2900,11 +3040,14 @@ mixin template Replayer(bool debug_ = false)
     }
     else
     {
-        static assert(0, "Replayer should be mixed into the context of an event handler. " ~
-            "(Could not access variables named neither `plugin` nor `service` from within " ~
-            __FUNCTION__ ~ ")");
+        import std.format : format;
+        static assert(0, ("`Replayer` should be mixed into the context of an event handler. " ~
+            "(Could not access variables named neither `plugin` nor `service` " ~
+            "from within `%s`)").format(__FUNCTION__));
     }
 
+    private enum requestVariableName = text("_request", hashOf(__FUNCTION__) % 100);
+    mixin("TriggerRequest " ~ requestVariableName ~ ';');
 
     // explainReplain
     /++
@@ -3035,17 +3178,47 @@ version(WithPlugins)
 mixin template UserAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home,
     bool debug_ = false, string module_ = __MODULE__)
 {
-    static assert (!__traits(compiles, typeof(this)),
-        module_ ~ '.' ~ typeof(this).stringof ~ " mixes in UserAwareness " ~
-        "but it is supposed to be mixed in at module scope");
-
     static if (__traits(compiles, .hasUserAwareness))
     {
-        static assert(0, "Double mixin of UserAwareness in module " ~ module_);
+        import std.format : format;
+        static assert(0, "Double mixin of `%s` in `%s`"
+            .format("UserAwareness", module_));
     }
     else
     {
         private enum hasUserAwareness = true;
+    }
+
+    static if(!__traits(isModule, __traits(parent, hasUserAwareness)))
+    {
+        import std.format : format;
+
+        alias parent = __traits(parent, hasUserAwareness);
+
+        static if (isSomeFunction!parent)
+        {
+            enum parentType = "function";
+            enum parentName = __FUNCTION__;
+        }
+        else static if (is(parent == class))
+        {
+            enum parentType = "class";
+            enum parentName = parent.stringof;
+        }
+        else static if (is(parent == struct))
+        {
+            enum parentType = "struct";
+            enum parentName = parent.stringof;
+        }
+        else
+        {
+            enum parentType = "(unknown)";
+            enum parentName = __traits(identifier, parent);
+        }
+
+        static assert(0, ("%s `%s` mixes in `%s` but it is only supposed to be " ~
+            "mixed into a module-level scope")
+            .format(parentType, parentName, "UserAwareness"));
     }
 
     static if (!__traits(compiles, .hasMinimalAuthentication))
@@ -3312,22 +3485,56 @@ version(WithPlugins)
 mixin template ChannelAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home,
     bool debug_ = false, string module_ = __MODULE__)
 {
-    static assert (!__traits(compiles, typeof(this)),
-        module_ ~ '.' ~ typeof(this).stringof ~ " mixes in ChannelAwareness " ~
-        "but it is supposed to be mixed in at module scope");
-
-    static assert(__traits(compiles, .hasUserAwareness), module_ ~
-        " is missing UserAwareness mixin (needed for ChannelAwareness).");
-
     static if (__traits(compiles, .hasChannelAwareness))
     {
-        static assert(0, "Double mixin of ChannelAwareness in module " ~ module_);
+        import std.format : format;
+        static assert(0, "Double mixin of `%s` in `%s`"
+            .format("ChannelAwareness", module_));
     }
     else
     {
         private enum hasChannelAwareness = true;
     }
 
+    static if(!__traits(isModule, __traits(parent, hasChannelAwareness)))
+    {
+        import std.format : format;
+
+        alias parent = __traits(parent, hasChannelAwareness);
+
+        static if (isSomeFunction!parent)
+        {
+            enum parentType = "function";
+            enum parentName = __FUNCTION__;
+        }
+        else static if (is(parent == class))
+        {
+            enum parentType = "class";
+            enum parentName = parent.stringof;
+        }
+        else static if (is(parent == struct))
+        {
+            enum parentType = "struct";
+            enum parentName = parent.stringof;
+        }
+        else
+        {
+            enum parentType = "(unknown)";
+            enum parentName = __traits(identifier, parent);
+        }
+
+        static assert(0, ("%s `%s` mixes in `%s` but it is only supposed to be " ~
+            "mixed into a module-level scope")
+            .format(parentType, parentName, "ChannelAwareness"));
+    }
+
+    static if (!__traits(compiles, .hasUserAwareness))
+    {
+        import std.format : format;
+        static assert(0, ("`%s` is missing a `UserAwareness` mixin " ~
+            "(needed for `ChannelAwareness`)")
+            .format(module_));
+    }
 
     // onChannelAwarenessSelfjoinMixin
     /++
@@ -3767,20 +3974,55 @@ version(TwitchSupport)
 mixin template TwitchAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home,
     bool debug_ = false, string module_ = __MODULE__)
 {
-    static assert (!__traits(compiles, typeof(this)),
-        module_ ~ '.' ~ typeof(this).stringof ~ " mixes in TwitchAwareness " ~
-        "but it is supposed to be mixed in at module scope");
-
-    static assert(__traits(compiles, .hasChannelAwareness), module_ ~
-        " is missing ChannelAwareness mixin (needed for TwitchAwareness).");
-
     static if (__traits(compiles, .hasTwitchAwareness))
     {
-        static assert(0, "Double mixin of TwitchAwareness in module " ~ module_);
+        import std.format : format;
+        static assert(0, "Double mixin of `%s` in `%s`"
+            .format("TwitchAwareness", module_));
     }
     else
     {
         private enum hasTwitchAwareness = true;
+    }
+
+    static if(!__traits(isModule, __traits(parent, hasTwitchAwareness)))
+    {
+        import std.format : format;
+
+        alias parent = __traits(parent, hasTwitchAwareness);
+
+        static if (isSomeFunction!parent)
+        {
+            enum parentType = "function";
+            enum parentName = __FUNCTION__;
+        }
+        else static if (is(parent == class))
+        {
+            enum parentType = "class";
+            enum parentName = parent.stringof;
+        }
+        else static if (is(parent == struct))
+        {
+            enum parentType = "struct";
+            enum parentName = parent.stringof;
+        }
+        else
+        {
+            enum parentType = "(unknown)";
+            enum parentName = __traits(identifier, parent);
+        }
+
+        static assert(0, ("%s `%s` mixes in `%s` but it is only supposed to be " ~
+            "mixed into a module-level scope")
+            .format(parentType, parentName, "TwitchAwareness"));
+    }
+
+    static if (!__traits(compiles, .hasChannelAwareness))
+    {
+        import std.format : format;
+        static assert(0, ("`%s` is missing a `ChannelAwareness` mixin " ~
+            "(needed for `TwitchAwareness`)")
+            .format(module_));
     }
 
 
@@ -3889,17 +4131,47 @@ else
 mixin template TwitchAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home,
     bool debug_ = false, string module_ = __MODULE__)
 {
-    static assert (!__traits(compiles, typeof(this)),
-        module_ ~ '.' ~ typeof(this).stringof ~ " mixes in TwitchAwareness " ~
-        "but it is supposed to be mixed in at module scope");
-
     static if (__traits(compiles, .hasTwitchAwareness))
     {
-        static assert(0, "Double mixin of TwitchAwareness in module " ~ module_);
+        import std.format : format;
+        static assert(0, "Double mixin of `%s` in `%s`"
+            .format("TwitchAwareness", module_));
     }
     else
     {
         private enum hasTwitchAwareness = true;
+    }
+
+    static if(!__traits(isModule, __traits(parent, hasTwitchAwareness)))
+    {
+        import std.format : format;
+
+        alias parent = __traits(parent, hasTwitchAwareness);
+
+        static if (isSomeFunction!parent)
+        {
+            enum parentType = "function";
+            enum parentName = __FUNCTION__;
+        }
+        else static if (is(parent == class))
+        {
+            enum parentType = "class";
+            enum parentName = parent.stringof;
+        }
+        else static if (is(parent == struct))
+        {
+            enum parentType = "struct";
+            enum parentName = parent.stringof;
+        }
+        else
+        {
+            enum parentType = "(unknown)";
+            enum parentName = __traits(identifier, parent);
+        }
+
+        static assert(0, ("%s `%s` mixes in `%s` but it is only supposed to be " ~
+            "mixed into a module-level scope")
+            .format(parentType, parentName, "TwitchAwareness"));
     }
 }
 
@@ -4494,6 +4766,49 @@ mixin template WHOISFiberDelegate(alias onSuccess, alias onFailure = null)
 if (isSomeFunction!onSuccess && (is(typeof(onFailure) == typeof(null)) || isSomeFunction!onFailure))
 {
     import std.conv : text;
+
+    static if (__traits(compiles, hasWHOISFiber))
+    {
+        import std.format : format;
+        static assert(0, "Double mixin of `%s` in `%s`"
+            .format("WHOISFiberDelegate", __FUNCTION__));
+    }
+    else
+    {
+        enum hasWHOISFiber = true;
+    }
+
+    static if(!isSomeFunction!(__traits(parent, hasWHOISFiber)))
+    {
+        import std.format : format;
+
+        alias parent = __traits(parent, hasWHOISFiber);
+
+        static if (__traits(isModule, parent))
+        {
+            enum parentType = "module";
+            enum parentName = module_;
+        }
+        else static if (is(parent == class))
+        {
+            enum parentType = "class";
+            enum parentName = parent.stringof;
+        }
+        else static if (is(parent == struct))
+        {
+            enum parentType = "struct";
+            enum parentName = parent.stringof;
+        }
+        else
+        {
+            enum parentType = "(unknown)";
+            enum parentName = __traits(identifier, parent);
+        }
+
+        static assert(0, ("%s `%s` mixes in `%s` but it is only supposed to be " ~
+            "mixed into a function")
+            .format(parentType, parentName, "WHOISFiberDelegate"));
+    }
 
     static if (__traits(compiles, plugin))
     {

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -1504,7 +1504,8 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                         static if (!commandUDA.string_.length)
                         {
                             import std.format : format;
-                            static assert(0, "`%s` has an empty `BotCommand.string_`".format(name));
+                            static assert(0, "`%s.%s` has an empty `BotCommand` string"
+                                .format(module_, __traits(identifier, fun)));
                         }
 
                         static if (verbose)

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -1673,9 +1673,11 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                         static if (!Enum!(IRCEvent.Type).toString(U).beginsWith("ERR_") &&
                             !Enum!(IRCEvent.Type).toString(U).beginsWith("RPL_"))
                         {
-                            pragma(msg, module_ ~ '.' ~ __traits(identifier, fun) ~
-                                " is annotated with IRCEvent.Type." ~
-                                Enum!(IRCEvent.Type).toString(U) ~ " but is missing a PrivilegeLevel.");
+                            import std.format : format;
+                            pragma(msg, ("`%s.%s` is annotated with " ~
+                                "`IRCEvent.Type.%s` but is missing a `PrivilegeLevel`")
+                                .format(module_, __traits(identifier, fun),
+                                Enum!(IRCEvent.Type).toString(U)));
                         }*/
 
                         static if (

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -1715,7 +1715,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                         {
                             import std.format : format;
                             static assert(0, ("`%s` is missing a `MinimalAuthentication` " ~
-                                "mixin (needed for `PrivilegeLevel` checks")
+                                "mixin (needed for `PrivilegeLevel` checks)")
                                 .format(module_));
                         }
                     }

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -284,8 +284,9 @@ private final class TriggerRequestImpl(F, Payload = typeof(null)) : TriggerReque
         else
         {
             import std.format : format;
-            static assert(0, "Unknown function signature in `TriggerRequestImpl`: `%s`"
-                .format(typeof(fn).stringof));
+            static assert(0, ("`TriggerRequestImpl` instantiated with an invalid " ~
+                "trigger function signature: `%s`")
+                .format(F.stringof));
         }
     }
 }
@@ -1412,7 +1413,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                 else static if (eventTypeUDA == IRCEvent.Type.PRIVMSG)
                 {
                     import std.format : format;
-                    static assert(0, ("`%s.%s` is annotated `IRCEvent.Type.PRIVMMSG`, " ~
+                    static assert(0, ("`%s.%s` is annotated `IRCEvent.Type.PRIVMSG`, " ~
                         "which is not a valid event type. Use `IRCEvent.Type.CHAN` " ~
                         "or `IRCEvent.Type.QUERY` instead")
                         .format(module_, __traits(identifier, fun)));
@@ -1422,8 +1423,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                     import std.format : format;
                     static assert(0, ("`%s.%s` is annotated `IRCEvent.Type.WHISPER`, " ~
                         "which is not a valid event type. Use `IRCEvent.Type.QUERY` instead")
-                        .format(module_, __traits(identifier, fun),
-                        Enum!(IRCEvent.Type).stringof(eventTypeUDA)));
+                        .format(module_, __traits(identifier, fun)));
                 }
                 else
                 {
@@ -1574,7 +1574,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                             static if (!regexUDA.expression.length)
                             {
                                 import std.format : format;
-                                static assert(0, "`%s.%s` has an incomplete `BotRegex` annotation"
+                                static assert(0, "`%s.%s` has an empty `BotRegex` expression"
                                     .format(module_, __traits(identifier, fun)));
                             }
 
@@ -1735,9 +1735,9 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                             IRCEvent, PrivilegeLevel))
                         {
                             import std.format : format;
-                            static assert(0, "Custom `allow` in `%s.%s` has an invalid signature: `%s`"
-                                .format(module_, typeof(this).stringof,
-                                    stringofParams!(__traits(getMember, this, "allow"))));
+                            static assert(0, ("Custom `allow` function in `%s.%s` " ~
+                                "has an invalid signature: `%s`")
+                                .format(module_, typeof(this).stringof, typeof(allow).stringof));
                         }
 
                         static if (verbose)
@@ -1799,9 +1799,9 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                         else static if (Filter!(isIRCPluginParam, Params).length)
                         {
                             import std.format : format;
-                            static assert(0, ("`%s.%s takes a superclass `IRCPlugin` " ~
-                                "instead of a subclass `%s`")
-                                .format(module_, __traits(identifier, fun), typeof(fun).stringof));
+                            static assert(0, ("`%s.%s` takes a superclass `IRCPlugin` " ~
+                                "parameter instead of a subclass `%s`")
+                                .format(module_, __traits(identifier, fun), This.stringof));
                         }
                         else
                         {

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -1183,42 +1183,17 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
         private enum hasIRCPluginImpl = true;
     }
 
+    // Use a custom constraint to force the scope to be an IRCPlugin
     static if(!is(__traits(parent, hasIRCPluginImpl) : IRCPlugin))
     {
         import std.format : format;
-        import std.traits : isSomeFunction;
 
         alias parent = __traits(parent, hasIRCPluginImpl);
-
-        static if (isSomeFunction!parent)
-        {
-            enum parentType = "function";
-            enum parentName = __FUNCTION__;
-        }
-        else static if ((__VERSION__ >= 2087L) && __traits(isModule, parent))
-        {
-            enum parentType = "module";
-            enum parentName = module_;
-        }
-        else static if (is(parent == class))
-        {
-            enum parentType = "class";
-            enum parentName = parent.stringof;
-        }
-        else static if (is(parent == struct))
-        {
-            enum parentType = "struct";
-            enum parentName = parent.stringof;
-        }
-        else
-        {
-            enum parentType = "(unknown)";
-            enum parentName = __traits(identifier, parent);
-        }
+        alias parentInfo = CategoryName!parent;
 
         static assert(0, ("%s `%s` mixes in `%s` but it is only supposed to be " ~
             "mixed into an `IRCPlugin` subclass")
-            .format(parentType, parentName, "IRCPluginImpl"));
+            .format(parentInfo.type, parentInfo.fqn, "IRCPluginImpl"));
     }
 
     @safe:
@@ -2587,46 +2562,20 @@ public:
         private enum hasMessagingProxy = true;
     }
 
+    // Use a custom constraint to force the scope to be an IRCPlugin
     static if(!is(__traits(parent, hasMessagingProxy) : IRCPlugin))
     {
         import std.format : format;
-        import std.traits : isSomeFunction;
 
-        alias parent = __traits(parent, chan);
-
-        static if (isSomeFunction!parent)
-        {
-            enum parentType = "function";
-            enum parentName = __FUNCTION__;
-        }
-        else static if ((__VERSION__ >= 2087L) && __traits(isModule, parent))
-        {
-            enum parentType = "module";
-            enum parentName = module_;
-        }
-        else static if (is(parent == class))
-        {
-            enum parentType = "class";
-            enum parentName = parent.stringof;
-        }
-        else static if (is(parent == struct))
-        {
-            enum parentType = "struct";
-            enum parentName = parent.stringof;
-        }
-        else
-        {
-            enum parentType = "(unknown)";
-            enum parentName = __traits(identifier, parent);
-        }
+        alias parent = __traits(parent, hasMessagingProxy);
+        alias parentInfo = CategoryName!parent;
 
         static assert(0, ("%s `%s` mixes in `%s` but it is only supposed to be " ~
             "mixed into an `IRCPlugin` subclass")
-            .format(parentType, parentName, "MessagingProxy"));
+            .format(parentInfo.type, parentInfo.fqn, "MessagingProxy"));
     }
 
     pragma(inline):
-
 
     // chan
     /++
@@ -2868,37 +2817,7 @@ mixin template MinimalAuthentication(bool debug_ = false, string module_ = __MOD
         private enum hasMinimalAuthentication = true;
     }
 
-    static if((__VERSION__ >= 2087L) && !__traits(isModule, __traits(parent, hasMinimalAuthentication)))
-    {
-        import std.format : format;
-
-        alias parent = __traits(parent, hasMinimalAuthentication);
-
-        static if (isSomeFunction!parent)
-        {
-            enum parentType = "function";
-            enum parentName = __FUNCTION__;
-        }
-        else static if (is(parent == class))
-        {
-            enum parentType = "class";
-            enum parentName = parent.stringof;
-        }
-        else static if (is(parent == struct))
-        {
-            enum parentType = "struct";
-            enum parentName = parent.stringof;
-        }
-        else
-        {
-            enum parentType = "(unknown)";
-            enum parentName = __traits(identifier, parent);
-        }
-
-        static assert(0, ("%s `%s` mixes in `%s` but it is only supposed to be " ~
-            "mixed into a module-level scope")
-            .format(parentType, parentName, "MinimalAuthentication"));
-    }
+    mixin MixinConstraints!("MinimalAuthentication", hasMinimalAuthentication, MixinScope.module_);
 
 
     // onMinimalAuthenticationAccountInfoTargetMixin
@@ -3032,37 +2951,7 @@ mixin template Replayer(bool debug_ = false, string module_ = __MODULE__)
         enum hasReplayer = true;
     }
 
-    static if(!isSomeFunction!(__traits(parent, hasReplayer)))
-    {
-        import std.format : format;
-
-        alias parent = __traits(parent, hasReplayer);
-
-        static if ((__VERSION__ >= 2087L) && __traits(isModule, parent))
-        {
-            enum parentType = "module";
-            enum parentName = module_;
-        }
-        else static if (is(parent == class))
-        {
-            enum parentType = "class";
-            enum parentName = parent.stringof;
-        }
-        else static if (is(parent == struct))
-        {
-            enum parentType = "struct";
-            enum parentName = parent.stringof;
-        }
-        else
-        {
-            enum parentType = "(unknown)";
-            enum parentName = __traits(identifier, parent);
-        }
-
-        static assert(0, ("%s `%s` mixes in `%s` but it is only supposed to be " ~
-            "mixed into a function")
-            .format(parentType, parentName, "Replayer"));
-    }
+    mixin MixinConstraints!("Replayer", hasReplayer, MixinScope.function_);
 
     static if (__traits(compiles, plugin))
     {
@@ -3225,37 +3114,7 @@ mixin template UserAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home,
         private enum hasUserAwareness = true;
     }
 
-    static if((__VERSION__ >= 2087L) && !__traits(isModule, __traits(parent, hasUserAwareness)))
-    {
-        import std.format : format;
-
-        alias parent = __traits(parent, hasUserAwareness);
-
-        static if (isSomeFunction!parent)
-        {
-            enum parentType = "function";
-            enum parentName = __FUNCTION__;
-        }
-        else static if (is(parent == class))
-        {
-            enum parentType = "class";
-            enum parentName = parent.stringof;
-        }
-        else static if (is(parent == struct))
-        {
-            enum parentType = "struct";
-            enum parentName = parent.stringof;
-        }
-        else
-        {
-            enum parentType = "(unknown)";
-            enum parentName = __traits(identifier, parent);
-        }
-
-        static assert(0, ("%s `%s` mixes in `%s` but it is only supposed to be " ~
-            "mixed into a module-level scope")
-            .format(parentType, parentName, "UserAwareness"));
-    }
+    mixin MixinConstraints!("UserAwareness", hasUserAwareness, MixinScope.module_);
 
     static if (!__traits(compiles, .hasMinimalAuthentication))
     {
@@ -3532,37 +3391,7 @@ mixin template ChannelAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home
         private enum hasChannelAwareness = true;
     }
 
-    static if((__VERSION__ >= 2087L) && !__traits(isModule, __traits(parent, hasChannelAwareness)))
-    {
-        import std.format : format;
-
-        alias parent = __traits(parent, hasChannelAwareness);
-
-        static if (isSomeFunction!parent)
-        {
-            enum parentType = "function";
-            enum parentName = __FUNCTION__;
-        }
-        else static if (is(parent == class))
-        {
-            enum parentType = "class";
-            enum parentName = parent.stringof;
-        }
-        else static if (is(parent == struct))
-        {
-            enum parentType = "struct";
-            enum parentName = parent.stringof;
-        }
-        else
-        {
-            enum parentType = "(unknown)";
-            enum parentName = __traits(identifier, parent);
-        }
-
-        static assert(0, ("%s `%s` mixes in `%s` but it is only supposed to be " ~
-            "mixed into a module-level scope")
-            .format(parentType, parentName, "ChannelAwareness"));
-    }
+    mixin MixinConstraints!("ChannelAwareness", hasChannelAwareness, MixinScope.module_);
 
     static if (!__traits(compiles, .hasUserAwareness))
     {
@@ -4021,37 +3850,7 @@ mixin template TwitchAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home,
         private enum hasTwitchAwareness = true;
     }
 
-    static if((__VERSION__ >= 2087L) && !__traits(isModule, __traits(parent, hasTwitchAwareness)))
-    {
-        import std.format : format;
-
-        alias parent = __traits(parent, hasTwitchAwareness);
-
-        static if (isSomeFunction!parent)
-        {
-            enum parentType = "function";
-            enum parentName = __FUNCTION__;
-        }
-        else static if (is(parent == class))
-        {
-            enum parentType = "class";
-            enum parentName = parent.stringof;
-        }
-        else static if (is(parent == struct))
-        {
-            enum parentType = "struct";
-            enum parentName = parent.stringof;
-        }
-        else
-        {
-            enum parentType = "(unknown)";
-            enum parentName = __traits(identifier, parent);
-        }
-
-        static assert(0, ("%s `%s` mixes in `%s` but it is only supposed to be " ~
-            "mixed into a module-level scope")
-            .format(parentType, parentName, "TwitchAwareness"));
-    }
+    mixin MixinConstraints!("TwitchAwareness", hasTwitchAwareness, MixinScope.module_);
 
     static if (!__traits(compiles, .hasChannelAwareness))
     {
@@ -4178,37 +3977,7 @@ mixin template TwitchAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home,
         private enum hasTwitchAwareness = true;
     }
 
-    static if((__VERSION__ >= 2087L) && !__traits(isModule, __traits(parent, hasTwitchAwareness)))
-    {
-        import std.format : format;
-
-        alias parent = __traits(parent, hasTwitchAwareness);
-
-        static if (isSomeFunction!parent)
-        {
-            enum parentType = "function";
-            enum parentName = __FUNCTION__;
-        }
-        else static if (is(parent == class))
-        {
-            enum parentType = "class";
-            enum parentName = parent.stringof;
-        }
-        else static if (is(parent == struct))
-        {
-            enum parentType = "struct";
-            enum parentName = parent.stringof;
-        }
-        else
-        {
-            enum parentType = "(unknown)";
-            enum parentName = __traits(identifier, parent);
-        }
-
-        static assert(0, ("%s `%s` mixes in `%s` but it is only supposed to be " ~
-            "mixed into a module-level scope")
-            .format(parentType, parentName, "TwitchAwareness"));
-    }
+    mixin MixinConstraints!("TwitchAwareness", hasTwitchAwareness, MixinScope.module_);
 
     static if (!__traits(compiles, .hasChannelAwareness))
     {
@@ -4822,37 +4591,7 @@ if (isSomeFunction!onSuccess && (is(typeof(onFailure) == typeof(null)) || isSome
         enum hasWHOISFiber = true;
     }
 
-    static if(!isSomeFunction!(__traits(parent, hasWHOISFiber)))
-    {
-        import std.format : format;
-
-        alias parent = __traits(parent, hasWHOISFiber);
-
-        static if ((__VERSION__ >= 2087L) && __traits(isModule, parent))
-        {
-            enum parentType = "module";
-            enum parentName = module_;
-        }
-        else static if (is(parent == class))
-        {
-            enum parentType = "class";
-            enum parentName = parent.stringof;
-        }
-        else static if (is(parent == struct))
-        {
-            enum parentType = "struct";
-            enum parentName = parent.stringof;
-        }
-        else
-        {
-            enum parentType = "(unknown)";
-            enum parentName = __traits(identifier, parent);
-        }
-
-        static assert(0, ("%s `%s` mixes in `%s` but it is only supposed to be " ~
-            "mixed into a function")
-            .format(parentType, parentName, "WHOISFiberDelegate"));
-    }
+    mixin MixinConstraints!("WHOISFiberDelegate", hasWHOISFiber, MixinScope.function_);
 
     static if (__traits(compiles, plugin))
     {

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -2285,21 +2285,8 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
     pragma(inline)
     public string name() @property const pure nothrow @nogc
     {
-        enum ctName =
-        {
-            import lu.string : contains, nom;
-
-            string moduleName = module_;  // mutable
-
-            while (moduleName.contains('.'))
-            {
-                moduleName.nom('.');
-            }
-
-            return moduleName;
-        }().idup;
-
-        return ctName;
+        mixin("static import thisModule = " ~ module_ ~ ";");
+        return __traits(identifier, thisModule);
     }
 
 

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -1266,7 +1266,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                             static if (hasUDA!(this.tupleof[i].tupleof[n], Enabler))
                             {
                                 static assert(is(typeof(this.tupleof[i].tupleof[n]) : bool),
-                                    Unqual!(typeof(this)).stringof ~ " has a non-bool Enabler");
+                                    '`' ~ Unqual!(typeof(this)).stringof ~ "` has a non-bool `Enabler`");
 
                                 retval = submember;
                                 break top;

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -261,7 +261,7 @@ private final class TriggerRequestImpl(F, Payload = typeof(null)) : TriggerReque
         import std.meta : AliasSeq, staticMap;
         import std.traits : Parameters, Unqual, arity;
 
-        assert((fn !is null), "null fn in TriggerRequestImpl!" ~ F.stringof);
+        assert((fn !is null), "null fn in `TriggerRequestImpl!" ~ F.stringof ~ "`");
 
         alias Params = staticMap!(Unqual, Parameters!fn);
 
@@ -283,7 +283,9 @@ private final class TriggerRequestImpl(F, Payload = typeof(null)) : TriggerReque
         }
         else
         {
-            static assert(0, "Unknown function signature in TriggerRequestImpl: " ~ typeof(fn).stringof);
+            import std.format : format;
+            static assert(0, "Unknown function signature in `TriggerRequestImpl`: `%s`"
+                .format(typeof(fn).stringof));
         }
     }
 }

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -1995,8 +1995,9 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
             }
             else
             {
-                static assert(0, module_ ~ ".initialise has an unsupported " ~
-                    "function signature: " ~ typeof(.initialise).stringof);
+                import std.format : format;
+                static assert(0, "`%s.initialise` has an unsupported function signature: `%s`"
+                    .format(module_, typeof(.initialise).stringof));
             }
         }
     }
@@ -2024,8 +2025,9 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
             }
             else
             {
-                static assert(0, module_ ~ ".postprocess has an unsupported " ~
-                    "function signature: " ~ typeof(.postprocess).stringof);
+                import std.format : format;
+                static assert(0, "`%s.postprocess` has an unsupported function signature: `%s`"
+                    .format(module_, typeof(.postprocess).stringof));
             }
         }
     }
@@ -2049,8 +2051,9 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
             }
             else
             {
-                static assert(0, module_ ~ ".initResources has an unsupported " ~
-                    "function signature: " ~ typeof(.initResources).stringof);
+                import std.format : format;
+                static assert(0, "`%s.initResources` has an unsupported function signature: `%s`"
+                    .format(module_, typeof(.initResources).stringof));
             }
         }
     }
@@ -2261,8 +2264,9 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
             }
             else
             {
-                static assert(0, module_ ~ ".start has an unsupported " ~
-                    "function signature: " ~ typeof(.start).stringof);
+                import std.format : format;
+                static assert(0, "`%s.start` has an unsupported function signature: `%s`"
+                    .format(module_, typeof(.start).stringof));
             }
         }
     }
@@ -2286,8 +2290,9 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
             }
             else
             {
-                static assert(0, module_ ~ ".teardown has an unsupported " ~
-                    "function signature: " ~ typeof(.teardown).stringof);
+                import std.format : format;
+                static assert(0, "`%s.teardown` has an unsupported function signature: `%s`"
+                    .format(module_, typeof(.teardown).stringof));
             }
         }
     }
@@ -2441,8 +2446,9 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                 }
                 else
                 {
-                    static assert(0, module_ ~ ".periodically has an unsupported " ~
-                        "function signature: " ~ typeof(.periodically).stringof);
+                    import std.format : format;
+                    static assert(0, "`%s.periodically` has an unsupported function signature: `%s`"
+                        .format(module_, typeof(.periodically).stringof));
                 }
             }
         }
@@ -2467,8 +2473,9 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
             }
             else
             {
-                static assert(0, module_ ~ ".reload has an unsupported " ~
-                    "function signature: " ~ typeof(.reload).stringof);
+                import std.format : format;
+                static assert(0, "`%s.reload` has an unsupported function signature: `%s`"
+                    .format(module_, typeof(.reload).stringof));
             }
         }
     }
@@ -2501,8 +2508,9 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
             }
             else
             {
-                static assert(0, module_ ~ ".onBusMessage has an unsupported " ~
-                    "function signature: " ~ typeof(.onBusMessage).stringof);
+                import std.format : format;
+                static assert(0, "`%s.onBusMessage` has an unsupported function signature: `%s`"
+                    .format(module_, typeof(.onBusMessage).stringof));
             }
         }
     }

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -1654,8 +1654,9 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                     import std.format : format;
 
                     enum typestring = Enum!(IRCEvent.Type).toString(eventTypeUDA);
-                    pragma(msg, "Note: %s is a wildcard %s event but is not Chainable nor Terminating"
-                        .format(name, typestring));
+                    pragma(msg, ("Note: `%s.%s` is a wildcard `IRCEvent.Type.%s` event " ~
+                        "but is not `Chainable` nor `Terminating`")
+                        .format(module_, __traits(identifier, fun), typestring));
                 }
 
                 static if (!hasUDA!(fun, PrivilegeLevel) && !isAwarenessFunction!fun)

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -2392,7 +2392,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                     else
                     {
                         import std.format : format;
-                        pragma(msg, `Warning: %s.%s is missing a Description annotation for command "%s"`
+                        pragma(msg, "Warning: `%s.%s` is missing a `Description` annotation for command \"%s\""
                             .format(module_, __traits(identifier, fun), commandUDA.string_));
                     }
                 }

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -5139,3 +5139,243 @@ string nameOf(const IRCPlugin plugin, const string nickname) pure @safe nothrow 
 
     return nickname;
 }
+
+
+// MixinScope
+/++
+ +  The types of scope into which we might mix in one of our mixin templates.
+ +/
+enum MixinScope
+{
+    function_,  /// Mixed in inside a function.
+    class_,     /// Mixed in inside a class.
+    struct_,    /// Mixed in inside a struct.
+    module_,    /// Mixed in inside a module.
+}
+
+
+// CategoryName
+/++
+ +  Provides string representations of the category of a symbol, where such is not
+ +  a fundamental primitive variable but a module, a function, a delegate,
+ +  a class or a struct.
+ +
+ +  Module detection only works on compilers 2.087 and later, due to missing
+ +  support for `__traits(isModule)`.
+ +
+ +  Example:
+ +  ---
+ +  void foo() {}
+ +
+ +  alias categoryName = CategoryName!foo;
+ +
+ +  writeln(categoryName.type);
+ +  writeln(categoryName.name);
+ +  writeln(categoryName.fqn);
+ +  ---
+ +
+ +  Params:
+ +      sym = Symbol to provide the strings for.
+ +/
+template CategoryName(alias sym)
+{
+    import std.traits : fullyQualifiedName;
+
+
+    // type
+    /++
+     +  String representation of the fundamental type of `sym`.
+     +/
+    enum type = ()
+    {
+        import std.traits : isDelegate, isFunction;
+
+
+        static if ((__VERSION__ >= 2087L) && __traits(isModule, sym))
+        {
+            return "module";
+        }
+        else static if (isFunction!sym)
+        {
+            return "function";
+        }
+        else static if (isDelegate!sym)
+        {
+            return "delegate";
+        }
+        else static if (is(sym == class) || is(typeof(sym) == class))
+        {
+            return "class";
+        }
+        else static if (is(sym == struct) || is(typeof(sym) == struct))
+        {
+            return "struct";
+        }
+        else static if (__VERSION__ < 2087L)
+        {
+            return "(module?)";
+        }
+        else
+        {
+            return "(unknown)";
+        }
+    }();
+
+
+    // name
+    /++
+     +  A short name for `sym`.
+     +/
+    enum name = __traits(identifier, sym);
+
+
+    // fqn
+    /++
+     +  The fully qualified name for `sym`.
+     +/
+    enum fqn = fullyQualifiedName!sym;
+}
+
+unittest
+{
+    bool localSymbol;
+
+    void fn() {}
+
+    auto dg = () => localSymbol;
+
+    class C {}
+    C c;
+
+    struct S {}
+    S s;
+
+    alias Ffn = CategoryName!fn;
+    static assert(Ffn.type == "function");
+    static assert(Ffn.name == "fn");
+    // Can't test fqn from inside a unittest
+
+    alias Fdg = CategoryName!dg;
+    static assert(Fdg.type == "delegate");
+    static assert(Fdg.name == "dg");
+    // Ditto
+
+    alias Fc = CategoryName!c;
+    static assert(Fc.type == "class");
+    static assert(Fc.name == "c");
+    // Ditto
+
+    alias Fs = CategoryName!s;
+    static assert(Fs.type == "struct");
+    static assert(Fs.name == "s");
+
+    alias Fm = CategoryName!(kameloso.plugins.common);
+    static assert(Fm.type == "module");
+    static assert(Fm.name == "common");
+    static assert(Fm.fqn == "kameloso.plugins.common");
+}
+
+
+// MixinConstraints
+/++
+ +  Mixes in static constraints into another mixin template, to provide static
+ +  guarantees that it is not mixed into a type of scope other than the one specified.
+ +
+ +  Using this you can ensure that a mixin template meant to be mixed into a
+ +  class isn't mixed into a module-level scope, or into a function, etc.
+ +
+ +  Example:
+ +  ---
+ +  module foo;
+ +
+ +  mixin template Foo()
+ +  {
+ +      enum sentinelValue = true;  // One symbol required to get the parent scope
+ +
+ +      mixin MixinConstraints!("Foo", sentinelValue, MixinScope.module_);  // Constrained to module-level scope
+ +  }
+ +
+ +  mixin Foo;  // no problem
+ +
+ +  void bar()
+ +  {
+ +      mixin Foo;  // static assert(0): scope is MixinScope.function_, not MixinSCope.module_
+ +  }
+ +  ---
+ +
+ +  Params:
+ +      mixinName = String name of the mixing in mixin. Can be anything; it's
+ +          just used for the static assert error messages.
+ +      sentinel = Alias to a symbol inside the mixing in mixin. This is required
+ +          and can be anything; an enum literal, a variable, a function.
+ +      mixinScope = The scope into which to only allow the mixin to be mixed in.
+ +          All other kinds of scopes will be statically rejected.
+ +/
+mixin template MixinConstraints(string mixinName, alias sentinel, MixinScope mixinScope)
+{
+private:
+    import std.format : format;
+
+    static assert((is(typeof(sentinel)) && !__traits(isTemplate, sentinel))
+    ,   "Invalid sentinel symbol `%s` passed to `MixinConstraints` (mixed in from `%s`)"
+        .format(__traits(identifier, sentinel), mixinName));
+
+    alias mixinParent = __traits(parent, sentinel);
+    alias mixinParentInfo = CategoryName!mixinParent;
+
+    static if (mixinScope == MixinScope.function_)
+    {
+        import std.traits : isSomeFunction;
+
+        static if (!isSomeFunction!(__traits(parent, sentinel)))
+        {
+            static assert(0, ("%s `%s` mixes in `%s` but it is only supposed to be " ~
+                "mixed into a function")
+                .format(mixinParentInfo.type, mixinParentInfo.fqn, mixinName));
+        }
+    }
+    else static if (mixinScope == MixinScope.class_)
+    {
+        static if(!is(__traits(parent, sentinel) == class))
+        {
+            static assert(0, ("%s `%s` mixes in `%s` but it is only supposed to be " ~
+                "mixed into a class")
+                .format(mixinParentInfo.type, mixinParentInfo.fqn, mixinName));
+        }
+    }
+    else static if (mixinScope == MixinScope.struct_)
+    {
+        static if(!is(__traits(parent, sentinel) == struct))
+        {
+            static assert(0, ("%s `%s` mixes in `%s` but it is only supposed to be " ~
+                "mixed into a struct")
+                .format(mixinParentInfo.type, mixinParentInfo.fqn, mixinName));
+        }
+    }
+    else static if (mixinScope == MixinScope.module_)
+    {
+        static if (__VERSION__ < 2087L)
+        {
+            import std.traits : isSomeFunction;
+
+            static if (isSomeFunction!(__traits(parent, sentinel)) ||
+                is(__traits(parent, sentinel) == class) ||
+                is(__traits(parent, sentinel) == struct))
+            {
+                static assert(0, ("%s `%s` mixes in `%s` but it is only supposed to be " ~
+                    "mixed into a module-level scope")
+                    .format(mixinParentInfo.type, mixinParentInfo.fqn, mixinName));
+            }
+        }
+        else static if (!__traits(isModule, __traits(parent, sentinel)))
+        {
+            static assert(0, ("%s `%s` mixes in `%s` but it is only supposed to be " ~
+                "mixed into a module-level scope")
+                .format(mixinParentInfo.type, mixinParentInfo.fqn, mixinName));
+        }
+    }
+    else
+    {
+        static assert(0, "Logic error; unexpected member of `MixinScope`");
+    }
+}

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -1570,16 +1570,16 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                         {
                             import std.regex : Regex;
 
-                            static if (regexUDA.engine == Regex!char.init)
+                            static if (!regexUDA.expression.length)
                             {
                                 import std.format : format;
-                                static assert(0, "`%s` has an incomplete `BotRegex`".format(name));
+                                static assert(0, "`%s.%s` has an incomplete `BotRegex` annotation"
+                                    .format(module_, __traits(identifier, fun)));
                             }
 
                             static if (verbose)
                             {
-                                writeln("BotRegex: ", regexUDA.expression.length ?
-                                    regexUDA.expression : "(cannot get expression)");
+                                writeln("BotRegex: `", regexUDA.expression, "`");
                                 if (settings.flush) stdout.flush();
                             }
 

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -4851,9 +4851,9 @@ if (isSomeFunction!onSuccess && (is(typeof(onFailure) == typeof(null)) || isSome
     }
     else
     {
-        static assert(0, "WHOISFiberDelegate should be mixed into the context " ~
+        static assert(0, "`WHOISFiberDelegate` should be mixed into the context " ~
             "of an event handler. (Could not access variables named neither " ~
-            `"plugin" nor "service" from within ` ~ __FUNCTION__ ~ ")");
+            "`plugin` nor `service` from within `" ~ __FUNCTION__ ~ "`)");
     }
 
 
@@ -4962,9 +4962,10 @@ if (isSomeFunction!onSuccess && (is(typeof(onFailure) == typeof(null)) || isSome
             }
             else
             {
-                static assert(0, "Unexpected signature of success function " ~
-                    "alias passed to mixin WHOISFiberDelegate in " ~ __FUNCTION__ ~
-                    ": " ~ typeof(onSuccess).stringof ~ " " ~ __traits(identifier, onSuccess));
+                import std.format : format;
+                static assert(0, ("Unexpected signature of success function/delegate " ~
+                    "alias passed to mixin `WHOISFiberDelegate` in `%s`: `%s %s`")
+                    .format(__FUNCTION__, typeof(onSuccess).stringof, __traits(identifier, onSuccess)));
             }
         }
         else /* if ((whoisEvent.type == IRCEvent.Type.RPL_ENDOFWHOIS) ||
@@ -4992,9 +4993,10 @@ if (isSomeFunction!onSuccess && (is(typeof(onFailure) == typeof(null)) || isSome
                 }
                 else
                 {
-                    static assert(0, "Unexpected signature of failure function " ~
-                        "alias passed to mixin WHOISFiberDelegate in " ~ __FUNCTION__ ~
-                        ": " ~ typeof(onFailure).stringof ~ " " ~ __traits(identifier, onFailure));
+                    import std.format : format;
+                    static assert(0, ("Unexpected signature of failure function/delegate " ~
+                        "alias passed to mixin `WHOISFiberDelegate` in `%s`: `%s %s`")
+                        .format(__FUNCTION__, typeof(onFailure).stringof, __traits(identifier, onFailure)));
                 }
             }
         }

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -1188,12 +1188,12 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
     {
         import std.format : format;
 
-        alias parent = __traits(parent, hasIRCPluginImpl);
-        alias parentInfo = CategoryName!parent;
+        alias pluginImplParent = __traits(parent, hasIRCPluginImpl);
+        alias pluginImplParentInfo = CategoryName!pluginImplParent;
 
         static assert(0, ("%s `%s` mixes in `%s` but it is only supposed to be " ~
             "mixed into an `IRCPlugin` subclass")
-            .format(parentInfo.type, parentInfo.fqn, "IRCPluginImpl"));
+            .format(pluginImplParentInfo.type, pluginImplParentInfo.fqn, "IRCPluginImpl"));
     }
 
     @safe:
@@ -2567,12 +2567,12 @@ public:
     {
         import std.format : format;
 
-        alias parent = __traits(parent, hasMessagingProxy);
-        alias parentInfo = CategoryName!parent;
+        alias messagingParent = __traits(parent, hasMessagingProxy);
+        alias messagingParentInfo = CategoryName!messagingParent;
 
         static assert(0, ("%s `%s` mixes in `%s` but it is only supposed to be " ~
             "mixed into an `IRCPlugin` subclass")
-            .format(parentInfo.type, parentInfo.fqn, "MessagingProxy"));
+            .format(messagingParentInfo.type, messagingParentInfo.fqn, "MessagingProxy"));
     }
 
     pragma(inline):

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -1355,6 +1355,8 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
          +/
         Next handle(alias fun)(const IRCEvent event)
         {
+            import std.format : format;
+
             enum verbose = hasUDA!(fun, Verbose) || debug_;
 
             static if (verbose)
@@ -1362,21 +1364,10 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                 import kameloso.common : settings;
                 import lu.conv : Enum;
                 import std.stdio : stdout, writeln, writefln;
+
+                enum name = "[%s] %s".format(__traits(identifier, thisModule),
+                        __traits(identifier, fun));
             }
-
-            enum name = ()
-            {
-                import lu.conv : Enum;
-                import std.format : format;
-
-                string pluginName = module_;  // mutable
-                while (pluginName.contains('.'))
-                {
-                    pluginName.nom('.');
-                }
-
-                return "[%s] %s".format(pluginName, __traits(identifier, fun));
-            }();
 
             udaloop:
             foreach (immutable eventTypeUDA; getUDAs!(fun, IRCEvent.Type))
@@ -1412,7 +1403,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
 
                 static if (verbose)
                 {
-                    writeln("-- ", name, " @ ", Enum!(IRCEvent.Type).toString(event.type));
+                    writefln("-- %s @ %s", name, Enum!(IRCEvent.Type).toString(event.type));
                     if (settings.flush) stdout.flush();
                 }
 

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -951,36 +951,30 @@ struct BotRegex
     /// The regular expression in string form.
     string expression;
 
-    /// Creates a new `BotRegex` with the passed `policy` and regex `engine`.
-    this(const PrefixPolicy policy, Regex!char engine) pure
-    {
-        this.policy = policy;
-        this.engine = engine;
-    }
-
     /++
      +  Creates a new `BotRegex` with the passed `policy` and regex `expression` string.
      +/
     this(const PrefixPolicy policy, const string expression)
     {
         this.policy = policy;
-        this.engine = expression.regex;
-        this.expression = expression;
-    }
 
-    /// Creates a new `BotRegex` with the passed regex `engine`.
-    this(Regex!char engine) pure
-    {
-        this.policy = PrefixPolicy.prefixed;
-        this.engine = engine;
+        if (expression.length)
+        {
+            this.engine = expression.regex;
+            this.expression = expression;
+        }
     }
 
     /// Creates a new `BotRegex` with the passed regex `expression` string.
     this(const string expression)
     {
         this.policy = PrefixPolicy.prefixed;
-        this.engine = expression.regex;
-        this.expression = expression;
+
+        if (expression.length)
+        {
+            this.engine = expression.regex;
+            this.expression = expression;
+        }
     }
 }
 

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -42,9 +42,9 @@ static if (__VERSION__ == 2079L)
 
     static if (getSymbolsByUDA!(Foo_2079, UDA_2079).length != 3)
     {
-        pragma(msg, "WARNING: You are using a 2.079.0 compiler with a broken " ~
+        pragma(msg, "WARNING: You are using a `2.079.0` compiler with a broken " ~
             "crucial trait in its standard library. The program will not " ~
-            "function normally. Please upgrade to 2.079.1.");
+            "function normally. Please upgrade to `2.079.1` or later.");
     }
 }
 

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -4209,6 +4209,14 @@ mixin template TwitchAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home,
             "mixed into a module-level scope")
             .format(parentType, parentName, "TwitchAwareness"));
     }
+
+    static if (!__traits(compiles, .hasChannelAwareness))
+    {
+        import std.format : format;
+        static assert(0, ("`%s` is missing a `ChannelAwareness` mixin " ~
+            "(needed for `TwitchAwareness`)")
+            .format(module_));
+    }
 }
 
 

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -1619,7 +1619,12 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                             }
                             catch (Exception e)
                             {
-                                logger.warning("BotRegex exception: ", e.msg);
+                                static if (verbose)
+                                {
+                                    writeln("...BotRegex exception: ", e.msg);
+                                    version(PrintStacktraces) writeln(e.toString);
+                                    if (settings.flush) stdout.flush();
+                                }
                                 continue;  // next BotRegex
                             }
                         }

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -2926,7 +2926,7 @@ mixin template Replayer(bool debug_ = false, string module_ = __MODULE__)
     }
     else
     {
-        enum hasReplayer = true;
+        private enum hasReplayer = true;
     }
 
     mixin MixinConstraints!("Replayer", hasReplayer, MixinScope.function_);
@@ -4566,7 +4566,7 @@ if (isSomeFunction!onSuccess && (is(typeof(onFailure) == typeof(null)) || isSome
     }
     else
     {
-        enum hasWHOISFiber = true;
+        private enum hasWHOISFiber = true;
     }
 
     mixin MixinConstraints!("WHOISFiberDelegate", hasWHOISFiber, MixinScope.function_);

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -1195,7 +1195,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
             enum parentType = "function";
             enum parentName = __FUNCTION__;
         }
-        else static if (__traits(isModule, parent))
+        else static if ((__VERSION__ >= 2087L) && __traits(isModule, parent))
         {
             enum parentType = "module";
             enum parentName = module_;
@@ -2599,7 +2599,7 @@ public:
             enum parentType = "function";
             enum parentName = __FUNCTION__;
         }
-        else static if (__traits(isModule, parent))
+        else static if ((__VERSION__ >= 2087L) && __traits(isModule, parent))
         {
             enum parentType = "module";
             enum parentName = module_;
@@ -2868,7 +2868,7 @@ mixin template MinimalAuthentication(bool debug_ = false, string module_ = __MOD
         private enum hasMinimalAuthentication = true;
     }
 
-    static if(!__traits(isModule, __traits(parent, hasMinimalAuthentication)))
+    static if((__VERSION__ >= 2087L) && !__traits(isModule, __traits(parent, hasMinimalAuthentication)))
     {
         import std.format : format;
 
@@ -3038,7 +3038,7 @@ mixin template Replayer(bool debug_ = false, string module_ = __MODULE__)
 
         alias parent = __traits(parent, hasReplayer);
 
-        static if (__traits(isModule, parent))
+        static if ((__VERSION__ >= 2087L) && __traits(isModule, parent))
         {
             enum parentType = "module";
             enum parentName = module_;
@@ -3225,7 +3225,7 @@ mixin template UserAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home,
         private enum hasUserAwareness = true;
     }
 
-    static if(!__traits(isModule, __traits(parent, hasUserAwareness)))
+    static if((__VERSION__ >= 2087L) && !__traits(isModule, __traits(parent, hasUserAwareness)))
     {
         import std.format : format;
 
@@ -3532,7 +3532,7 @@ mixin template ChannelAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home
         private enum hasChannelAwareness = true;
     }
 
-    static if(!__traits(isModule, __traits(parent, hasChannelAwareness)))
+    static if((__VERSION__ >= 2087L) && !__traits(isModule, __traits(parent, hasChannelAwareness)))
     {
         import std.format : format;
 
@@ -4021,7 +4021,7 @@ mixin template TwitchAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home,
         private enum hasTwitchAwareness = true;
     }
 
-    static if(!__traits(isModule, __traits(parent, hasTwitchAwareness)))
+    static if((__VERSION__ >= 2087L) && !__traits(isModule, __traits(parent, hasTwitchAwareness)))
     {
         import std.format : format;
 
@@ -4178,7 +4178,7 @@ mixin template TwitchAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home,
         private enum hasTwitchAwareness = true;
     }
 
-    static if(!__traits(isModule, __traits(parent, hasTwitchAwareness)))
+    static if((__VERSION__ >= 2087L) && !__traits(isModule, __traits(parent, hasTwitchAwareness)))
     {
         import std.format : format;
 
@@ -4828,7 +4828,7 @@ if (isSomeFunction!onSuccess && (is(typeof(onFailure) == typeof(null)) || isSome
 
         alias parent = __traits(parent, hasWHOISFiber);
 
-        static if (__traits(isModule, parent))
+        static if ((__VERSION__ >= 2087L) && __traits(isModule, parent))
         {
             enum parentType = "module";
             enum parentName = module_;

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -2795,7 +2795,7 @@ mixin template MinimalAuthentication(bool debug_ = false, string module_ = __MOD
         private enum hasMinimalAuthentication = true;
     }
 
-    mixin MixinConstraints!("MinimalAuthentication", hasMinimalAuthentication, MixinScope.module_);
+    mixin MixinConstraints!("MinimalAuthentication", MixinScope.module_);
 
 
     // onMinimalAuthenticationAccountInfoTargetMixin
@@ -2929,7 +2929,7 @@ mixin template Replayer(bool debug_ = false, string module_ = __MODULE__)
         private enum hasReplayer = true;
     }
 
-    mixin MixinConstraints!("Replayer", hasReplayer, MixinScope.function_);
+    mixin MixinConstraints!("Replayer", MixinScope.function_);
 
     static if (__traits(compiles, plugin))
     {
@@ -3092,7 +3092,7 @@ mixin template UserAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home,
         private enum hasUserAwareness = true;
     }
 
-    mixin MixinConstraints!("UserAwareness", hasUserAwareness, MixinScope.module_);
+    mixin MixinConstraints!("UserAwareness", MixinScope.module_);
 
     static if (!__traits(compiles, .hasMinimalAuthentication))
     {
@@ -3369,7 +3369,7 @@ mixin template ChannelAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home
         private enum hasChannelAwareness = true;
     }
 
-    mixin MixinConstraints!("ChannelAwareness", hasChannelAwareness, MixinScope.module_);
+    mixin MixinConstraints!("ChannelAwareness", MixinScope.module_);
 
     static if (!__traits(compiles, .hasUserAwareness))
     {
@@ -3828,7 +3828,7 @@ mixin template TwitchAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home,
         private enum hasTwitchAwareness = true;
     }
 
-    mixin MixinConstraints!("TwitchAwareness", hasTwitchAwareness, MixinScope.module_);
+    mixin MixinConstraints!("TwitchAwareness", MixinScope.module_);
 
     static if (!__traits(compiles, .hasChannelAwareness))
     {
@@ -3955,7 +3955,7 @@ mixin template TwitchAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home,
         private enum hasTwitchAwareness = true;
     }
 
-    mixin MixinConstraints!("TwitchAwareness", hasTwitchAwareness, MixinScope.module_);
+    mixin MixinConstraints!("TwitchAwareness", MixinScope.module_);
 
     static if (!__traits(compiles, .hasChannelAwareness))
     {
@@ -4569,7 +4569,7 @@ if (isSomeFunction!onSuccess && (is(typeof(onFailure) == typeof(null)) || isSome
         private enum hasWHOISFiber = true;
     }
 
-    mixin MixinConstraints!("WHOISFiberDelegate", hasWHOISFiber, MixinScope.function_);
+    mixin MixinConstraints!("WHOISFiberDelegate", MixinScope.function_);
 
     static if (__traits(compiles, plugin))
     {

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -4987,7 +4987,16 @@ unittest
     static assert(Fs.name == "s");
 
     alias Fm = CategoryName!(kameloso.plugins.common);
-    static assert(Fm.type == "module");
+
+    static if (__VERSION__ >= 2087L)
+    {
+        static assert(Fm.type == "module");
+    }
+    else
+    {
+        static assert(Fm.type == "(module?)");
+    }
+
     static assert(Fm.name == "common");
     static assert(Fm.fqn == "kameloso.plugins.common");
 }


### PR DESCRIPTION
This adds logic to help constrain mixin templates to statically only be allowed to be mixed into a specified type of scope. If it's mixed into the wrong type, it will `static assert(0)` with a helpful message.

```d
enum MixinScope
{
    function_,  /// Mixed in inside a function.
    class_,     /// Mixed in inside a class.
    struct_,    /// Mixed in inside a struct.
    module_,    /// Mixed in inside a module.
}
```

This is a good candidate to move to lu, but let's merge it here first.