### PR TITLE
Scheduled Fiber accuracy

### DIFF
--- a/source/kameloso/kameloso.d
+++ b/source/kameloso/kameloso.d
@@ -651,7 +651,8 @@ Next mainLoop(ref Kameloso instance)
             return Next.retry;
         }
 
-        immutable nowInUnix = Clock.currTime.toUnixTime;
+        deprecated immutable nowInUnix = Clock.currTime.toUnixTime;
+        immutable now = Clock.currStdTime;
 
         foreach (plugin; instance.plugins)
         {

--- a/source/kameloso/kameloso.d
+++ b/source/kameloso/kameloso.d
@@ -651,8 +651,8 @@ Next mainLoop(ref Kameloso instance)
             return Next.retry;
         }
 
-        deprecated immutable nowInUnix = Clock.currTime.toUnixTime;
-        immutable now = Clock.currStdTime;
+        immutable nowInUnix = Clock.currTime.toUnixTime;
+        immutable nowInHnsecs = Clock.currStdTime;
 
         foreach (plugin; instance.plugins)
         {

--- a/source/kameloso/kameloso.d
+++ b/source/kameloso/kameloso.d
@@ -1291,18 +1291,18 @@ void processAwaitingFibers(IRCPlugin plugin, const IRCEvent event)
  +  Params:
  +      plugin = The `kameloso.plugins.ircplugin.IRCPlugin` whose queued
  +          `ScheduledFiber`s to iterate and process.
- +      nowInUnix = Current UNIX timestamp to compare the `ScheduledFiber`'s
- +          UNIX timestamp with.
+ +      nowInHnsecs = Current timestamp to compare the `ScheduledFiber`'s
+ +          timestamp with.
  +/
-void processScheduledFibers(IRCPlugin plugin, const long nowInUnix)
-in ((nowInUnix > 0), "Tried to process queued `ScheduledFiber`s with an unset timestamp")
+void processScheduledFibers(IRCPlugin plugin, const long nowInHnsecs)
+in ((nowInHnsecs > 0), "Tried to process queued `ScheduledFiber`s with an unset timestamp")
 do
 {
     size_t[] toRemove;
 
     foreach (immutable i, scheduledFiber; plugin.state.scheduledFibers)
     {
-        if (scheduledFiber.timestamp > nowInUnix) continue;
+        if (scheduledFiber.timestamp > nowInHnsecs) continue;
 
         try
         {

--- a/source/kameloso/plugins/ircplugin.d
+++ b/source/kameloso/plugins/ircplugin.d
@@ -232,9 +232,11 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                         static if (isAnnotated!(this.tupleof[i].tupleof[n], Enabler))
                         {
                             import std.traits : Unqual;
+                            alias ThisEnabler = Unqual!(typeof(this.tupleof[i].tupleof[n]));
 
-                            static assert(is(typeof(this.tupleof[i].tupleof[n]) : bool),
-                                '`' ~ Unqual!(typeof(this)).stringof ~ "` has a non-bool `Enabler`");
+                            static assert(is(ThisEnabler : bool),
+                                '`' ~ Unqual!(typeof(this)).stringof ~
+                                "` has a non-bool `Enabler`: `" ~ ThisEnabler.stringof ~ '`');
 
                             retval = submember;
                             break top;

--- a/source/kameloso/plugins/ircplugin.d
+++ b/source/kameloso/plugins/ircplugin.d
@@ -519,25 +519,18 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                 if (settings.flush) stdout.flush();
             }
 
-            static if (hasUDA!(fun, ChannelPolicy))
-            {
-                enum policy = getUDAs!(fun, ChannelPolicy)[0];
-            }
-            else
-            {
-                // Default policy if none given is `ChannelPolicy.home`
-                enum policy = ChannelPolicy.home;
-            }
-
-            static if (verbose)
-            {
-                writeln("...ChannelPolicy.", Enum!ChannelPolicy.toString(policy));
-                if (settings.flush) stdout.flush();
-            }
-
-            static if (policy == ChannelPolicy.home)
+            static if (!hasUDA!(fun, ChannelPolicy) ||
+                getUDAs!(fun, ChannelPolicy)[0] == ChannelPolicy.home)
             {
                 import std.algorithm.searching : canFind;
+
+                // Default policy if none given is `ChannelPolicy.home`
+
+                static if (verbose)
+                {
+                    writeln("...ChannelPolicy.home");
+                    if (settings.flush) stdout.flush();
+                }
 
                 if (!event.channel.length)
                 {
@@ -552,19 +545,16 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                     }
 
                     // channel policy does not match
-                    return Next.continue_;  // next function
+                    return Next.continue_;  // next fun
                 }
-            }
-            else static if (policy == ChannelPolicy.any)
-            {
-                // drop down, no need to check
             }
             else
             {
-                import std.format : format;
-                static assert(0, ("Logic error; `%s` is annotated with " ~
-                    "an unexpected `ChannelPolicy`")
-                    .format(fullyQualifiedName!fun));
+                static if (verbose)
+                {
+                    writeln("...ChannelPolicy.any");
+                    if (settings.flush) stdout.flush();
+                }
             }
 
             static if (hasUDA!(fun, BotCommand) || hasUDA!(fun, BotRegex))

--- a/source/kameloso/plugins/ircplugin.d
+++ b/source/kameloso/plugins/ircplugin.d
@@ -164,7 +164,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
     private import core.thread : Fiber;
 
     /// Symbol needed for the mixin constraints to work.
-    enum mixinSentinel = true;
+    private static enum mixinSentinel = true;
 
     // Use a custom constraint to force the scope to be an IRCPlugin
     static if(!is(__traits(parent, mixinSentinel) : IRCPlugin))

--- a/source/kameloso/plugins/ircplugin.d
+++ b/source/kameloso/plugins/ircplugin.d
@@ -624,15 +624,12 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                     import lu.string : strippedLeft;
                     import std.algorithm.comparison : equal;
                     import std.typecons : No, Yes;
-                    import std.uni : asLowerCase, toLower;
+                    import std.uni : asLowerCase;
 
                     mutEvent.content = mutEvent.content.strippedLeft;
                     immutable thisCommand = mutEvent.content.nom!(Yes.inherit, Yes.decode)(' ');
 
-                    enum lowercaseUDAString = commandUDA.word.toLower;
-
-                    if ((thisCommand.length == lowercaseUDAString.length) &&
-                        thisCommand.asLowerCase.equal(lowercaseUDAString))
+                    if (thisCommand.asLowerCase.equal(commandUDA.word.asLowerCase))
                     {
                         static if (verbose)
                         {

--- a/source/kameloso/plugins/seen.d
+++ b/source/kameloso/plugins/seen.d
@@ -19,10 +19,7 @@
  +  the function(s) annotated with its type.
  +
  +  Callback `core.thread.Fiber`s *are* supported. They can be registered to
- +  process on incoming events, or scheduled with a worst-case precision of
- +  `lu.net.DefaultTimeout.receive` milliseconds, plus up to
- +  `kameloso.plugins.package.EnabledPlugins.length` number of plugins' event
- +  handling execution time. Generally the latter is insignificant.
+ +  process on incoming events, or scheduled with a high degree of precision.
  +
  +  See the GitHub wiki for more information about available commands:<br>
  +  - https://github.com/zorael/kameloso/wiki/Current-plugins#seen
@@ -157,9 +154,10 @@ public:
  +
  +  * `kameloso.plugins.common.IRCPluginState.scheduledFibers` is also an array of
  +     `core.thread.Fiber`s, but not an associative one keyed on event types.
- +     Instead they are tuples of a `core.thread.Fiber` and a `long` UNIX
+ +     Instead they are tuples of a `core.thread.Fiber` and a `long`
  +     timestamp of when they should be run.
- +     Use `kameloso.plugins.common.delayFiber` to enqueue.
+ +     Use `kameloso.plugins.common.delayFiber` to enqueue, or
+ +     `kameloso.plugins.common.delayFiberMsecs` for greater granularity.
  +
  +  * `kameloso.plugins.common.IRCPluginState.nextPeriodical` is a UNIX timestamp
  +     of when the `periodical(IRCPlugin)` function should be run next. It is a


### PR DESCRIPTION
This changes the way scheduled Fiber timestamps are being stored from being a UNIX timestamp in seconds to being the hecto-nanoseconds that `Clock.currStdTime` returns. Other timed features, such as `periodically`, work as they always have.

`mainLoop` is altered to adjust the socket read timeout to coincide with when the next scheduled Fiber is due. Its accuracy is highly dependent on current plugins' handling times, but cursory testing showed it to generally be within 50ms.