### PR TITLE
Add support for identifying users by hostmask

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ All of the above are plugins and can be runtime disabled or compiled out. It is 
 
 ## Current limitations
 
-Use on networks without [*services*](https://en.wikipedia.org/wiki/IRC_services) (`NickServ`/`Q`/`AuthServ`/...) may be difficult, since the bot identifies people by their account names. You will probably want to register yourself with such, where available. This is not an unsolvable problem though; the authentication logic is centralised and can likely be extended to match host masks (`*!*@*`) instead.
+[Services](https://en.wikipedia.org/wiki/IRC_services) accounts (`NickServ`/`Q`/`AuthServ`/...) are used to uniquely identify users. You will probably want to register yourself with such, where available. There is experimental support for servers that can only provide conventional hostmasks (`nickname!ident@address.tld`), but it needs testing. Caveat emptor.
 
 Note that while IRC is standardised, servers still come in [many flavours](https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/IRCd_software_implementations3.svg/1533px-IRCd_software_implementations3.svg.png), some of which [outright conflict](http://defs.ircdocs.horse/defs/numerics.html) with others. If something doesn't immediately work, generally it's because we simply haven't encountered that type of event before, and so no rules for how to parse it have yet been written. Please file a GitHub issue [to the **dialect** project](https://github.com/zorael/dialect/issues).
 

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -710,7 +710,7 @@ struct Kameloso
      +  update all plugins to have a current copy of it.
      +
      +  Params:
-     +      sttings = `kameloso.common.CoreSettings` to propagate to all plugins.
+     +      settings = `kameloso.common.CoreSettings` to propagate to all plugins.
      +/
     void propagateSettings(CoreSettings settings) nothrow @nogc
     {

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -112,7 +112,7 @@ struct CoreSettings
     bool brightTerminal = false;
 
     /// Flag denoting that usermask should be used instead of accounts to authenticate.
-    bool useHostmasks = false;
+    bool preferHostmasks = false;
 
     /// Whether to connect to IPv6 addresses or only use IPV4 ones.
     bool ipv6 = true;

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -519,7 +519,7 @@ struct Kameloso
             }
         }
 
-        immutable allCustomSuccess = plugins.applyCustomSettings(customSettings);
+        immutable allCustomSuccess = plugins.applyCustomSettings(customSettings, settings);
 
         if (!allCustomSuccess)
         {

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -23,6 +23,9 @@ shared static this()
 
     // This is technically before settings have been read...
     logger = new KamelosoLogger;
+
+    // settings needs instantiating now.
+    settings = new CoreSettings;
 }
 
 

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -471,6 +471,7 @@ struct Kameloso
         state.server = parser.server;
         state.bot = this.bot;
         state.mainThread = thisTid;
+        state.settings = .settings;
         immutable now = Clock.currTime.toUnixTime;
 
         plugins.reserve(EnabledPlugins.length);

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -790,10 +790,10 @@ void printVersionInfo(TerminalForeground colourCode) @system
  +      pre = String to preface the line with, usually a colour code string.
  +      post = String to end the line with, usually a resetting code string.
  +/
-void printVersionInfo(const string pre = string.init, const string post = string.init) @system
+void printVersionInfo(const string pre = string.init, const string post = string.init) @safe
 {
     import kameloso.constants : KamelosoInfo;
-    import std.stdio : stdout, writefln;
+    import std.stdio : writefln;
 
     writefln("%skameloso IRC bot v%s, built %s\n$ git clone %s.git%s",
         pre,
@@ -801,8 +801,6 @@ void printVersionInfo(const string pre = string.init, const string post = string
         cast(string)KamelosoInfo.built,
         cast(string)KamelosoInfo.source,
         post);
-
-    if (settings.flush) stdout.flush();
 }
 
 

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -476,7 +476,7 @@ struct Kameloso
         state.server = parser.server;
         state.bot = this.bot;
         state.mainThread = thisTid;
-        state.settings = .settings;
+        state.settings = settings;
         immutable now = Clock.currTime.toUnixTime;
 
         plugins.reserve(EnabledPlugins.length);

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -60,9 +60,7 @@ Logger logger;
  +      bright = Whether the terminal has a bright background or not.
  +      flush = Whether or not to flush stdout after finishing writing to it.
  +/
-void initLogger(const bool monochrome = settings.monochrome,
-    const bool bright = settings.brightTerminal,
-    const bool flush = settings.flush)
+void initLogger(const bool monochrome, const bool bright, const bool flush)
 out (; (logger !is null), "Failed to initialise logger")
 do
 {
@@ -460,7 +458,8 @@ struct Kameloso
      +  Throws:
      +      `kameloso.plugins.common.IRCPluginSettingsException` on failure to apply custom settings.
      +/
-    void initPlugins(const string[] customSettings, out string[][string] missingEntries,
+    void initPlugins(const string[] customSettings,
+        out string[][string] missingEntries,
         out string[][string] invalidEntries) @system
     {
         import kameloso.plugins : EnabledPlugins;

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -267,6 +267,11 @@ struct Kameloso
     IRCPlugin[] plugins;
 
     /++
+     +  The root copy of the program-wide settings.
+     +/
+    CoreSettings settings;
+
+    /++
      +  When a nickname was last issued a WHOIS query for, for hysteresis
      +  and rate-limiting.
      +/

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -81,7 +81,7 @@ do
  +  `kameloso.common.settings`, so they know to use monochrome output or not.
  +  It is a problem that needs solving.
  +/
-CoreSettings settings;
+CoreSettings* settings;
 
 
 // CoreSettings

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -716,7 +716,7 @@ struct Kameloso
     void propagateSettings(CoreSettings settings) nothrow @nogc
     {
         // Inherit the changes ourselves
-        .settings = settings;
+        this.settings = settings;
 
         foreach (plugin; plugins)
         {

--- a/source/kameloso/config.d
+++ b/source/kameloso/config.d
@@ -51,9 +51,14 @@ void writeConfigurationFile(ref Kameloso instance, const string filename) @syste
 
         sink.serialise(parser.client, bot, parser.server, settings);
 
-        foreach (plugin; instance.plugins)
+        foreach (immutable i, plugin; instance.plugins)
         {
             plugin.serialiseConfigInto(sink);
+
+            if (i+1 < instance.plugins.length)
+            {
+                sink.put('\n');
+            }
         }
 
         immutable justified = sink.data.justifiedEntryValueText;

--- a/source/kameloso/config.d
+++ b/source/kameloso/config.d
@@ -35,7 +35,6 @@ public:
  +/
 void writeConfigurationFile(ref Kameloso instance, const string filename) @system
 {
-    import kameloso.common : settings;
     import lu.serialisation : justifiedEntryValueText, serialise;
     import lu.string : beginsWith, encode64;
     import std.array : Appender;

--- a/source/kameloso/getopt.d
+++ b/source/kameloso/getopt.d
@@ -233,13 +233,13 @@ public:
  +/
 Next handleGetopt(ref Kameloso instance, string[] args, out string[] customSettings) @system
 {
-    import kameloso.common : printVersionInfo, settings;
+    import kameloso.common : printVersionInfo;
     import kameloso.config : applyDefaults, readConfigInto;
     import std.format : format;
     import std.getopt : arraySep, config, getopt;
     import std.stdio : stdout, writeln;
 
-    scope(exit) if (settings.flush) stdout.flush();
+    scope(exit) if (instance.settings.flush) stdout.flush();
 
     bool shouldWriteConfig;
     bool shouldShowVersion;

--- a/source/kameloso/getopt.d
+++ b/source/kameloso/getopt.d
@@ -47,7 +47,7 @@ import std.typecons : No, Yes;
  +/
 void printHelp(GetoptResult results, const bool monochrome, const bool brightTerminal) @system
 {
-    import kameloso.common : printVersionInfo, settings;
+    import kameloso.common : printVersionInfo;
     import std.stdio : writeln;
 
     string pre, post;

--- a/source/kameloso/getopt.d
+++ b/source/kameloso/getopt.d
@@ -41,8 +41,11 @@ import std.typecons : No, Yes;
  +
  +  Params:
  +      results = Results from a `std.getopt.getopt` call, usually with `.helpWanted` true.
+ +      monochrome = Whether or not terminal colours should be used.
+ +      brightTerminal = Whether or not the terminal has a bright background
+ +          and colours should be adjusted to suit.
  +/
-void printHelp(GetoptResult results) @system
+void printHelp(GetoptResult results, const bool monochrome, const bool brightTerminal) @system
 {
     import kameloso.common : printVersionInfo, settings;
     import std.stdio : writeln;
@@ -53,12 +56,12 @@ void printHelp(GetoptResult results) @system
     {
         import kameloso.terminal : TerminalForeground, colour;
 
-        if (!settings.monochrome)
+        if (!monochrome)
         {
             enum headertintColourBright = TerminalForeground.black.colour.idup;
             enum headertintColourDark = TerminalForeground.white.colour.idup;
             enum defaulttintColour = TerminalForeground.default_.colour.idup;
-            pre = settings.brightTerminal ? headertintColourBright : headertintColourDark;
+            pre = brightTerminal ? headertintColourBright : headertintColourDark;
             post = defaulttintColour;
         }
     }
@@ -70,11 +73,11 @@ void printHelp(GetoptResult results) @system
 
     version(Colours)
     {
-        if (!settings.monochrome)
+        if (!monochrome)
         {
             import kameloso.terminal : TerminalForeground, colour;
 
-            immutable headlineTint = settings.brightTerminal ?
+            immutable headlineTint = brightTerminal ?
                 TerminalForeground.green : TerminalForeground.lightgreen;
             headline = headline.colour(headlineTint);
         }
@@ -105,7 +108,7 @@ void printHelp(GetoptResult results) @system
 void writeConfig(ref Kameloso instance, ref IRCClient client, ref IRCServer server,
     ref IRCBot bot, const string[] customSettings) @system
 {
-    import kameloso.common : Tint, logger, printVersionInfo, settings;
+    import kameloso.common : Tint, logger, printVersionInfo;
     import kameloso.config : writeConfigurationFile;
     import kameloso.constants : KamelosoDefaultStrings;
     import kameloso.printing : printObjects;
@@ -119,7 +122,7 @@ void writeConfig(ref Kameloso instance, ref IRCClient client, ref IRCServer serv
     {
         import kameloso.terminal : TerminalForeground;
 
-        if (!settings.monochrome)
+        if (!instance.settings.monochrome)
         {
             import kameloso.terminal : colour;
 
@@ -140,11 +143,11 @@ void writeConfig(ref Kameloso instance, ref IRCClient client, ref IRCServer serv
     // string, and havig it there would enforce the default string if none present.
     if (!instance.bot.quitReason.length) instance.bot.quitReason = KamelosoDefaultStrings.quitReason;
 
-    printObjects(client, instance.bot, server, settings);
+    printObjects(client, instance.bot, server, instance.settings);
 
-    instance.writeConfigurationFile(settings.configFile);
+    instance.writeConfigurationFile(instance.settings.configFile);
 
-    logger.logf("Configuration written to %s%s\n", Tint.info, settings.configFile);
+    logger.logf("Configuration written to %s%s\n", Tint.info, instance.settings.configFile);
 
     if (!instance.bot.admins.length && !instance.bot.homeChannels.length)
     {
@@ -163,10 +166,14 @@ void writeConfig(ref Kameloso instance, ref IRCClient client, ref IRCServer serv
  +      instance = Reference to the current `kameloso.common.Kameloso`.
  +      customSettings = const string array to all the custom settings set
  +          via `getopt`, to apply to things before saving to disk.
+ +      monochrome = Whether or not terminal colours should be used.
+ +      brightTerminal = Whether or not the terminal has a bright background
+ +          and colours should be adjusted to suit.
  +/
-void printSettings(ref Kameloso instance, const string[] customSettings) @system
+void printSettings(ref Kameloso instance, const string[] customSettings,
+    const bool monochrome, const bool brightTerminal) @system
 {
-    import kameloso.common : printVersionInfo, settings;
+    import kameloso.common : printVersionInfo;
     import kameloso.printing : printObjects;
     import std.stdio : writeln;
 
@@ -176,12 +183,12 @@ void printSettings(ref Kameloso instance, const string[] customSettings) @system
     {
         import kameloso.terminal : TerminalForeground, colour;
 
-        if (!settings.monochrome)
+        if (!monochrome)
         {
             enum headertintColourBright = TerminalForeground.black.colour.idup;
             enum headertintColourDark = TerminalForeground.white.colour.idup;
             enum defaulttintColour = TerminalForeground.default_.colour.idup;
-            pre = settings.brightTerminal ? headertintColourBright : headertintColourDark;
+            pre = brightTerminal ? headertintColourBright : headertintColourDark;
             post = defaulttintColour;
         }
     }
@@ -189,7 +196,8 @@ void printSettings(ref Kameloso instance, const string[] customSettings) @system
     printVersionInfo(pre, post);
     writeln();
 
-    printObjects!(No.printAll)(instance.parser.client, instance.bot, instance.parser.server, settings);
+    printObjects!(No.printAll)(instance.parser.client, instance.bot,
+        instance.parser.server, instance.settings);
 
     string[][string] ignore;
     instance.initPlugins(customSettings, ignore, ignore);
@@ -348,7 +356,7 @@ Next handleGetopt(ref Kameloso instance, string[] args, out string[] customSetti
         else if (configFileResults.helpWanted)
         {
             // --help|-h was passed; show the help table and quit
-            printHelp(results);
+            printHelp(results, instance.settings.monochrome, instance.settings.brightTerminal);
             return Next.returnSuccess;
         }
 
@@ -424,7 +432,8 @@ Next handleGetopt(ref Kameloso instance, string[] args, out string[] customSetti
         if (shouldShowSettings)
         {
             // --settings was passed, show all options and quit
-            printSettings(instance, customSettings);
+            printSettings(instance, customSettings, instance.settings.monochrome,
+                instance.settings.brightTerminal);
             return Next.returnSuccess;
         }
 

--- a/source/kameloso/kameloso.d
+++ b/source/kameloso/kameloso.d
@@ -5,7 +5,8 @@ module kameloso.kameloso;
 
 private:
 
-import kameloso.common;
+import kameloso.common : CoreSettings, Kameloso, OutgoingLine, Tint,
+    initLogger, logger, printVersionInfo;
 import kameloso.printing;
 import kameloso.thread : ThreadMessage;
 import dialect;
@@ -1823,19 +1824,19 @@ void complainAboutInvalidConfigurationEntries(const string[][string] invalidEntr
  +  Params:
  +      binaryPath = Full path to the current binary.
  +/
-void complainAboutMissingConfiguration(const string binaryPath)
+void complainAboutMissingConfiguration(const string configFile, const string binaryPath)
 {
     import std.file : exists;
     import std.path : baseName;
 
     logger.warning("Warning: No administrators nor home channels configured!");
 
-    if (settings.configFile.exists)
+    if (configFile.exists)
     {
         import kameloso.config : complainAboutIncompleteConfiguration;
 
         logger.logf("Edit %s%s%s and make sure it has at least one of the following:",
-            Tint.info, settings.configFile, Tint.log);
+            Tint.info, configFile, Tint.log);
         complainAboutIncompleteConfiguration();
     }
     else
@@ -1885,7 +1886,7 @@ void preInstanceSetup()
  +
  +  This is called during early execution.
  +/
-void setupSettings()
+void setupSettings(ref CoreSettings settings)
 {
     import kameloso.platform : configurationBaseDirectory, currentPlatform, resourceBaseDirectory;
     import std.path : buildNormalizedPath;
@@ -2328,7 +2329,7 @@ int initBot(string[] args)
     Attempt attempt;
 
     // Set up `kameloso.common.settings`, expanding paths.
-    setupSettings();
+    setupSettings(instance.settings);
 
     // Initialise the logger immediately so it's always available.
     // handleGetopt re-inits later when we know the settings for monochrome
@@ -2402,7 +2403,7 @@ int initBot(string[] args)
 
     if (!instance.bot.homeChannels.length && !instance.bot.admins.length)
     {
-        complainAboutMissingConfiguration(args[0]);
+        complainAboutMissingConfiguration(instance.settings.configFile, args[0]);
     }
 
     // Verify that settings are as they should be (nickname exists and not too long, etc)

--- a/source/kameloso/kameloso.d
+++ b/source/kameloso/kameloso.d
@@ -2319,8 +2319,11 @@ int initBot(string[] args)
     // Set up the terminal environment.
     preInstanceSetup();
 
+    static import kameloso.common;
+
     // Initialise the main Kameloso. Set its abort pointer to the global abort.
     Kameloso instance;
+    kameloso.common.settings = &instance.settings;
     instance.abort = &abort;
     Attempt attempt;
 

--- a/source/kameloso/kameloso.d
+++ b/source/kameloso/kameloso.d
@@ -1822,6 +1822,7 @@ void complainAboutInvalidConfigurationEntries(const string[][string] invalidEntr
  +  the calling site.
  +
  +  Params:
+ +      configFile = Full path to the configuration file.
  +      binaryPath = Full path to the current binary.
  +/
 void complainAboutMissingConfiguration(const string configFile, const string binaryPath)
@@ -1885,6 +1886,9 @@ void preInstanceSetup()
  +  Sets up `kameloso.common.settings`, expanding paths and more.
  +
  +  This is called during early execution.
+ +
+ +  Params:
+ +      settings = A reference to the `kameloso.common.CoreSettings` we want to set up.
  +/
 void setupSettings(ref CoreSettings settings)
 {

--- a/source/kameloso/messaging.d
+++ b/source/kameloso/messaging.d
@@ -40,7 +40,6 @@ module kameloso.messaging;
 
 private:
 
-import kameloso.common : settings;
 import kameloso.plugins.ircplugin : IRCPluginState;
 import dialect.defs;
 import lu.string : beginsWithOneOf;
@@ -73,7 +72,7 @@ public:
  +      background = Whether or not to send it as a low-priority background message.
  +/
 void chan(Flag!"priority" priority = No.priority)(ref IRCPluginState state,
-    const string channelName, const string content, bool quiet = settings.hideOutgoing,
+    const string channelName, const string content, bool quiet = false,
     const bool background = false)
 in (channelName.length, "Tried to send a channel message but no channel was given")
 do
@@ -146,7 +145,7 @@ unittest
  +      background = Whether or not to send it as a low-priority background message.
  +/
 void query(Flag!"priority" priority = No.priority)(ref IRCPluginState state,
-    const string nickname, const string content, const bool quiet = settings.hideOutgoing,
+    const string nickname, const string content, const bool quiet = false,
     const bool background = false)
 in (nickname.length, "Tried to send a private query but no nickname was given")
 do
@@ -204,7 +203,7 @@ unittest
  +/
 void privmsg(Flag!"priority" priority = No.priority)(ref IRCPluginState state,
     const string channel, const string nickname, const string content,
-    const bool quiet = settings.hideOutgoing, const bool background = false)
+    const bool quiet = false, const bool background = false)
 in ((channel.length || nickname.length), "Tried to send a PRIVMSG but no channel nor nickname was given")
 do
 {
@@ -272,7 +271,7 @@ unittest
  +      background = Whether or not to send it as a low-priority background message.
  +/
 void emote(Flag!"priority" priority = No.priority)(ref IRCPluginState state,
-    const string emoteTarget, const string content, const bool quiet = settings.hideOutgoing,
+    const string emoteTarget, const string content, const bool quiet = false,
     const bool background = false)
 in (emoteTarget.length, "Tried to send an emote but no target was given")
 do
@@ -349,7 +348,7 @@ unittest
  +/
 void mode(Flag!"priority" priority = No.priority)(ref IRCPluginState state,
     const string channel, const const(char)[] modes, const string content = string.init,
-    const bool quiet = settings.hideOutgoing, const bool background = false)
+    const bool quiet = false, const bool background = false)
 in (channel.length, "Tried to set a mode but no channel was given")
 do
 {
@@ -402,7 +401,7 @@ unittest
  +      background = Whether or not to send it as a low-priority background message.
  +/
 void topic(Flag!"priority" priority = No.priority)(ref IRCPluginState state,
-    const string channel, const string content, const bool quiet = settings.hideOutgoing,
+    const string channel, const string content, const bool quiet = false,
     const bool background = false)
 in (channel.length, "Tried to set a topic but no channel was given")
 do
@@ -454,7 +453,7 @@ unittest
  +      background = Whether or not to send it as a low-priority background message.
  +/
 void invite(Flag!"priority" priority = No.priority)(ref IRCPluginState state,
-    const string channel, const string nickname, const bool quiet = settings.hideOutgoing,
+    const string channel, const string nickname, const bool quiet = false,
     const bool background = false)
 in (channel.length, "Tried to send an invite but no channel was given")
 in (nickname.length, "Tried to send an invite but no nickname was given")
@@ -508,7 +507,7 @@ unittest
  +/
 void join(Flag!"priority" priority = No.priority)(ref IRCPluginState state,
     const string channel, const string key = string.init,
-    const bool quiet = settings.hideOutgoing, const bool background = false)
+    const bool quiet = false, const bool background = false)
 in (channel.length, "Tried to join a channel but no channel was given")
 do
 {
@@ -560,7 +559,7 @@ unittest
  +/
 void kick(Flag!"priority" priority = No.priority)(ref IRCPluginState state,
     const string channel, const string nickname, const string reason = string.init,
-    const bool quiet = settings.hideOutgoing, const bool background = false)
+    const bool quiet = false, const bool background = false)
 in (channel.length, "Tried to kick someone but no channel was given")
 in (nickname.length, "Tried to kick someone but no nickname was given")
 do
@@ -615,7 +614,7 @@ unittest
  +/
 void part(Flag!"priority" priority = No.priority)(ref IRCPluginState state,
     const string channel, const string reason = string.init,
-    const bool quiet = settings.hideOutgoing, const bool background = false)
+    const bool quiet = false, const bool background = false)
 in (channel.length, "Tried to part a channel but no channel was given")
 do
 {
@@ -665,7 +664,7 @@ unittest
  +      quiet = Whether or not to echo what was sent to the local terminal.
  +/
 void quit(Flag!"priority" priority = Yes.priority)(ref IRCPluginState state,
-    const string reason = string.init, const bool quiet = settings.hideOutgoing)
+    const string reason = string.init, const bool quiet = false)
 {
     static if (priority) import std.concurrency : send = prioritySend;
 
@@ -714,7 +713,7 @@ unittest
  +/
 void whois(Flag!"priority" priority = No.priority)(ref IRCPluginState state,
     const string nickname, const bool force = false,
-    const bool quiet = settings.hideOutgoing, const bool background = false,
+    const bool quiet = false, const bool background = false,
     const string caller = __FUNCTION__)
 in (nickname.length, caller ~ " tried to WHOIS but no nickname was given")
 do
@@ -779,8 +778,7 @@ unittest
  +      background = Whether or not to send it as a low-priority background message.
  +/
 void raw(Flag!"priority" priority = No.priority)(ref IRCPluginState state,
-    const string line, const bool quiet = settings.hideOutgoing,
-    const bool background = false)
+    const string line, const bool quiet = false, const bool background = false)
 {
     static if (priority) import std.concurrency : send = prioritySend;
 

--- a/source/kameloso/plugins/admin.d
+++ b/source/kameloso/plugins/admin.d
@@ -1486,7 +1486,8 @@ void onSetCommand(AdminPlugin plugin, const IRCEvent event)
 
         try
         {
-            immutable success = thisFiber.payload.applyCustomSettings([ event.content ]);
+            immutable success = thisFiber.payload
+                .applyCustomSettings([ event.content ], plugin.state.settings);
 
             if (success)
             {
@@ -1736,7 +1737,8 @@ void onBusMessage(AdminPlugin plugin, const string header, shared Sendable conte
             auto thisFiber = cast(CarryingFiber!(IRCPlugin[]))(Fiber.getThis);
             assert(thisFiber, "Incorrectly cast Fiber: " ~ typeof(thisFiber).stringof);
 
-            immutable success = thisFiber.payload.applyCustomSettings([ slice ]);
+            immutable success = thisFiber.payload
+                .applyCustomSettings([ slice ], plugin.state.settings);
             if (success) logger.log("Setting changed.");
             // applyCustomSettings displays its own error messages
         }

--- a/source/kameloso/plugins/admin.d
+++ b/source/kameloso/plugins/admin.d
@@ -790,24 +790,35 @@ in (((list == "whitelist") || (list == "blacklist") || (list == "operator")),
         immutable result = plugin.alterAccountClassifier(Yes.add, list, user.account, channel);
         return report(result, nameOf(*user));
     }
-    else if (!specified.isValidNickname(plugin.state.server))
+    else
     {
-        if (event.sender.nickname.length)
-        {
-            // IRC report
+        immutable invalid = plugin.state.settings.preferHostmasks ?
+            !specified.isValidHostmask(plugin.state.server) :
+            !specified.isValidNickname(plugin.state.server);
 
-            immutable message = plugin.state.settings.colouredOutgoing ?
-                "Invalid nickname/account: " ~ specified.ircColour(IRCColour.red).ircBold :
-                "Invalid nickname/account: " ~ specified;
-
-            privmsg(plugin.state, event.channel, event.sender.nickname, message);
-        }
-        else
+        if (invalid)
         {
-            // Terminal report
-            logger.warning("Invalid nickname/account: ", Tint.log, specified);
+            immutable invalidWhat = plugin.state.settings.preferHostmasks ?
+                "hostmask" :
+                "nickname/account";
+
+            if (event.sender.nickname.length)
+            {
+                // IRC report
+
+                immutable message = plugin.state.settings.colouredOutgoing ?
+                    "Invalid " ~ invalidWhat ~ ": " ~ specified.ircColour(IRCColour.red).ircBold :
+                    "Invalid " ~ invalidWhat ~ ": " ~ specified;
+
+                privmsg(plugin.state, event.channel, event.sender.nickname, message);
+            }
+            else
+            {
+                // Terminal report
+                logger.warning("Invalid " ~ invalidWhat ~ ": ", Tint.log, specified);
+            }
+            return;
         }
-        return;
     }
 
     void onSuccess(const string id)

--- a/source/kameloso/plugins/admin.d
+++ b/source/kameloso/plugins/admin.d
@@ -790,35 +790,24 @@ in (((list == "whitelist") || (list == "blacklist") || (list == "operator")),
         immutable result = plugin.alterAccountClassifier(Yes.add, list, user.account, channel);
         return report(result, nameOf(*user));
     }
-    else
+    else if (!specified.isValidNickname(plugin.state.server))
     {
-        immutable invalid = plugin.state.settings.preferHostmasks ?
-            !specified.isValidHostmask(plugin.state.server) :
-            !specified.isValidNickname(plugin.state.server);
-
-        if (invalid)
+        if (event.sender.nickname.length)
         {
-            immutable invalidWhat = plugin.state.settings.preferHostmasks ?
-                "hostmask" :
-                "nickname/account";
+            // IRC report
 
-            if (event.sender.nickname.length)
-            {
-                // IRC report
+            immutable message = plugin.state.settings.colouredOutgoing ?
+                "Invalid nickname/account: " ~ specified.ircColour(IRCColour.red).ircBold :
+                "Invalid nickname/account: " ~ specified;
 
-                immutable message = plugin.state.settings.colouredOutgoing ?
-                    "Invalid " ~ invalidWhat ~ ": " ~ specified.ircColour(IRCColour.red).ircBold :
-                    "Invalid " ~ invalidWhat ~ ": " ~ specified;
-
-                privmsg(plugin.state, event.channel, event.sender.nickname, message);
-            }
-            else
-            {
-                // Terminal report
-                logger.warning("Invalid " ~ invalidWhat ~ ": ", Tint.log, specified);
-            }
-            return;
+            privmsg(plugin.state, event.channel, event.sender.nickname, message);
         }
+        else
+        {
+            // Terminal report
+            logger.warning("Invalid nickname/account: ", Tint.log, specified);
+        }
+        return;
     }
 
     void onSuccess(const string id)

--- a/source/kameloso/plugins/admin.d
+++ b/source/kameloso/plugins/admin.d
@@ -1144,7 +1144,7 @@ void onCommandResetTerminal()
     import std.stdio : stdout, write;
 
     write(cast(char)TerminalToken.reset);
-    if (settings.flush) stdout.flush();
+    stdout.flush();
 }
 
 

--- a/source/kameloso/plugins/admin.d
+++ b/source/kameloso/plugins/admin.d
@@ -23,7 +23,7 @@ private:
 import kameloso.plugins.ircplugin;
 import kameloso.plugins.common;
 import kameloso.plugins.awareness : ChannelAwareness, TwitchAwareness, UserAwareness;
-import kameloso.common : Tint, logger, settings;
+import kameloso.common : Tint, logger;
 import kameloso.irccolours : IRCColour, ircBold, ircColour, ircColourByHash;
 import kameloso.messaging;
 import dialect.defs;
@@ -93,7 +93,7 @@ void onAnyEvent(AdminPlugin plugin, const IRCEvent event)
     {
         if (event.tags.length) write('@', event.tags, ' ');
         writeln(event.raw, '$');
-        if (settings.flush) stdout.flush();
+        if (plugin.state.settings.flush) stdout.flush();
     }
 
     if (plugin.adminSettings.printBytes)
@@ -105,7 +105,7 @@ void onAnyEvent(AdminPlugin plugin, const IRCEvent event)
             writefln("[%d] %s : %03d", i, cast(char)c, c);
         }
 
-        if (settings.flush) stdout.flush();
+        if (plugin.state.settings.flush) stdout.flush();
     }
 
     version(AdminAssertGeneration)
@@ -135,7 +135,7 @@ void onAnyEvent(AdminPlugin plugin, const IRCEvent event)
                 plugin.previousClient = plugin.state.client;
             }
 
-            if (settings.flush) stdout.flush();
+            if (plugin.state.settings.flush) stdout.flush();
         }
     }
 }
@@ -169,7 +169,7 @@ void onCommandShowUser(AdminPlugin plugin, const IRCEvent event)
         }
         else
         {
-            immutable message = settings.colouredOutgoing ?
+            immutable message = plugin.state.settings.colouredOutgoing ?
                 "No such user: " ~ username.ircColour(IRCColour.red).ircBold :
                 "No such user: " ~ username;
 
@@ -228,7 +228,7 @@ void onCommandShowUsers(AdminPlugin plugin)
     }
 
     writeln(plugin.state.users.length, " users.");
-    if (settings.flush) stdout.flush();
+    if (plugin.state.settings.flush) stdout.flush();
 }
 
 
@@ -307,7 +307,7 @@ void onCommandHome(AdminPlugin plugin, const IRCEvent event)
     {
         privmsg(plugin.state, event.channel, event.sender.nickname,
             "Usage: %s%s [add|del|list] [channel]"
-            .format(settings.prefix, event.aux));
+            .format(plugin.state.settings.prefix, event.aux));
     }
 
     if (!event.content.length)
@@ -505,7 +505,7 @@ in (rawChannel.length, "Tried to delete a home but the channel string was empty"
 
         enum pattern = "Channel %s was not listed as a home.";
 
-        immutable message = settings.colouredOutgoing ?
+        immutable message = plugin.state.settings.colouredOutgoing ?
             pattern.format(channel.ircBold) :
             pattern.format(channel);
 
@@ -610,7 +610,7 @@ do
     {
         import std.format : format;
         privmsg(plugin.state, event.channel, event.sender.nickname,
-            "Usage: %s%s [add|del|list]".format(settings.prefix, list));
+            "Usage: %s%s [add|del|list]".format(plugin.state.settings.prefix, list));
     }
 
     if (!event.content.length)
@@ -731,7 +731,7 @@ in (((list == "whitelist") || (list == "blacklist") || (list == "operator")),
             case success:
                 enum pattern = "Added %s as %s in %s.";
 
-                immutable message = settings.colouredOutgoing ?
+                immutable message = plugin.state.settings.colouredOutgoing ?
                     pattern.format(id.ircColourByHash.ircBold, asWhat, channel) :
                     pattern.format(id, asWhat, channel);
 
@@ -745,7 +745,7 @@ in (((list == "whitelist") || (list == "blacklist") || (list == "operator")),
             case alreadyInList:
                 enum pattern = "%s was already %s in %s.";
 
-                immutable message = settings.colouredOutgoing ?
+                immutable message = plugin.state.settings.colouredOutgoing ?
                     pattern.format(id.ircColourByHash.ircBold, asWhat, channel) :
                     pattern.format(id, asWhat, channel);
 
@@ -797,7 +797,7 @@ in (((list == "whitelist") || (list == "blacklist") || (list == "operator")),
         {
             // IRC report
 
-            immutable message = settings.colouredOutgoing ?
+            immutable message = plugin.state.settings.colouredOutgoing ?
                 "Invalid nickname/account: " ~ specified.ircColour(IRCColour.red).ircBold :
                 "Invalid nickname/account: " ~ specified;
 
@@ -941,7 +941,7 @@ in (((list == "whitelist") || (list == "blacklist") || (list == "operator")),
         case noSuchAccount:
             enum pattern = "No such account %s to remove as %s in %s.";
 
-            immutable message = settings.colouredOutgoing ?
+            immutable message = plugin.state.settings.colouredOutgoing ?
                 pattern.format(account.ircColourByHash.ircBold, asWhat, channel) :
                 pattern.format(account, asWhat, channel);
 
@@ -951,7 +951,7 @@ in (((list == "whitelist") || (list == "blacklist") || (list == "operator")),
         case noSuchChannel:
             enum pattern = "Account %s isn't %s in %s.";
 
-            immutable message = settings.colouredOutgoing ?
+            immutable message = plugin.state.settings.colouredOutgoing ?
                 pattern.format(account.ircColourByHash.ircBold, asWhat, channel) :
                 pattern.format(account, asWhat, channel);
 
@@ -961,7 +961,7 @@ in (((list == "whitelist") || (list == "blacklist") || (list == "operator")),
         case success:
             enum pattern = "Removed %s as %s in %s.";
 
-            immutable message = settings.colouredOutgoing ?
+            immutable message = plugin.state.settings.colouredOutgoing ?
                 pattern.format(account.ircColourByHash.ircBold, asWhat, channel) :
                 pattern.format(account, asWhat, channel);
 
@@ -1168,7 +1168,7 @@ void onCommandPrintRaw(AdminPlugin plugin, const IRCEvent event)
 
     plugin.adminSettings.printRaw = !plugin.adminSettings.printRaw;
 
-    immutable message = settings.colouredOutgoing ?
+    immutable message = plugin.state.settings.colouredOutgoing ?
         "Printing all: " ~ plugin.adminSettings.printRaw.text.ircBold :
         "Printing all: " ~ plugin.adminSettings.printRaw.text;
 
@@ -1196,7 +1196,7 @@ void onCommandPrintBytes(AdminPlugin plugin, const IRCEvent event)
 
     plugin.adminSettings.printBytes = !plugin.adminSettings.printBytes;
 
-    immutable message = settings.colouredOutgoing ?
+    immutable message = plugin.state.settings.colouredOutgoing ?
         "Printing bytes: " ~ plugin.adminSettings.printBytes.text.ircBold :
         "Printing bytes: " ~ plugin.adminSettings.printBytes.text;
 
@@ -1226,7 +1226,7 @@ void onCommandAsserts(AdminPlugin plugin, const IRCEvent event)
 
     plugin.adminSettings.printAsserts = !plugin.adminSettings.printAsserts;
 
-    immutable message = settings.colouredOutgoing ?
+    immutable message = plugin.state.settings.colouredOutgoing ?
         "Printing asserts: " ~ plugin.adminSettings.printAsserts.text.ircBold :
         "Printing asserts: " ~ plugin.adminSettings.printAsserts.text;
 
@@ -1241,7 +1241,7 @@ void onCommandAsserts(AdminPlugin plugin, const IRCEvent event)
             plugin.state.client, plugin.state.server);
     }
 
-    if (settings.flush) stdout.flush();
+    if (plugin.state.settings.flush) stdout.flush();
 }
 
 
@@ -1621,7 +1621,7 @@ void onCommandBus(AdminPlugin plugin, const IRCEvent event)
         logger.info("Sending bus message.");
         writeln("Header: ", event.content);
         writeln("Content: (empty)");
-        if (settings.flush) stdout.flush();
+        if (plugin.state.settings.flush) stdout.flush();
 
         plugin.state.mainThread.send(ThreadMessage.BusMessage(), event.content);
     }
@@ -1633,7 +1633,7 @@ void onCommandBus(AdminPlugin plugin, const IRCEvent event)
         logger.info("Sending bus message.");
         writeln("Header: ", header);
         writeln("Content: ", slice);
-        if (settings.flush) stdout.flush();
+        if (plugin.state.settings.flush) stdout.flush();
 
         plugin.state.mainThread.send(ThreadMessage.BusMessage(),
             header, busMessage(slice));

--- a/source/kameloso/plugins/admin.d
+++ b/source/kameloso/plugins/admin.d
@@ -704,7 +704,6 @@ void lookupEnlist(AdminPlugin plugin, const string rawSpecified, const string li
 in (((list == "whitelist") || (list == "blacklist") || (list == "operator")),
     list ~ " is not whitelist, operator nor blacklist")
 {
-    import kameloso.common : settings;
     import dialect.common : isValidNickname;
     import lu.string : contains, stripped;
     import std.range : only;

--- a/source/kameloso/plugins/admin.d
+++ b/source/kameloso/plugins/admin.d
@@ -1879,5 +1879,8 @@ private:
     /// File with user definitions. Must be the same as in persistence.d.
     @Resource string userFile = "users.json";
 
+    /// File with hostmasks definitions. Must be the same as in persistence.d
+    @Resource string hostmasksFile = "hostmasks.json";
+
     mixin IRCPluginImpl;
 }

--- a/source/kameloso/plugins/admin.d
+++ b/source/kameloso/plugins/admin.d
@@ -878,12 +878,6 @@ in (((list == "whitelist") || (list == "blacklist") || (list == "operator")),
         }
     }
 
-    if (plugin.state.settings.preferHostmasks)
-    {
-        // Don't look up, just add what was specified to support partial globs
-        return onSuccess(specified);
-    }
-
     // User not on record or on record but no account; WHOIS and try based on results
 
     mixin WHOISFiberDelegate!(onSuccess, onFailure);

--- a/source/kameloso/plugins/admin.d
+++ b/source/kameloso/plugins/admin.d
@@ -889,6 +889,12 @@ in (((list == "whitelist") || (list == "blacklist") || (list == "operator")),
         }
     }
 
+    if (plugin.state.settings.preferHostmasks)
+    {
+        // Don't look up, just add what was specified to support partial globs
+        return onSuccess(specified);
+    }
+
     // User not on record or on record but no account; WHOIS and try based on results
 
     mixin WHOISFiberDelegate!(onSuccess, onFailure);

--- a/source/kameloso/plugins/automode.d
+++ b/source/kameloso/plugins/automode.d
@@ -16,7 +16,7 @@ private:
 import kameloso.plugins.ircplugin;
 import kameloso.plugins.common;
 import kameloso.plugins.awareness : ChannelAwareness, UserAwareness;
-import kameloso.common : Tint, logger, settings;
+import kameloso.common : Tint, logger;
 import kameloso.irccolours : IRCColour, ircBold, ircColour, ircColourByHash;
 import kameloso.messaging;
 import dialect.defs;
@@ -287,7 +287,7 @@ void onCommandAutomode(AutomodePlugin plugin, const IRCEvent event)
 
         enum pattern = "Automode modified! %s on %s: +%s";
 
-        immutable message = settings.colouredOutgoing ?
+        immutable message = plugin.state.settings.colouredOutgoing ?
             pattern.format(nickname.ircColourByHash.ircBold,
                 event.channel.ircBold, mode.ircBold) :
             pattern.format(nickname, event.channel, mode);
@@ -311,7 +311,7 @@ void onCommandAutomode(AutomodePlugin plugin, const IRCEvent event)
 
         enum pattern = "Automode for %s cleared.";
 
-        immutable message = settings.colouredOutgoing ?
+        immutable message = plugin.state.settings.colouredOutgoing ?
             pattern.format(nickname.ircColourByHash.ircBold) :
             pattern.format(nickname);
 
@@ -335,7 +335,7 @@ void onCommandAutomode(AutomodePlugin plugin, const IRCEvent event)
 
     default:
         chan(plugin.state, event.channel, "Usage: %s%s [add|clear|list] [nickname/account] [mode]"
-            .format(settings.prefix, event.aux));
+            .format(plugin.state.settings.prefix, event.aux));
         break;
     }
 }

--- a/source/kameloso/plugins/automode.d
+++ b/source/kameloso/plugins/automode.d
@@ -97,6 +97,7 @@ void initResources(AutomodePlugin plugin)
 @(IRCEvent.Type.ACCOUNT)
 @(IRCEvent.Type.RPL_WHOISACCOUNT)
 @(IRCEvent.Type.RPL_WHOISREGNICK)
+@(IRCEvent.Type.RPL_WHOISUSER)
 @(IRCEvent.Type.JOIN)
 @(PrivilegeLevel.ignore)
 @(ChannelPolicy.home)
@@ -115,6 +116,14 @@ void onAccountInfo(AutomodePlugin plugin, const IRCEvent event)
         account = sender.account;
         nickname = sender.nickname;
         break;
+
+    case RPL_WHOISUSER:
+        if (plugin.state.settings.preferHostmasks)
+        {
+            // Persistence will have set the account field.
+            goto case RPL_WHOISACCOUNT;
+        }
+        return;
 
     case RPL_WHOISACCOUNT:
     case RPL_WHOISREGNICK:

--- a/source/kameloso/plugins/chanqueries.d
+++ b/source/kameloso/plugins/chanqueries.d
@@ -61,7 +61,6 @@ enum ChannelState : ubyte
 @(IRCEvent.Type.PING)
 void startChannelQueries(ChanQueriesService service)
 {
-    import kameloso.common : settings;
     import core.thread : Fiber;
 
     if (service.querying) return;  // Try again next PING
@@ -80,7 +79,8 @@ void startChannelQueries(ChanQueriesService service)
         querylist ~= channelName;
     }
 
-    if (!querylist.length && !settings.eagerLookups) return;  // Continue anyway if eagerLookups
+    // Continue anyway if eagerLookups
+    if (!querylist.length && !service.state.settings.eagerLookups) return;
 
     void dg()
     {
@@ -204,7 +204,7 @@ void startChannelQueries(ChanQueriesService service)
         }
 
         // Stop here if we can't or are not interested in going further
-        if (!service.serverSupportsWHOIS || !settings.eagerLookups) return;
+        if (!service.serverSupportsWHOIS || !service.state.settings.eagerLookups) return;
 
         import kameloso.constants : Timeout;
 

--- a/source/kameloso/plugins/chatbot.d
+++ b/source/kameloso/plugins/chatbot.d
@@ -18,7 +18,6 @@ private:
 import kameloso.plugins.ircplugin;
 import kameloso.plugins.common;
 import kameloso.plugins.awareness : MinimalAuthentication;
-import kameloso.common : settings;
 import kameloso.irccolours : ircBold;
 import kameloso.messaging;
 import dialect.defs;
@@ -142,7 +141,7 @@ void onCommandBash(ChatbotPlugin plugin, const IRCEvent event)
     import std.concurrency : spawn;
 
     // Defer all work to the worker thread
-    spawn(&worker, cast(shared)plugin.state, event, settings.colouredOutgoing);
+    spawn(&worker, cast(shared)plugin.state, event, plugin.state.settings.colouredOutgoing);
 }
 
 

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -2014,7 +2014,9 @@ if (isSomeFunction!onSuccess && (is(typeof(onFailure) == typeof(null)) || isSome
             }
             else static if (TakesParams!(onSuccess, AliasSeq!string))
             {
-                return onSuccess(whoisEvent.target.account);
+                return onSuccess(context.state.settings.useHostmasks ?
+                    whoisEvent.target.hostmask :
+                    whoisEvent.target.account);
             }
             else static if (arity!onSuccess == 0)
             {
@@ -2046,6 +2048,7 @@ if (isSomeFunction!onSuccess && (is(typeof(onFailure) == typeof(null)) || isSome
                 }
                 else static if (TakesParams!(onFailure, AliasSeq!string))
                 {
+                    // Never called when using hostmasks
                     return onFailure(whoisEvent.target.account);
                 }
                 else static if (arity!onFailure == 0)
@@ -2094,12 +2097,12 @@ if (isSomeFunction!onSuccess && (is(typeof(onFailure) == typeof(null)) || isSome
         scope(exit) context.unlistFiberAwaitingEvents(thisFiber, whoisEventTypes[]);
 
         if ((whoisEvent.type == IRCEvent.Type.RPL_WHOISACCOUNT) ||
-            (whoisEvent.type == IRCEvent.Type.RPL_WHOISREGNICK))
+            (whoisEvent.type == IRCEvent.Type.RPL_WHOISREGNICK) ||
+            context.state.settings.useHostmasks)
         {
             callOnSuccess();
         }
-        else /* if ((whoisEvent.type == IRCEvent.Type.RPL_ENDOFWHOIS) ||
-            (whoisEvent.type == IRCEvent.Type.ERR_NOSUCHNICK)) */
+        else
         {
             callOnFailure();
         }

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -2126,6 +2126,7 @@ if (isSomeFunction!onSuccess && (is(typeof(onFailure) == typeof(null)) || isSome
     {
         import kameloso.messaging : whois;
         import kameloso.thread : CarryingFiber;
+        import lu.string : contains, nom;
         import lu.traits : TakesParams;
         import std.meta : AliasSeq;
         import std.traits : arity;
@@ -2232,21 +2233,27 @@ if (isSomeFunction!onSuccess && (is(typeof(onFailure) == typeof(null)) || isSome
 
         context.awaitEvents(fiber, whoisEventTypes[]);
 
+        string slice = nickname;
+
+        immutable nicknamePart = slice.contains('!') ?
+            slice.nom('!') :
+            slice;
+
         if (issueWhois)
         {
             if (background)
             {
                 // Args are state, nick, force, quiet, background, caller
                 // Need force (true) to not miss events
-                whois(context.state, nickname, true, true, true);
+                whois(context.state, nicknamePart, true, true, true);
             }
             else
             {
-                whois!(Yes.priority)(context.state, nickname, true, true);  // Ditto
+                whois!(Yes.priority)(context.state, nicknamePart, true, true);  // Ditto
             }
         }
 
-        mixin(carriedVariableName) = nickname;
+        mixin(carriedVariableName) = nicknamePart;
     }
 }
 

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -478,7 +478,7 @@ unittest
         "myplugin.d=99.99",
     ];
 
-    applyCustomSettings([ plugin ], newSettings);
+    applyCustomSettings([ plugin ], newSettings, state.settings);
 
     const ps = (cast(MyPlugin)plugin).myPluginSettings;
 

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -2384,3 +2384,26 @@ string idOf(IRCPlugin plugin, const string nickname) pure @safe nothrow @nogc
         return nickname;
     }
 }
+
+
+// hostmask
+/++
+ +  Formats an `dialect.defs.IRCUser` into a hostmask representing its values.
+ +
+ +  Params:
+ +      user = `dialect.defs.IRCUser` to summarise into a hostmask.
+ +
+ +  Returns:
+ +      A hostmask "*!*@*" string.
+ +/
+pragma(inline)
+string hostmask(const IRCUser user) pure @safe
+{
+    import std.format : format;
+
+    immutable nickname = user.nickname.length ? user.nickname : "*";
+    immutable ident = user.ident.length ? user.ident : "*";
+    immutable address = user.address.length ? user.address : "*";
+
+    return "%s!%s@%s".format(nickname, ident, address);
+}

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -2448,6 +2448,7 @@ bool isValidHostmask(const string hostmask, const IRCServer server) pure @safe n
         case '9':
         case '-':
         case '_':
+        case '*':
 
         static if (address)
         {
@@ -2548,6 +2549,10 @@ unittest
     }
     {
         immutable hostmask = "*!*@2001::ff:09:ff";
+        assert(hostmask.isValidHostmask(server));
+    }
+    {
+        immutable hostmask = "kameloso!~kameloso@2001*";
         assert(hostmask.isValidHostmask(server));
     }
 }

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -985,10 +985,10 @@ private:
     /++
      +  Sends a channel message.
      +/
-    void chan(Flag!"priority" priority = No.priority)(const string channel,
-        const string content, bool quiet = kameloso.common.settings.hideOutgoing)
+    void chan(Flag!"priority" priority = No.priority)(const string channel, const string content)
     {
-        return kameloso.messaging.chan!priority(privateState, channel, content, quiet);
+        return kameloso.messaging.chan!priority(privateState, channel, content,
+            privateState.settings.hideOutgoing);
     }
 
 
@@ -996,10 +996,10 @@ private:
     /++
      +  Sends a private query message to a user.
      +/
-    void query(Flag!"priority" priority = No.priority)(const string nickname,
-        const string content, const bool quiet = kameloso.common.settings.hideOutgoing)
+    void query(Flag!"priority" priority = No.priority)(const string nickname, const string content)
     {
-        return kameloso.messaging.query!priority(privateState, nickname, content, quiet);
+        return kameloso.messaging.query!priority(privateState, nickname, content,
+            privateState.settings.hideOutgoing);
     }
 
 
@@ -1012,9 +1012,10 @@ private:
      +  underlying same type; `dialect.defs.IRCEvent.Type.PRIVMSG`.
      +/
     void privmsg(Flag!"priority" priority = No.priority)(const string channel,
-        const string nickname, const string content, const bool quiet = kameloso.common.settings.hideOutgoing)
+        const string nickname, const string content)
     {
-        return kameloso.messaging.privmsg!priority(privateState, channel, nickname, content, quiet);
+        return kameloso.messaging.privmsg!priority(privateState, channel,
+            nickname, content, privateState.settings.hideOutgoing);
     }
 
 
@@ -1023,9 +1024,10 @@ private:
      +  Sends an `ACTION` "emote" to the supplied target (nickname or channel).
      +/
     void emote(Flag!"priority" priority = No.priority)(const string emoteTarget,
-        const string content, const bool quiet = kameloso.common.settings.hideOutgoing)
+        const string content)
     {
-        return kameloso.messaging.emote!priority(privateState, emoteTarget, content, quiet);
+        return kameloso.messaging.emote!priority(privateState, emoteTarget,
+            content, privateState.settings.hideOutgoing);
     }
 
 
@@ -1036,10 +1038,10 @@ private:
      +  This includes modes that pertain to a user in the context of a channel, like bans.
      +/
     void mode(Flag!"priority" priority = No.priority)(const string channel,
-        const string modes, const string content = string.init,
-        const bool quiet = kameloso.common.settings.hideOutgoing)
+        const string modes, const string content = string.init)
     {
-        return kameloso.messaging.mode!priority(privateState, channel, modes, content, quiet);
+        return kameloso.messaging.mode!priority(privateState, channel, modes,
+            content, privateState.settings.hideOutgoing);
     }
 
 
@@ -1047,10 +1049,10 @@ private:
     /++
      +  Sets the topic of a channel.
      +/
-    void topic(Flag!"priority" priority = No.priority)(const string channel,
-        const string content, const bool quiet = kameloso.common.settings.hideOutgoing)
+    void topic(Flag!"priority" priority = No.priority)(const string channel, const string content)
     {
-        return kameloso.messaging.topic!priority(privateState, channel, content, quiet);
+        return kameloso.messaging.topic!priority(privateState, channel, content,
+            privateState.settings.hideOutgoing);
     }
 
 
@@ -1058,10 +1060,10 @@ private:
     /++
      +  Invites a user to a channel.
      +/
-    void invite(Flag!"priority" priority = No.priority)(const string channel,
-        const string nickname, const bool quiet = kameloso.common.settings.hideOutgoing)
+    void invite(Flag!"priority" priority = No.priority)(const string channel, const string nickname)
     {
-        return kameloso.messaging.invite!priority(privateState, channel, nickname, quiet);
+        return kameloso.messaging.invite!priority(privateState, channel,
+            nickname, privateState.settings.hideOutgoing);
     }
 
 
@@ -1070,9 +1072,10 @@ private:
      +  Joins a channel.
      +/
     void join(Flag!"priority" priority = No.priority)(const string channel,
-        const string key = string.init, const bool quiet = kameloso.common.settings.hideOutgoing)
+        const string key = string.init)
     {
-        return kameloso.messaging.join!priority(privateState, channel, key, quiet);
+        return kameloso.messaging.join!priority(privateState, channel, key,
+            privateState.settings.hideOutgoing);
     }
 
 
@@ -1081,10 +1084,10 @@ private:
      +  Kicks a user from a channel.
      +/
     void kick(Flag!"priority" priority = No.priority)(const string channel,
-        const string nickname, const string reason = string.init,
-        const bool quiet = kameloso.common.settings.hideOutgoing)
+        const string nickname, const string reason = string.init)
     {
-        return kameloso.messaging.kick!priority(privateState, channel, nickname, reason, quiet);
+        return kameloso.messaging.kick!priority(privateState, channel, nickname,
+            reason, privateState.settings.hideOutgoing);
     }
 
 
@@ -1093,9 +1096,10 @@ private:
      +  Leaves a channel.
      +/
     void part(Flag!"priority" priority = No.priority)(const string channel,
-        const string reason = string.init, const bool quiet = kameloso.common.settings.hideOutgoing)
+        const string reason = string.init)
     {
-        return kameloso.messaging.part!priority(privateState, channel, reason, quiet);
+        return kameloso.messaging.part!priority(privateState, channel, reason,
+            privateState.settings.hideOutgoing);
     }
 
 
@@ -1103,10 +1107,10 @@ private:
     /++
      +  Disconnects from the server, optionally with a quit reason.
      +/
-    void quit(Flag!"priority" priority = No.priority)(const string reason = string.init,
-        const bool quiet = kameloso.common.settings.hideOutgoing)
+    void quit(Flag!"priority" priority = No.priority)(const string reason = string.init)
     {
-        return kameloso.messaging.quit!priority(privateState, reason, quiet);
+        return kameloso.messaging.quit!priority(privateState, reason,
+            privateState.settings.hideOutgoing);
     }
 
 
@@ -1115,10 +1119,10 @@ private:
      +  Queries the server for WHOIS information about a user.
      +/
     void whois(Flag!"priority" priority = No.priority)(const string nickname,
-        const bool force = false, const bool quiet = kameloso.common.settings.hideOutgoing,
-        const string caller = __FUNCTION__)
+        const bool force = false, const string caller = __FUNCTION__)
     {
-        return kameloso.messaging.whois!priority(privateState, nickname, force, quiet, caller);
+        return kameloso.messaging.whois!priority(privateState, nickname, force,
+            privateState.settings.hideOutgoing, caller);
     }
 
     // raw
@@ -1128,10 +1132,10 @@ private:
      +  This is used to send messages of types for which there exist no helper
      +  functions.
      +/
-    void raw(Flag!"priority" priority = No.priority)(const string line,
-        const bool quiet = kameloso.common.settings.hideOutgoing)
+    void raw(Flag!"priority" priority = No.priority)(const string line)
     {
-        return kameloso.messaging.raw!priority(privateState, line, quiet);
+        return kameloso.messaging.raw!priority(privateState, line,
+            privateState.settings.hideOutgoing);
     }
 
 

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -2014,7 +2014,7 @@ if (isSomeFunction!onSuccess && (is(typeof(onFailure) == typeof(null)) || isSome
             }
             else static if (TakesParams!(onSuccess, AliasSeq!string))
             {
-                return onSuccess(context.state.settings.useHostmasks ?
+                return onSuccess(context.state.settings.preferHostmasks ?
                     whoisEvent.target.hostmask :
                     whoisEvent.target.account);
             }
@@ -2098,7 +2098,7 @@ if (isSomeFunction!onSuccess && (is(typeof(onFailure) == typeof(null)) || isSome
 
         if ((whoisEvent.type == IRCEvent.Type.RPL_WHOISACCOUNT) ||
             (whoisEvent.type == IRCEvent.Type.RPL_WHOISREGNICK) ||
-            context.state.settings.useHostmasks)
+            context.state.settings.preferHostmasks)
         {
             callOnSuccess();
         }

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -1961,8 +1961,9 @@ if (isSomeFunction!onSuccess && (is(typeof(onFailure) == typeof(null)) || isSome
     /++
      +  Event types that we may encounter as responses to WHOIS queries.
      +/
-    static immutable whoisEventTypes =
+    static immutable IRCEvent.Type[6] whoisEventTypes =
     [
+        IRCEvent.Type.RPL_WHOISUSER,
         IRCEvent.Type.RPL_WHOISACCOUNT,
         IRCEvent.Type.RPL_WHOISREGNICK,
         IRCEvent.Type.RPL_ENDOFWHOIS,
@@ -1994,7 +1995,7 @@ if (isSomeFunction!onSuccess && (is(typeof(onFailure) == typeof(null)) || isSome
 
         immutable whoisEvent = thisFiber.payload;
 
-        assert(whoisEventTypes.canFind(whoisEvent.type),
+        assert(whoisEventTypes[].canFind(whoisEvent.type),
             "WHOIS Fiber delegate was invoked with an unexpected event type: " ~
             "`IRCEvent.Type." ~ Enum!(IRCEvent.Type).toString(whoisEvent.type) ~'`');
 
@@ -2090,7 +2091,7 @@ if (isSomeFunction!onSuccess && (is(typeof(onFailure) == typeof(null)) || isSome
         }
 
         // Clean up awaiting fiber entries on exit, just to be neat.
-        scope(exit) context.unlistFiberAwaitingEvents(thisFiber, whoisEventTypes);
+        scope(exit) context.unlistFiberAwaitingEvents(thisFiber, whoisEventTypes[]);
 
         if ((whoisEvent.type == IRCEvent.Type.RPL_WHOISACCOUNT) ||
             (whoisEvent.type == IRCEvent.Type.RPL_WHOISREGNICK))
@@ -2226,7 +2227,7 @@ if (isSomeFunction!onSuccess && (is(typeof(onFailure) == typeof(null)) || isSome
 
         Fiber fiber = new CarryingFiber!IRCEvent(&whoisFiberDelegate, 32_768);
 
-        context.awaitEvents(fiber, whoisEventTypes);
+        context.awaitEvents(fiber, whoisEventTypes[]);
 
         if (issueWhois)
         {

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -2151,8 +2151,10 @@ if (isSomeFunction!onSuccess && (is(typeof(onFailure) == typeof(null)) || isSome
                     {
                         static if (TakesParams!(onSuccess, AliasSeq!IRCEvent))
                         {
-                            // No can do
-                            return;
+                            // Can't WHOIS on Twitch
+                            throw new Exception("Tried to enqueue a `" ~
+                                typeof(onSuccess).stringof ~ " onSuccess` function " ~
+                                "when on Twitch (can't WHOIS)");
                         }
                         else static if (TakesParams!(onSuccess, AliasSeq!IRCUser))
                         {
@@ -2173,15 +2175,13 @@ if (isSomeFunction!onSuccess && (is(typeof(onFailure) == typeof(null)) || isSome
                     }
                 }
 
-                static if (TakesParams!(onSuccess, AliasSeq!IRCEvent))
+                static if (TakesParams!(onSuccess, AliasSeq!IRCEvent) ||
+                    TakesParams!(onSuccess, AliasSeq!IRCUser))
                 {
-                    // No can do
-                    return;
-                }
-                else static if (TakesParams!(onSuccess, AliasSeq!IRCUser))
-                {
-                    // No can do
-                    return;
+                    // Can't WHOIS on Twitch
+                    throw new Exception("Tried to enqueue a `" ~
+                        typeof(onSuccess).stringof ~ " onSuccess` function " ~
+                        "when on Twitch without `UserAwareness` (can't WHOIS)");
                 }
                 else static if (TakesParams!(onSuccess, AliasSeq!string))
                 {

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -387,9 +387,18 @@ bool applyCustomSettings(IRCPlugin[] plugins, const string[] customSettings)
                         Tint.log, Tint.warning, setting);
                     noErrors = false;
                 }
-                else if ((setting == "monochrome") || (setting == "brightTerminal"))
+                else
                 {
-                    initLogger(settings.monochrome, settings.brightTerminal, settings.flush);
+                    if ((setting == "monochrome") || (setting == "brightTerminal"))
+                    {
+                        initLogger(settings.monochrome, settings.brightTerminal, settings.flush);
+                    }
+
+                    foreach (plugin; plugins)
+                    {
+                        plugin.state.settings = settings;
+                        //plugin.state.settingsUpdated = true;
+                    }
                 }
             }
             catch (ConvException e)

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -344,7 +344,7 @@ private import kameloso.common : CoreSettings;
  +      plugins = Array of all `IRCPlugin`s.
  +      customSettings = Array of custom settings to apply to plugins' own
  +          setting, in the string forms of "`plugin.setting=value`".
- +      settings = A copy of the program-wide `kameloso.common.CoreSettings`.
+ +      copyOfSettings = A copy of the program-wide `kameloso.common.CoreSettings`.
  +
  +  Returns:
  +      `true` if no setting name mismatches occurred, `false` if it did.
@@ -2120,6 +2120,10 @@ if (isSomeFunction!onSuccess && (is(typeof(onFailure) == typeof(null)) || isSome
      +      nickname = Nickname of the user the enqueueing event relates to.
      +      issueWhois = Whether to actually issue WHOIS queries at all or just enqueue.
      +      background = Whether or not to issue queries as low-priority background messages.
+     +
+     +  Throws:
+     +      `object.Exception` if a success of failure function was to trigger
+     +      in an impossible scenario, such as on WHOIS results on Twitch.
      +/
     void enqueueAndWHOIS(const string nickname, const bool issueWhois = true,
         const bool background = false)

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -2512,3 +2512,42 @@ bool isValidHostmask(const string hostmask, const IRCServer server) pure @safe n
     if (!address.length) return false;
     return (address == "*") || isValidAddress(address);
 }
+
+///
+unittest
+{
+    IRCServer server;
+
+    {
+        immutable hostmask = "*!*@*";
+        assert(hostmask.isValidHostmask(server));
+    }
+    {
+        immutable hostmask = "nick123`!*@*";
+        assert(hostmask.isValidHostmask(server));
+    }
+    {
+        immutable hostmask = "*!~ident0-9_@*";
+        assert(hostmask.isValidHostmask(server));
+    }
+    {
+        immutable hostmask = "*!ident0-9_@*";
+        assert(hostmask.isValidHostmask(server));
+    }
+    {
+        immutable hostmask = "*!~~ident0-9_@*";
+        assert(!hostmask.isValidHostmask(server));
+    }
+    {
+        immutable hostmask = "*!*@address.tld.net";
+        assert(hostmask.isValidHostmask(server));
+    }
+    {
+        immutable hostmask = "*!*@~address.tld.net";
+        assert(!hostmask.isValidHostmask(server));
+    }
+    {
+        immutable hostmask = "*!*@2001::ff:09:ff";
+        assert(hostmask.isValidHostmask(server));
+    }
+}

--- a/source/kameloso/plugins/common.d
+++ b/source/kameloso/plugins/common.d
@@ -374,8 +374,14 @@ bool applyCustomSettings(IRCPlugin[] plugins, const string[] customSettings)
 
         if (pluginstring == "core")
         {
-            import kameloso.common : initLogger, settings;
+            import kameloso.common : initLogger;
             import lu.objmanip : setMemberByName;
+
+            if (!plugins.length) return false;
+
+            // Get a copy of the settings from the first plugin and modify it,
+            // flag it as updated and pass it around.
+            auto settings = plugins[0].state.settings;
 
             try
             {
@@ -397,7 +403,7 @@ bool applyCustomSettings(IRCPlugin[] plugins, const string[] customSettings)
                     foreach (plugin; plugins)
                     {
                         plugin.state.settings = settings;
-                        //plugin.state.settingsUpdated = true;
+                        plugin.state.settingsUpdated = true;
                     }
                 }
             }

--- a/source/kameloso/plugins/connect.d
+++ b/source/kameloso/plugins/connect.d
@@ -456,7 +456,8 @@ void onEndOfMotdTwitch(ConnectService service)
 
     if (service.state.server.daemon != IRCServer.Daemon.twitch) return;
 
-    settings.colouredOutgoing = false;
+    service.state.settings.colouredOutgoing = false;
+    service.state.settingsUpdated = true;
 
     if (settings.prefix.beginsWith(".") || settings.prefix.beginsWith("/"))
     {

--- a/source/kameloso/plugins/connect.d
+++ b/source/kameloso/plugins/connect.d
@@ -18,7 +18,7 @@ private:
 
 import kameloso.plugins.ircplugin;
 import kameloso.plugins.common;
-import kameloso.common : Tint, logger, settings;
+import kameloso.common : Tint, logger;
 import kameloso.messaging;
 import kameloso.thread : ThreadMessage;
 import dialect.defs;
@@ -272,7 +272,11 @@ void tryAuth(ConnectService service)
             }
 
             query(service.state, serviceNick, "%s %s".format(verb, password), true);
-            if (!settings.hideOutgoing) logger.tracef("--> PRIVMSG %s :%s hunter2", serviceNick, verb);
+
+            if (!service.state.settings.hideOutgoing)
+            {
+                logger.tracef("--> PRIVMSG %s :%s hunter2", serviceNick, verb);
+            }
             break;
 
         case snircd:
@@ -289,13 +293,21 @@ void tryAuth(ConnectService service)
             }
 
             query(service.state, serviceNick, "%s %s %s".format(verb, account, password), true);
-            if (!settings.hideOutgoing) logger.tracef("--> PRIVMSG %s :%s %s hunter2", serviceNick, verb, account);
+
+            if (!service.state.settings.hideOutgoing)
+            {
+                logger.tracef("--> PRIVMSG %s :%s %s hunter2", serviceNick, verb, account);
+            }
             break;
 
         case rusnet:
             // Doesn't want a PRIVMSG
             raw(service.state, "NICKSERV IDENTIFY " ~ password, true);
-            if (!settings.hideOutgoing) logger.trace("--> NICKSERV IDENTIFY hunter2");
+
+            if (!service.state.settings.hideOutgoing)
+            {
+                logger.trace("--> NICKSERV IDENTIFY hunter2");
+            }
             break;
 
         version(TwitchSupport)
@@ -459,11 +471,13 @@ void onEndOfMotdTwitch(ConnectService service)
     service.state.settings.colouredOutgoing = false;
     service.state.settingsUpdated = true;
 
-    if (settings.prefix.beginsWith(".") || settings.prefix.beginsWith("/"))
+    immutable prefix = service.state.settings.prefix;
+
+    if (prefix.beginsWith(".") || prefix.beginsWith("/"))
     {
         logger.warningf(`WARNING: A prefix of "%s%s%s" will *not* work on Twitch servers, ` ~
             `as %1$s.%3$s and %1$s/%3$s are reserved for Twitch's own commands.`,
-            Tint.log, settings.prefix, Tint.warning);
+            Tint.log, prefix, Tint.warning);
     }
 }
 
@@ -787,7 +801,7 @@ void onSASLAuthenticate(ConnectService service)
             immutable encoded = encode64(authToken);
 
             raw(service.state, "AUTHENTICATE " ~ encoded, true);
-            if (!settings.hideOutgoing) logger.trace("--> AUTHENTICATE hunter2");
+            if (!service.state.settings.hideOutgoing) logger.trace("--> AUTHENTICATE hunter2");
         }
         catch (Base64Exception e)
         {
@@ -979,7 +993,7 @@ void register(ConnectService service)
         if (bot.pass.length)
         {
             raw(service.state, "PASS " ~ bot.pass, true);
-            if (!settings.hideOutgoing) logger.trace("--> PASS hunter2");  // fake it
+            if (!service.state.settings.hideOutgoing) logger.trace("--> PASS hunter2");  // fake it
         }
 
         import core.thread : Fiber;

--- a/source/kameloso/plugins/help.d
+++ b/source/kameloso/plugins/help.d
@@ -16,7 +16,7 @@ private:
 import kameloso.plugins.ircplugin;
 import kameloso.plugins.common;
 import kameloso.plugins.awareness : MinimalAuthentication;
-import kameloso.common : logger, settings;
+import kameloso.common : logger;
 import kameloso.messaging;
 import dialect.defs;
 
@@ -102,7 +102,7 @@ void onCommandHelp(HelpPlugin plugin, const IRCEvent event)
                     {
                         enum pattern = "No help available for command %s of plugin %s";
 
-                        immutable message = settings.colouredOutgoing ?
+                        immutable message = plugin.state.settings.colouredOutgoing ?
                             pattern.format(specifiedCommand.ircBold, specifiedPlugin.ircBold) :
                             pattern.format(specifiedCommand, specifiedPlugin);
 
@@ -112,7 +112,7 @@ void onCommandHelp(HelpPlugin plugin, const IRCEvent event)
                     return;
                 }
 
-                immutable message = settings.colouredOutgoing ?
+                immutable message = plugin.state.settings.colouredOutgoing ?
                     "No such plugin: " ~ specifiedPlugin.ircBold :
                     "No such plugin: " ~ specifiedPlugin;
 
@@ -120,11 +120,11 @@ void onCommandHelp(HelpPlugin plugin, const IRCEvent event)
             }
             else
             {
-                if (content.beginsWith(settings.prefix))
+                if (content.beginsWith(plugin.state.settings.prefix))
                 {
                     // Not a plugin, just a command (probably)
                     string slice = content;
-                    slice.nom!(Yes.decode)(settings.prefix);
+                    slice.nom!(Yes.decode)(plugin.state.settings.prefix);
                     immutable specifiedCommand = slice;
 
                     foreach (p; plugins)
@@ -148,7 +148,7 @@ void onCommandHelp(HelpPlugin plugin, const IRCEvent event)
                     }
                     else if (!p.commands.length)
                     {
-                        immutable message = settings.colouredOutgoing ?
+                        immutable message = plugin.state.settings.colouredOutgoing ?
                             "No commands available for plugin " ~ content.ircBold :
                             "No commands available for plugin " ~ content;
 
@@ -159,7 +159,7 @@ void onCommandHelp(HelpPlugin plugin, const IRCEvent event)
                     enum width = 12;
                     enum pattern = "* %-*s %-([%s]%| %)";
 
-                    immutable message = settings.colouredOutgoing ?
+                    immutable message = plugin.state.settings.colouredOutgoing ?
                         pattern.format(width, p.name.ircBold, p.commands.keys.sort()) :
                         pattern.format(width, p.name, p.commands.keys.sort());
 
@@ -167,7 +167,7 @@ void onCommandHelp(HelpPlugin plugin, const IRCEvent event)
                     return;
                 }
 
-                immutable message = settings.colouredOutgoing ?
+                immutable message = plugin.state.settings.colouredOutgoing ?
                     "No such plugin: " ~ content.ircBold :
                     "No such plugin: " ~ content;
 
@@ -186,7 +186,8 @@ void onCommandHelp(HelpPlugin plugin, const IRCEvent event)
                 .format(cast(string)KamelosoInfo.version_,
                 cast(string)KamelosoInfo.built);
 
-            immutable banner = settings.colouredOutgoing ? bannerColoured : bannerUncoloured;
+            immutable banner = plugin.state.settings.colouredOutgoing ?
+                bannerColoured : bannerUncoloured;
             privmsg(plugin.state, channel, sender.nickname, banner);
             privmsg(plugin.state, channel, sender.nickname, "Available bot commands per plugin:");
 
@@ -197,7 +198,7 @@ void onCommandHelp(HelpPlugin plugin, const IRCEvent event)
                 enum width = 12;
                 enum pattern = "* %-*s %-([%s]%| %)";
 
-                immutable message = settings.colouredOutgoing ?
+                immutable message = plugin.state.settings.colouredOutgoing ?
                     pattern.format(width, p.name.ircBold, p.commands.keys.sort()) :
                     pattern.format(width, p.name, p.commands.keys.sort());
 
@@ -207,7 +208,7 @@ void onCommandHelp(HelpPlugin plugin, const IRCEvent event)
             enum pattern = "Use %s [%s] [%s] for information about a command.";
             enum colouredLine = pattern.format("help".ircBold, "plugin".ircBold, "command".ircBold);
 
-            immutable message = settings.colouredOutgoing ? colouredLine :
+            immutable message = plugin.state.settings.colouredOutgoing ? colouredLine :
                 "Use help [plugin] [command] for information about a command.";
 
             privmsg(plugin.state, channel, sender.nickname, message);
@@ -239,7 +240,7 @@ void sendCommandHelp(HelpPlugin plugin, const IRCPlugin otherPlugin,
 
     enum pattern = "[%s] %s: %s";
 
-    immutable message = settings.colouredOutgoing ?
+    immutable message = plugin.state.settings.colouredOutgoing ?
         pattern.format(otherPlugin.name.ircBold, command.ircBold, description.line) :
         pattern.format(otherPlugin.name, command, description.line);
 
@@ -256,9 +257,9 @@ void sendCommandHelp(HelpPlugin plugin, const IRCPlugin otherPlugin,
 
         // Prepend the prefix to non-PrefixPolicy.nickname commands
         immutable prefixedSyntax = description.syntax.beginsWith("$nickname") ?
-            udaSyntax : settings.prefix ~ udaSyntax;
+            udaSyntax : plugin.state.settings.prefix ~ udaSyntax;
 
-        immutable syntax = settings.colouredOutgoing ?
+        immutable syntax = plugin.state.settings.colouredOutgoing ?
             "Usage".ircBold ~ ": " ~ prefixedSyntax :
             "Usage: " ~ prefixedSyntax;
 

--- a/source/kameloso/plugins/ircplugin.d
+++ b/source/kameloso/plugins/ircplugin.d
@@ -602,7 +602,8 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                     // Reset between iterations as we nom the contents
                     mutEvent = event;
 
-                    if (!mutEvent.prefixPolicyMatches!verbose(commandUDA.policy, privateState.client))
+                    if (!mutEvent.prefixPolicyMatches!verbose(commandUDA.policy,
+                        privateState.client, privateState.settings.prefix))
                     {
                         static if (verbose)
                         {
@@ -661,7 +662,8 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                         // Reset between iterations; BotCommands may have altered it
                         mutEvent = event;
 
-                        if (!mutEvent.prefixPolicyMatches!verbose(regexUDA.policy, privateState.client))
+                        if (!mutEvent.prefixPolicyMatches!verbose(regexUDA.policy,
+                            privateState.client, privateState.settings.prefix))
                         {
                             static if (verbose)
                             {

--- a/source/kameloso/plugins/ircplugin.d
+++ b/source/kameloso/plugins/ircplugin.d
@@ -1585,15 +1585,16 @@ version(unittest)
  +      mutEvent = Reference to the mutable `dialect.defs.IRCEvent` we're considering.
  +      policy = Policy to apply.
  +      client = `dialect.defs.IRCClient` of the calling `IRCPlugin`'s `IRCPluginState`.
+ +      prefix = The prefix as set in the program-wide settings.
  +
  +  Returns:
  +      `true` if the message is in a context where the event matches the
  +      `policy`, `false` if not.
  +/
 bool prefixPolicyMatches(bool verbose = false)(ref IRCEvent mutEvent,
-    const PrefixPolicy policy, const IRCClient client)
+    const PrefixPolicy policy, const IRCClient client, const string prefix)
 {
-    import kameloso.common : settings, stripSeparatedPrefix;
+    import kameloso.common : stripSeparatedPrefix;
     import lu.string : beginsWith, nom;
     import std.typecons : No, Yes;
 
@@ -1616,14 +1617,14 @@ bool prefixPolicyMatches(bool verbose = false)(ref IRCEvent mutEvent,
         return true;
 
     case prefixed:
-        if (settings.prefix.length && content.beginsWith(settings.prefix))
+        if (prefix.length && content.beginsWith(prefix))
         {
             static if (verbose)
             {
-                writefln("starts with prefix (%s)", settings.prefix);
+                writefln("starts with prefix (%s)", prefix);
             }
 
-            content.nom!(Yes.decode)(settings.prefix);
+            content.nom!(Yes.decode)(prefix);
         }
         else
         {

--- a/source/kameloso/plugins/ircplugin.d
+++ b/source/kameloso/plugins/ircplugin.d
@@ -288,7 +288,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
 
         // PrivilegeLevel.ignore always passes, even for Class.blacklist.
         return (privilegeLevel == PrivilegeLevel.ignore) ? FilterResult.pass :
-            filterSender(privateState, event, privilegeLevel);
+            filterSender(privateState, event, privilegeLevel, privateState.settings.useHostmasks);
     }
 
 

--- a/source/kameloso/plugins/ircplugin.d
+++ b/source/kameloso/plugins/ircplugin.d
@@ -1015,12 +1015,14 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                 static if (isAnnotated!(this.tupleof[i], Resource))
                 {
                     import std.path : buildNormalizedPath, expandTilde;
-                    member = buildNormalizedPath(settings.resourceDirectory, member).expandTilde;
+                    member = buildNormalizedPath(privateState.settings.resourceDirectory, member)
+                        .expandTilde;
                 }
                 else static if (isAnnotated!(this.tupleof[i], Configuration))
                 {
                     import std.path : buildNormalizedPath, expandTilde;
-                    member = buildNormalizedPath(settings.configDirectory, member).expandTilde;
+                    member = buildNormalizedPath(privateState.settings.configDirectory, member)
+                        .expandTilde;
                 }
             }
         }

--- a/source/kameloso/plugins/ircplugin.d
+++ b/source/kameloso/plugins/ircplugin.d
@@ -363,7 +363,6 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
 
             static if (verbose)
             {
-                import kameloso.common : settings;
                 import lu.conv : Enum;
                 import std.format : format;
                 import std.stdio : stdout, writeln, writefln;
@@ -997,7 +996,6 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
      +/
     public this(IRCPluginState state) @system
     {
-        import kameloso.common : settings;
         import lu.traits : isAnnotated, isSerialisable;
         import std.traits : EnumMembers;
 

--- a/source/kameloso/plugins/ircplugin.d
+++ b/source/kameloso/plugins/ircplugin.d
@@ -518,7 +518,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
             static if (verbose)
             {
                 writeln("-- ", name, " @ ", Enum!(IRCEvent.Type).toString(event.type));
-                if (settings.flush) stdout.flush();
+                if (privateState.settings.flush) stdout.flush();
             }
 
             static if (!hasUDA!(fun, ChannelPolicy) ||
@@ -531,7 +531,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                 static if (verbose)
                 {
                     writeln("...ChannelPolicy.home");
-                    if (settings.flush) stdout.flush();
+                    if (privateState.settings.flush) stdout.flush();
                 }
 
                 if (!event.channel.length)
@@ -543,7 +543,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                     static if (verbose)
                     {
                         writeln("...ignore non-home channel ", event.channel);
-                        if (settings.flush) stdout.flush();
+                        if (privateState.settings.flush) stdout.flush();
                     }
 
                     // channel policy does not match
@@ -555,7 +555,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                 static if (verbose)
                 {
                     writeln("...ChannelPolicy.any");
-                    if (settings.flush) stdout.flush();
+                    if (privateState.settings.flush) stdout.flush();
                 }
             }
 
@@ -596,7 +596,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                     static if (verbose)
                     {
                         writefln(`...BotCommand "%s"`, commandUDA.word);
-                        if (settings.flush) stdout.flush();
+                        if (privateState.settings.flush) stdout.flush();
                     }
 
                     // Reset between iterations as we nom the contents
@@ -607,7 +607,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                         static if (verbose)
                         {
                             writeln("...policy doesn't match; continue next BotCommand");
-                            if (settings.flush) stdout.flush();
+                            if (privateState.settings.flush) stdout.flush();
                         }
 
                         continue;  // next BotCommand UDA
@@ -626,7 +626,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                         static if (verbose)
                         {
                             writeln("...command matches!");
-                            if (settings.flush) stdout.flush();
+                            if (privateState.settings.flush) stdout.flush();
                         }
 
                         mutEvent.aux = thisCommand;
@@ -655,7 +655,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                         static if (verbose)
                         {
                             writeln("BotRegex: `", regexUDA.expression, "`");
-                            if (settings.flush) stdout.flush();
+                            if (privateState.settings.flush) stdout.flush();
                         }
 
                         // Reset between iterations; BotCommands may have altered it
@@ -666,7 +666,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                             static if (verbose)
                             {
                                 writeln("...policy doesn't match; continue next BotRegex");
-                                if (settings.flush) stdout.flush();
+                                if (privateState.settings.flush) stdout.flush();
                             }
 
                             continue;  // next BotRegex UDA
@@ -683,7 +683,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                                 static if (verbose)
                                 {
                                     writeln("...expression matches!");
-                                    if (settings.flush) stdout.flush();
+                                    if (privateState.settings.flush) stdout.flush();
                                 }
 
                                 mutEvent.aux = hits[0];
@@ -705,7 +705,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                             {
                                 writeln("...BotRegex exception: ", e.msg);
                                 version(PrintStacktraces) writeln(e.toString);
-                                if (settings.flush) stdout.flush();
+                                if (privateState.settings.flush) stdout.flush();
                             }
                             continue;  // next BotRegex
                         }
@@ -721,7 +721,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                     static if (verbose)
                     {
                         writeln("...neither BotCommand nor BotRegex matched; continue funloop");
-                        if (settings.flush) stdout.flush();
+                        if (privateState.settings.flush) stdout.flush();
                     }
 
                     return Next.continue_; // next function
@@ -749,7 +749,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                 static if (verbose)
                 {
                     writeln("...PrivilegeLevel.", Enum!PrivilegeLevel.toString(privilegeLevel));
-                    if (settings.flush) stdout.flush();
+                    if (privateState.settings.flush) stdout.flush();
                 }
 
                 static if (__traits(hasMember, this, "allow") && isSomeFunction!(this.allow))
@@ -767,7 +767,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                     static if (verbose)
                     {
                         writeln("...custom allow!");
-                        if (settings.flush) stdout.flush();
+                        if (privateState.settings.flush) stdout.flush();
                     }
 
                     immutable result = this.allow(mutEvent, privilegeLevel);
@@ -777,7 +777,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                     static if (verbose)
                     {
                         writeln("...built-in allow.");
-                        if (settings.flush) stdout.flush();
+                        if (privateState.settings.flush) stdout.flush();
                     }
 
                     immutable result = allowImpl(mutEvent, privilegeLevel);
@@ -786,7 +786,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                 static if (verbose)
                 {
                     writeln("...result is ", Enum!FilterResult.toString(result));
-                    if (settings.flush) stdout.flush();
+                    if (privateState.settings.flush) stdout.flush();
                 }
 
                 with (FilterResult)
@@ -806,7 +806,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
                     static if (verbose)
                     {
                         writefln("...%s WHOIS", typeof(this).stringof);
-                        if (settings.flush) stdout.flush();
+                        if (privateState.settings.flush) stdout.flush();
                     }
 
                     static if (is(Params : AliasSeq!IRCEvent) || (arity!fun == 0))
@@ -844,7 +844,7 @@ mixin template IRCPluginImpl(bool debug_ = false, string module_ = __MODULE__)
             static if (verbose)
             {
                 writeln("...calling!");
-                if (settings.flush) stdout.flush();
+                if (privateState.settings.flush) stdout.flush();
             }
 
             static if (is(Params : AliasSeq!(typeof(this), IRCEvent)) ||

--- a/source/kameloso/plugins/notes.d
+++ b/source/kameloso/plugins/notes.d
@@ -15,7 +15,7 @@ private:
 import kameloso.plugins.ircplugin;
 import kameloso.plugins.common;
 import kameloso.plugins.awareness : MinimalAuthentication;
-import kameloso.common;
+import kameloso.common : Tint, logger;
 import kameloso.irccolours : ircBold, ircColourByHash;
 import kameloso.messaging;
 import dialect.defs;
@@ -68,7 +68,7 @@ void onReplayEvent(NotesPlugin plugin, const IRCEvent event)
 @(ChannelPolicy.home)
 void onWhoReply(NotesPlugin plugin, const IRCEvent event)
 {
-    if (settings.eagerLookups) return;
+    if (plugin.state.settings.eagerLookups) return;
 
     if (event.channel !in plugin.notes) return;
 
@@ -137,7 +137,7 @@ void playbackNotes(NotesPlugin plugin, const IRCUser givenUser,
 
                     enum pattern = "%s%s! %s left note %s ago: %s";
 
-                    immutable message = settings.colouredOutgoing ?
+                    immutable message = plugin.state.settings.colouredOutgoing ?
                         pattern.format(atSign, senderName.ircBold,
                             note.sender.ircColourByHash.ircBold, timestamp.ircBold, note.line) :
                         pattern.format(atSign, senderName, note.sender, timestamp, note.line);
@@ -150,7 +150,7 @@ void playbackNotes(NotesPlugin plugin, const IRCUser givenUser,
 
                     enum pattern = "%s%s! You have %s notes.";
 
-                    immutable message = settings.colouredOutgoing ?
+                    immutable message = plugin.state.settings.colouredOutgoing ?
                         pattern.format(atSign, senderName.ircBold, noteArray.length.text.ircBold) :
                         pattern.format(atSign, senderName, noteArray.length);
 
@@ -163,7 +163,7 @@ void playbackNotes(NotesPlugin plugin, const IRCUser givenUser,
 
                         enum entryPattern = "%s %s ago: %s";
 
-                        immutable report = settings.colouredOutgoing ?
+                        immutable report = plugin.state.settings.colouredOutgoing ?
                             entryPattern.format(note.sender.ircColourByHash.ircBold,
                                 timestamp, note.line) :
                             entryPattern.format(note.sender, timestamp, note.line);

--- a/source/kameloso/plugins/oneliners.d
+++ b/source/kameloso/plugins/oneliners.d
@@ -18,7 +18,7 @@ private:
 import kameloso.plugins.ircplugin;
 import kameloso.plugins.common;
 import kameloso.plugins.awareness : ChannelAwareness, TwitchAwareness, UserAwareness;
-import kameloso.common : logger, settings;
+import kameloso.common : logger;
 import kameloso.messaging;
 import dialect.defs;
 
@@ -49,10 +49,10 @@ void onOneliner(OnelinersPlugin plugin, const IRCEvent event)
 {
     import lu.string : beginsWith, contains, nom;
 
-    if (!event.content.beginsWith(settings.prefix)) return;
+    if (!event.content.beginsWith(plugin.state.settings.prefix)) return;
 
     string slice = event.content;
-    slice.nom(settings.prefix);
+    slice.nom(plugin.state.settings.prefix);
 
     // An empty command is invalid, as is one containing spaces
     if (!slice.length || slice.contains(' ')) return;
@@ -100,7 +100,7 @@ void onCommandModifyOneliner(OnelinersPlugin plugin, const IRCEvent event)
     void sendUsage(const string verb = "[add|del|list]", const bool includeText = true)
     {
         chan(plugin.state, event.channel, "Usage: %s%s %s [trigger]%s"
-            .format(settings.prefix, event.aux, verb,
+            .format(plugin.state.settings.prefix, event.aux, verb,
             includeText ? " [text]" : string.init));
     }
 
@@ -124,7 +124,7 @@ void onCommandModifyOneliner(OnelinersPlugin plugin, const IRCEvent event)
         saveResourceToDisk(plugin.onelinersByChannel, plugin.onelinerFile);
 
         chan(plugin.state, event.channel, "Oneliner %s%s added%s."
-            .format(settings.prefix, trigger,
+            .format(plugin.state.settings.prefix, trigger,
                 plugin.onelinersSettings.caseSensitiveTriggers ?
                 " (made lowercase)" : string.init));
         break;
@@ -137,7 +137,7 @@ void onCommandModifyOneliner(OnelinersPlugin plugin, const IRCEvent event)
         if (trigger !in plugin.onelinersByChannel[event.channel])
         {
             chan(plugin.state, event.channel, "No such trigger: %s%s"
-                .format(settings.prefix, slice));
+                .format(plugin.state.settings.prefix, slice));
             return;
         }
 
@@ -145,7 +145,7 @@ void onCommandModifyOneliner(OnelinersPlugin plugin, const IRCEvent event)
         saveResourceToDisk(plugin.onelinersByChannel, plugin.onelinerFile);
 
         chan(plugin.state, event.channel, "Oneliner %s%s removed."
-            .format(settings.prefix, trigger));
+            .format(plugin.state.settings.prefix, trigger));
         break;
 
     case "list":
@@ -191,7 +191,8 @@ void listCommands(OnelinersPlugin plugin, const string channelName)
 
     if (channelOneliners && channelOneliners.length)
     {
-        chan(plugin.state, channelName, ("Available commands: %-(" ~ settings.prefix ~ "%s, %)")
+        chan(plugin.state, channelName, ("Available commands: %-(" ~
+            plugin.state.settings.prefix ~ "%s, %)")
             .format(channelOneliners.byKey));
     }
     else

--- a/source/kameloso/plugins/persistence.d
+++ b/source/kameloso/plugins/persistence.d
@@ -261,11 +261,7 @@ void postprocessHostmasks(PersistenceService service, ref IRCEvent event)
                 }
                 catch (FormatException e)
                 {
-                    import kameloso.common : logger;
-
-                    logger.errorf("hostmasks file may be malformed; could not " ~
-                        "create an IRCUser from: ", hostmask);
-                    return string.init;
+                    // Malformed entry. Do nothing, try next mask
                 }
             }
 

--- a/source/kameloso/plugins/persistence.d
+++ b/source/kameloso/plugins/persistence.d
@@ -24,22 +24,6 @@ import kameloso.plugins.common;
 import dialect.defs;
 
 
-// hostmask
-/++
- +  FIXME
- +/
-string hostmask(const IRCUser user)
-{
-    import std.format : format;
-
-    immutable nickname = user.nickname.length ? user.nickname : "*";
-    immutable ident = user.ident.length ? user.ident : "*";
-    immutable address = user.address.length ? user.address : "*";
-
-    return "%s!%s@%s".format(nickname, ident, address);
-}
-
-
 // postprocess
 /++
  +  Hijacks a reference to a `dialect.defs.IRCEvent` after parsing and

--- a/source/kameloso/plugins/persistence.d
+++ b/source/kameloso/plugins/persistence.d
@@ -51,8 +51,6 @@ string hostmask(const IRCUser user)
  +/
 void postprocess(PersistenceService service, ref IRCEvent event)
 {
-    import kameloso.common : settings;
-
     return service.state.settings.useHostmasks ?
         postprocessHostmasks(service, event) :
         postprocessAccounts(service, event);

--- a/source/kameloso/plugins/persistence.d
+++ b/source/kameloso/plugins/persistence.d
@@ -718,16 +718,17 @@ private:
     /// File with user definitions.
     @Resource string userFile = "users.json";
 
+    /// File with user hostmasks.
+    @Resource string hostmasksFile = "hostmasks.json";
+
     /// Associative array of permanent user classifications, per account and channel name.
     IRCUser.Class[string][string] channelUsers;
 
     /++
-     +  Associative array of permanent user classifications, per
-     +  `dialect.defs.IRCUser` and channel name.
-     +
-     +  Matching is done with `dialect.common.matchesByMask`.
+     +  User "accounts" by hostmask. Future optimisation may involve making this
+     +  an `IRCUser[string]` associative array instead.
      +/
-    IRCUser.Class[IRCUser][string] channelHostmasks;
+    string[string] accountByUser;
 
     /// Associative array of which channel the latest class lookup for an account related to.
     string[string] userClassCurrentChannelCache;

--- a/source/kameloso/plugins/persistence.d
+++ b/source/kameloso/plugins/persistence.d
@@ -35,7 +35,7 @@ import dialect.defs;
  +/
 void postprocess(PersistenceService service, ref IRCEvent event)
 {
-    return service.state.settings.useHostmasks ?
+    return service.state.settings.preferHostmasks ?
         postprocessHostmasks(service, event) :
         postprocessAccounts(service, event);
 }

--- a/source/kameloso/plugins/persistence.d
+++ b/source/kameloso/plugins/persistence.d
@@ -253,7 +253,20 @@ void postprocessHostmasks(PersistenceService service, ref IRCEvent event)
 
             foreach (immutable hostmask, immutable account; aa)
             {
-                if (matchesByMask(user, IRCUser(hostmask))) return account;
+                import std.format : FormatException;
+
+                try
+                {
+                    if (matchesByMask(user, IRCUser(hostmask))) return account;
+                }
+                catch (FormatException e)
+                {
+                    import kameloso.common : logger;
+
+                    logger.errorf("hostmasks file may be malformed; could not " ~
+                        "create an IRCUser from: ", hostmask);
+                    return string.init;
+                }
             }
 
             return string.init;

--- a/source/kameloso/plugins/persistence.d
+++ b/source/kameloso/plugins/persistence.d
@@ -665,6 +665,42 @@ void initResources(PersistenceService service)
 }
 
 
+// initHostmaskResources
+/++
+ +  Reads, completes and saves the hostmasks JSON file, creating one if it
+ +  doesn't exist.
+ +
+ +  Throws: `kameloso.plugins.common.IRCPluginInitialisationException` on
+ +      failure loading the `user.json` file.
+ +/
+void initHostmaskResources(PersistenceService service)
+{
+    import lu.json : JSONStorage;
+    import std.json : JSONException, JSONValue;
+
+    JSONStorage json;
+    json.reset();
+
+    try
+    {
+        json.load(service.hostmasksFile);
+    }
+    catch (JSONException e)
+    {
+        import kameloso.common : logger;
+        import std.path : baseName;
+
+        version(PrintStacktraces) logger.trace(e.toString);
+        throw new IRCPluginInitialisationException(service.hostmasksFile.baseName ~ " may be malformed.");
+    }
+
+    // Let other Exceptions pass.
+
+    // Adjust saved JSON layout to be more easily edited
+    json.save!(JSONStorage.KeyOrderStrategy.passthrough)(service.hostmasksFile);
+}
+
+
 public:
 
 

--- a/source/kameloso/plugins/persistence.d
+++ b/source/kameloso/plugins/persistence.d
@@ -496,15 +496,14 @@ void periodically(PersistenceService service, const long now)
 }
 
 
-// reloadClassifiersFromDiskImpl
+// reloadAccountClassifiersFromDisk
 /++
  +  Reloads admin/whitelist/blacklist classifier definitions from disk.
  +
  +  Params:
  +      service = The current `PersistenceService`.
- +      preferHostmasks = Whether we should load hostmasks or accounts.
  +/
-void reloadClassifiersFromDiskImpl(PersistenceService service, const bool preferHostmasks)
+void reloadAccountClassifiersFromDisk(PersistenceService service)
 {
     import kameloso.common : logger;
     import lu.json : JSONStorage;
@@ -536,24 +535,12 @@ void reloadClassifiersFromDiskImpl(PersistenceService service, const bool prefer
             {
                 foreach (immutable userJSON; channelAccountJSON.array)
                 {
-                    if (preferHostmasks)
+                    if (channel !in service.channelUsers)
                     {
-                        if (channel !in service.channelUsers)
-                        {
-                            service.channelHostmasks[channel] = (IRCUser.Class[IRCUser]).init;
-                        }
-
-                        service.channelHostmasks[channel][IRCUser(userJSON.str)] = class_;
+                        service.channelUsers[channel] = (IRCUser.Class[string]).init;
                     }
-                    else
-                    {
-                        if (channel !in service.channelUsers)
-                        {
-                            service.channelUsers[channel] = (IRCUser.Class[string]).init;
-                        }
 
-                        service.channelUsers[channel][userJSON.str] = class_;
-                    }
+                    service.channelUsers[channel][userJSON.str] = class_;
                 }
             }
         }

--- a/source/kameloso/plugins/persistence.d
+++ b/source/kameloso/plugins/persistence.d
@@ -558,6 +558,28 @@ void reloadAccountClassifiersFromDisk(PersistenceService service)
 }
 
 
+// reloadHostmasksFromDisk
+/++
+ +  Reloads hostmasks definitions from disk.
+ +
+ +  Params:
+ +      service = The current `PersistenceService`.
+ +/
+void reloadHostmasksFromDisk(PersistenceService service)
+{
+    import lu.json : JSONStorage, populateFromJSON;
+
+    with (service)
+    {
+        JSONStorage hostmasksJSON;
+        hostmasksJSON.load(hostmasksFile);
+        //accountByUser.clear();
+        accountByUser.populateFromJSON(hostmasksJSON);
+        accountByUser.rehash();
+    }
+}
+
+
 // initResources
 /++
  +  Reads, completes and saves the user classification JSON file, creating one

--- a/source/kameloso/plugins/persistence.d
+++ b/source/kameloso/plugins/persistence.d
@@ -53,7 +53,7 @@ void postprocess(PersistenceService service, ref IRCEvent event)
 {
     import kameloso.common : settings;
 
-    return settings.useHostmasks ?
+    return service.state.settings.useHostmasks ?
         postprocessHostmasks(service, event) :
         postprocessAccounts(service, event);
 }

--- a/source/kameloso/plugins/persistence.d
+++ b/source/kameloso/plugins/persistence.d
@@ -276,12 +276,8 @@ void postprocessHostmasks(PersistenceService service, ref IRCEvent event)
         static void applyClassifiers(PersistenceService service,
             const IRCEvent event, ref IRCUser user)
         {
-            import std.stdio;
-            writeln("applyClassifiers:", user.nickname);
-
             if (user.class_ == IRCUser.Class.admin)
             {
-                writeln(user.nickname, " was already admin");
                 // Do nothing, admin is permanent and program-wide
                 return;
             }
@@ -290,8 +286,6 @@ void postprocessHostmasks(PersistenceService service, ref IRCEvent event)
             {
                 user.account = getAccount(user, service.accountByUser);
             }
-
-            scope(exit) writeln("end class:", user.class_);
 
             bool set;
 
@@ -322,7 +316,6 @@ void postprocessHostmasks(PersistenceService service, ref IRCEvent event)
 
             if (!set)
             {
-                writeln("anyone");
                 // All else failed, consider it a random
                 user.class_ = IRCUser.Class.anyone;
             }

--- a/source/kameloso/plugins/persistence.d
+++ b/source/kameloso/plugins/persistence.d
@@ -247,13 +247,13 @@ void postprocessHostmasks(PersistenceService service, ref IRCEvent event)
             return;
         }
 
-        static bool canFindByValueMask(const string[] array, const IRCUser user,
+        static bool isAnAdmin(const string[] array, const IRCUser user,
             const IRCServer.CaseMapping caseMapping)
         {
             import dialect.common : matchesByMask;
             import std.stdio;
 
-            writeln("canFindByValueMask: ", user.hostmask);
+            writeln("isAnAdmin: ", user.hostmask);
 
             foreach (immutable thisMask; array)
             {
@@ -282,13 +282,13 @@ void postprocessHostmasks(PersistenceService service, ref IRCEvent event)
             return false;
         }
 
-        static IRCUser.Class classByMaskMatch(const IRCUser.Class[IRCUser] aa,
+        static IRCUser.Class getClassFromList(const IRCUser.Class[IRCUser] aa,
             const IRCUser user, const IRCServer.CaseMapping caseMapping)
         {
             import dialect.common : matchesByMask;
             import std.stdio;
 
-            writeln("classByMaskMatch: ", user.hostmask);
+            writeln("getClassFromList: ", user.hostmask);
 
             foreach (immutable thisUser, immutable class_; aa)
             {
@@ -325,7 +325,7 @@ void postprocessHostmasks(PersistenceService service, ref IRCEvent event)
                 // Do nothing, admin is permanent and program-wide
                 return;
             }
-            else if (canFindByValueMask(service.state.bot.admins, user,
+            else if (isAnAdmin(service.state.bot.admins, user,
                 service.state.server.caseMapping))
             {
                 writeln("foudn an admin!", user.nickname);
@@ -338,7 +338,7 @@ void postprocessHostmasks(PersistenceService service, ref IRCEvent event)
                 if (const maskclasses = event.channel in service.channelHostmasks)
                 {
                     // Permanent class may be defined; apply if so, default to anyone
-                    user.class_ = classByMaskMatch(*maskclasses, user,
+                    user.class_ = getClassFromList(*maskclasses, user,
                         service.state.server.caseMapping);
                 }
                 else

--- a/source/kameloso/plugins/persistence.d
+++ b/source/kameloso/plugins/persistence.d
@@ -24,6 +24,22 @@ import kameloso.plugins.common;
 import dialect.defs;
 
 
+// hostmask
+/++
+ +  FIXME
+ +/
+string hostmask(const IRCUser user)
+{
+    import std.format : format;
+
+    immutable nickname = user.nickname.length ? user.nickname : "*";
+    immutable ident = user.ident.length ? user.ident : "*";
+    immutable address = user.address.length ? user.address : "*";
+
+    return "%s!%s@%s".format(nickname, ident, address);
+}
+
+
 // postprocess
 /++
  +  Hijacks a reference to a `dialect.defs.IRCEvent` after parsing and

--- a/source/kameloso/plugins/persistence.d
+++ b/source/kameloso/plugins/persistence.d
@@ -582,15 +582,31 @@ void reloadHostmasksFromDisk(PersistenceService service)
 
 // initResources
 /++
+ +  Initialises the service's hostmasks and accounts resources.
+ +
+ +  Merely calls `initAccountResources` and `initHostmaskResources`.
+ +/
+void initResources(PersistenceService service)
+{
+    service.initAccountResources();
+    service.initHostmaskResources();
+}
+
+
+// initAccountResources
+/++
  +  Reads, completes and saves the user classification JSON file, creating one
  +  if one doesn't exist. Removes any duplicate entries.
  +
  +  This ensures there will be "whitelist", "operator" and "blacklist" arrays in it.
  +
+ +  Params:
+ +      service = The current `PersistenceService`.
+ +
  +  Throws: `kameloso.plugins.common.IRCPluginInitialisationException` on
  +      failure loading the `user.json` file.
  +/
-void initResources(PersistenceService service)
+void initAccountResources(PersistenceService service)
 {
     import lu.json : JSONStorage;
     import std.json : JSONException, JSONValue;

--- a/source/kameloso/plugins/persistence.d
+++ b/source/kameloso/plugins/persistence.d
@@ -462,7 +462,8 @@ void onNick(PersistenceService service, const IRCEvent event)
 @(IRCEvent.Type.ERR_NOMOTD)
 void onEndOfMotd(PersistenceService service)
 {
-    service.reloadClassifiersFromDiskImpl(service.state.settings.preferHostmasks);
+    service.reloadAccountClassifiersFromDisk();
+    service.reloadHostmasksFromDisk();
 }
 
 
@@ -474,7 +475,8 @@ void onEndOfMotd(PersistenceService service)
 void reload(PersistenceService service)
 {
     service.state.users.rehash();
-    service.reloadClassifiersFromDiskImpl(service.state.settings.preferHostmasks);
+    service.reloadAccountClassifiersFromDisk();
+    service.reloadHostmasksFromDisk();
 }
 
 

--- a/source/kameloso/plugins/pipeline.d
+++ b/source/kameloso/plugins/pipeline.d
@@ -19,7 +19,7 @@ private:
 
 import kameloso.plugins.ircplugin;
 import kameloso.plugins.common;
-import kameloso.common;
+import kameloso.common : Tint, logger;
 import kameloso.messaging;
 import kameloso.thread : ThreadMessage;
 import dialect.defs;

--- a/source/kameloso/plugins/pipeline.d
+++ b/source/kameloso/plugins/pipeline.d
@@ -68,8 +68,12 @@ import std.stdio : File;
  +          `PipelinePlugin`, to provide the main thread's `core.thread.Tid` for
  +          concurrency messages, made `shared` to allow being sent between threads.
  +      filename = String filename of the FIFO to read from.
+ +      monochrome = Whether or not output should be in monochrome text.
+ +      brightTerminal = Whether or not the terminal has a bright background
+ +          and colours should be adjusted to suit.
  +/
-void pipereader(shared IRCPluginState newState, const string filename)
+void pipereader(shared IRCPluginState newState, const string filename,
+    const bool monochrome, const bool brightTerminal)
 in (filename.length, "Tried to set up a pipereader with an empty filename")
 {
     import std.file : FileException, exists, remove;
@@ -86,7 +90,7 @@ in (filename.length, "Tried to set up a pipereader with an empty filename")
 
     version(Colours)
     {
-        if (!settings.monochrome)
+        if (!monochrome)
         {
             import kameloso.constants : DefaultColours;
             import kameloso.terminal : colour;
@@ -95,7 +99,7 @@ in (filename.length, "Tried to set up a pipereader with an empty filename")
             // We don't have a logger instance so we have to access the
             // DefaultColours.logcolours{Bright,Dark} tables manually
 
-            if (settings.brightTerminal)
+            if (brightTerminal)
             {
                 enum infotintColourBright = DefaultColours.logcoloursBright[LogLevel.info].colour.idup;
                 enum logtintColourBright = DefaultColours.logcoloursBright[LogLevel.all].colour.idup;
@@ -333,7 +337,8 @@ void onMotd(PipelinePlugin plugin)
         try
         {
             createFIFO(fifoFilename);
-            fifoThread = spawn(&pipereader, cast(shared)state, fifoFilename);
+            fifoThread = spawn(&pipereader, cast(shared)state, fifoFilename,
+                plugin.state.settings.monochrome, plugin.state.settings.brightTerminal);
             workerRunning = true;
         }
         catch (ReturnValueException e)

--- a/source/kameloso/plugins/printer.d
+++ b/source/kameloso/plugins/printer.d
@@ -2565,21 +2565,21 @@ unittest
     {
         immutable emotes = "212612:14-22/75828:24-29";
         immutable line = "Moody the god pownyFine pownyL";
-        line.highlightEmotesImpl(sink, emotes, TerminalForeground.white, TerminalForeground.default_, false);
+        line.highlightEmotesImpl(sink, emotes, TerminalForeground.white, TerminalForeground.default_, false, false);
         assert((sink.data == "Moody the god \033[97mpownyFine\033[39m \033[97mpownyL\033[39m"), sink.data);
     }
     {
         sink.clear();
         immutable emotes = "25:41-45";
         immutable line = "whoever plays nintendo switch whisper me Kappa";
-        line.highlightEmotesImpl(sink, emotes, TerminalForeground.white, TerminalForeground.default_, false);
+        line.highlightEmotesImpl(sink, emotes, TerminalForeground.white, TerminalForeground.default_, false, false);
         assert((sink.data == "whoever plays nintendo switch whisper me \033[97mKappa\033[39m"), sink.data);
     }
     {
         sink.clear();
         immutable emotes = "877671:8-17,19-28,30-39";
         immutable line = "NOOOOOO camillsCry camillsCry camillsCry";
-        line.highlightEmotesImpl(sink, emotes, TerminalForeground.white, TerminalForeground.default_, false);
+        line.highlightEmotesImpl(sink, emotes, TerminalForeground.white, TerminalForeground.default_, false, false);
         assert((sink.data == "NOOOOOO \033[97mcamillsCry\033[39m " ~
             "\033[97mcamillsCry\033[39m \033[97mcamillsCry\033[39m"), sink.data);
     }
@@ -2587,7 +2587,7 @@ unittest
         sink.clear();
         immutable emotes = "822112:0-6,8-14,16-22";
         immutable line = "FortOne FortOne FortOne";
-        line.highlightEmotesImpl(sink, emotes, TerminalForeground.white, TerminalForeground.default_, false);
+        line.highlightEmotesImpl(sink, emotes, TerminalForeground.white, TerminalForeground.default_, false, false);
         assert((sink.data == "\033[97mFortOne\033[39m \033[97mFortOne\033[39m " ~
             "\033[97mFortOne\033[39m"), sink.data);
     }
@@ -2595,7 +2595,7 @@ unittest
         sink.clear();
         immutable emotes = "141844:17-24,26-33,35-42/141073:9-15";
         immutable line = "@mugs123 cohhWow cohhBoop cohhBoop cohhBoop";
-        line.highlightEmotesImpl(sink, emotes, TerminalForeground.white, TerminalForeground.default_, false);
+        line.highlightEmotesImpl(sink, emotes, TerminalForeground.white, TerminalForeground.default_, false, false);
         assert((sink.data == "@mugs123 \033[97mcohhWow\033[39m \033[97mcohhBoop\033[39m " ~
             "\033[97mcohhBoop\033[39m \033[97mcohhBoop\033[39m"), sink.data);
     }
@@ -2610,21 +2610,21 @@ unittest
             "FREE SUBSCRIPTION every month \033[97mcourageHYPE\033[39m \033[97mcourageHYPE\033[39m " ~
             "twitch.amazon.com/prime | Click subscribe now to check if a " ~
             "free prime sub is available to use!";
-        line.highlightEmotesImpl(sink, emotes, TerminalForeground.white, TerminalForeground.default_, false);
+        line.highlightEmotesImpl(sink, emotes, TerminalForeground.white, TerminalForeground.default_, false, false);
         assert((sink.data == highlitLine), sink.data);
     }
     {
         sink.clear();
         immutable emotes = "25:32-36";
         immutable line = "@kiwiskool but you’re a sub too Kappa";
-        line.highlightEmotesImpl(sink, emotes, TerminalForeground.white, TerminalForeground.default_, false);
+        line.highlightEmotesImpl(sink, emotes, TerminalForeground.white, TerminalForeground.default_, false, false);
         assert((sink.data == "@kiwiskool but you’re a sub too \033[97mKappa\033[39m"), sink.data);
     }
     {
         sink.clear();
         immutable emotes = "425618:6-8,16-18/1:20-21";
         immutable line = "高所恐怖症 LUL なにぬねの LUL :)";
-        line.highlightEmotesImpl(sink, emotes, TerminalForeground.white, TerminalForeground.default_, false);
+        line.highlightEmotesImpl(sink, emotes, TerminalForeground.white, TerminalForeground.default_, false, false);
         assert((sink.data == "高所恐怖症 \033[97mLUL\033[39m なにぬねの " ~
             "\033[97mLUL\033[39m \033[97m:)\033[39m"), sink.data);
     }
@@ -2632,7 +2632,7 @@ unittest
         sink.clear();
         immutable emotes = "425618:6-8,16-18/1:20-21";
         immutable line = "高所恐怖症 LUL なにぬねの LUL :)";
-        line.highlightEmotesImpl(sink, emotes, TerminalForeground.white, TerminalForeground.default_, true);
+        line.highlightEmotesImpl(sink, emotes, TerminalForeground.white, TerminalForeground.default_, true, false);
         assert((sink.data == "高所恐怖症 \033[34mLUL\033[39m なにぬねの " ~
             "\033[34mLUL\033[39m \033[91m:)\033[39m"), sink.data);
     }
@@ -2640,21 +2640,21 @@ unittest
         sink.clear();
         immutable emotes = "212612:14-22/75828:24-29";
         immutable line = "Moody the god pownyFine pownyL";
-        line.highlightEmotesImpl(sink, emotes, TerminalForeground.white, TerminalForeground.default_, true);
+        line.highlightEmotesImpl(sink, emotes, TerminalForeground.white, TerminalForeground.default_, true, false);
         assert((sink.data == "Moody the god \033[37mpownyFine\033[39m \033[96mpownyL\033[39m"), sink.data);
     }
     {
         sink.clear();
         immutable emotes = "25:41-45";
         immutable line = "whoever plays nintendo switch whisper me Kappa";
-        line.highlightEmotesImpl(sink, emotes, TerminalForeground.white, TerminalForeground.default_, true);
+        line.highlightEmotesImpl(sink, emotes, TerminalForeground.white, TerminalForeground.default_, true, false);
         assert((sink.data == "whoever plays nintendo switch whisper me \033[93mKappa\033[39m"), sink.data);
     }
     {
         sink.clear();
         immutable emotes = "877671:8-17,19-28,30-39";
         immutable line = "NOOOOOO camillsCry camillsCry camillsCry";
-        line.highlightEmotesImpl(sink, emotes, TerminalForeground.white, TerminalForeground.default_, true);
+        line.highlightEmotesImpl(sink, emotes, TerminalForeground.white, TerminalForeground.default_, true, false);
         assert((sink.data == "NOOOOOO \033[95mcamillsCry\033[39m " ~
             "\033[95mcamillsCry\033[39m \033[95mcamillsCry\033[39m"), sink.data);
     }

--- a/source/kameloso/plugins/printer.d
+++ b/source/kameloso/plugins/printer.d
@@ -400,7 +400,7 @@ void onPrintableEvent(PrinterPlugin plugin, const IRCEvent event)
 
         version(Colours)
         {
-            if (!settings.monochrome)
+            if (!plugin.state.settings.monochrome)
             {
                 plugin.formatMessageColoured(stdout.lockingTextWriter, mutEvent,
                     plugin.printerSettings.bellOnMention, plugin.printerSettings.bellOnError);
@@ -414,7 +414,7 @@ void onPrintableEvent(PrinterPlugin plugin, const IRCEvent event)
                 plugin.printerSettings.bellOnMention, plugin.printerSettings.bellOnError);
         }
 
-        if (settings.flush) stdout.flush();
+        if (plugin.state.settings.flush) stdout.flush();
         break;
     }
 }
@@ -940,7 +940,7 @@ void onISUPPORT(PrinterPlugin plugin)
 
         version(Colours)
         {
-            if (!settings.monochrome)
+            if (!plugin.state.settings.monochrome)
             {
                 import kameloso.terminal : TerminalReset, colour;
                 enum tintresetColour = TerminalReset.all.colour.idup;
@@ -1420,7 +1420,7 @@ if (isOutputRange!(Sink, char[]))
 
     bool shouldBell;
 
-    immutable bright = settings.brightTerminal;
+    immutable bright = plugin.state.settings.brightTerminal;
 
     /++
      +  Outputs a terminal ANSI colour token based on the hash of the passed

--- a/source/kameloso/plugins/printer.d
+++ b/source/kameloso/plugins/printer.d
@@ -2399,7 +2399,6 @@ version(Colours)
 version(TwitchSupport)
 void highlightEmotes(ref IRCEvent event, const bool colourful, const bool brightTerminal)
 {
-    import kameloso.common : settings;
     import kameloso.constants : DefaultColours;
     import kameloso.terminal : colourWith;
     import lu.string : contains;

--- a/source/kameloso/plugins/quotes.d
+++ b/source/kameloso/plugins/quotes.d
@@ -18,7 +18,7 @@ private:
 import kameloso.plugins.ircplugin;
 import kameloso.plugins.common;
 import kameloso.plugins.awareness : MinimalAuthentication;
-import kameloso.common : Tint, logger, settings;
+import kameloso.common : Tint, logger;
 import kameloso.irccolours : ircBold, ircColourByHash;
 import kameloso.messaging;
 import dialect.defs;
@@ -104,7 +104,7 @@ void onCommandQuote(QuotesPlugin plugin, const IRCEvent event)
     {
         enum pattern = `"%s" is not a valid account or nickname.`;
 
-        immutable message = settings.colouredOutgoing ?
+        immutable message = plugin.state.settings.colouredOutgoing ?
             pattern.format(specified.ircBold) :
             pattern.format(specified);
 
@@ -117,7 +117,7 @@ void onCommandQuote(QuotesPlugin plugin, const IRCEvent event)
     {
         enum pattern = "%s | %s";
 
-        immutable message = settings.colouredOutgoing ?
+        immutable message = plugin.state.settings.colouredOutgoing ?
             pattern.format(nickname.ircColourByHash.ircBold, endQuote) :
             pattern.format(nickname, endQuote);
 
@@ -145,7 +145,7 @@ void onCommandQuote(QuotesPlugin plugin, const IRCEvent event)
 
             enum pattern = "No quote on record for %s";
 
-            immutable message = settings.colouredOutgoing ?
+            immutable message = plugin.state.settings.colouredOutgoing ?
                 pattern.format(replyUser.nickname.ircColourByHash.ircBold) :
                 pattern.format(replyUser.nickname);
 
@@ -224,7 +224,7 @@ in (line.length, "Tried to add an empty quote")
 
         enum pattern = "Quote for %s saved (%s on record)";
 
-        immutable message = settings.colouredOutgoing ?
+        immutable message = plugin.state.settings.colouredOutgoing ?
             pattern.format(specified.ircColourByHash.ircBold,
                 plugin.quotes[specified].array.length.text.ircBold) :
             pattern.format(specified, plugin.quotes[specified].array.length);

--- a/source/kameloso/plugins/sedreplace.d
+++ b/source/kameloso/plugins/sedreplace.d
@@ -411,7 +411,6 @@ void onMessage(SedReplacePlugin plugin, const IRCEvent event)
 
                 if ((result == event.content) || !result.length) return;
 
-                import kameloso.common : settings;
                 import kameloso.messaging : chan;
                 import std.format : format;
 

--- a/source/kameloso/plugins/seen.d
+++ b/source/kameloso/plugins/seen.d
@@ -48,7 +48,7 @@ private import dialect.defs;
 private import kameloso.irccolours : ircBold, ircColourByHash;
 
 // `kameloso.common` for some globals.
-private import kameloso.common : Tint, logger, settings;
+private import kameloso.common : Tint, logger;
 
 // `std.datetime.systime` for the `Clock`, to update times with.
 private import std.datetime.systime : Clock;
@@ -624,14 +624,15 @@ void onCommandSeen(SeenPlugin plugin, const IRCEvent event)
     {
         if (!requestedUser.length)
         {
-            immutable message = "Usage: " ~ settings.prefix ~ event.aux ~ " [nickname]";
+            immutable message = "Usage: " ~ plugin.state.settings.prefix ~
+                event.aux ~ " [nickname]";
             privmsg(event.channel, event.sender.nickname, message);
             return;
         }
         else if (!requestedUser.isValidNickname(plugin.state.server))
         {
             // Nickname contained a space or other invalid character
-            immutable message = settings.colouredOutgoing ?
+            immutable message = plugin.state.settings.colouredOutgoing ?
                 "Invalid user: " ~ requestedUser.ircBold :
                 "Invalid user: " ~ requestedUser;
 
@@ -658,7 +659,7 @@ void onCommandSeen(SeenPlugin plugin, const IRCEvent event)
                 immutable line = (event.channel.length && (event.channel == channel.name)) ?
                     " is here right now!" : " is online right now.";
 
-                immutable message = settings.colouredOutgoing ?
+                immutable message = plugin.state.settings.colouredOutgoing ?
                     requestedUser.ircColourByHash.ircBold ~ line :
                     requestedUser ~ line;
 
@@ -676,7 +677,7 @@ void onCommandSeen(SeenPlugin plugin, const IRCEvent event)
             const timestamp = SysTime.fromUnixTime(*userTimestamp);
             immutable elapsed = timeSince(Clock.currTime - timestamp);
 
-            immutable message = settings.colouredOutgoing ?
+            immutable message = plugin.state.settings.colouredOutgoing ?
                 pattern.format(requestedUser.ircColourByHash.ircBold, elapsed) :
                 pattern.format(requestedUser, elapsed);
 
@@ -687,7 +688,7 @@ void onCommandSeen(SeenPlugin plugin, const IRCEvent event)
             enum pattern = "I have never seen %s.";
 
             // No matches for nickname `event.content` in `plugin.seenUsers`.
-            immutable message = settings.colouredOutgoing ?
+            immutable message = plugin.state.settings.colouredOutgoing ?
                 pattern.format(requestedUser.ircColourByHash.ircBold) :
                 pattern.format(requestedUser);
 

--- a/source/kameloso/plugins/twitchbot.d
+++ b/source/kameloso/plugins/twitchbot.d
@@ -893,7 +893,7 @@ in ((event != IRCEvent.init), "Tried to report stop time to an empty IRCEvent")
 @(ChannelPolicy.home)
 void onLink(TwitchBotPlugin plugin, const IRCEvent event)
 {
-    import kameloso.common : findURLs, settings;
+    import kameloso.common : findURLs;
     import lu.string : beginsWith;
     import std.algorithm.searching : canFind;
 

--- a/source/kameloso/plugins/twitchbot.d
+++ b/source/kameloso/plugins/twitchbot.d
@@ -22,7 +22,7 @@ private:
 import kameloso.plugins.ircplugin;
 import kameloso.plugins.common;
 import kameloso.plugins.awareness : ChannelAwareness, TwitchAwareness, UserAwareness;
-import kameloso.common : logger, settings;
+import kameloso.common : logger;
 import kameloso.messaging;
 import dialect.defs;
 import core.thread : Fiber;
@@ -83,7 +83,7 @@ void onCommandPermit(TwitchBotPlugin plugin, const IRCEvent event)
     if (!nickname.length)
     {
         chan(plugin.state, event.channel, "Usage: %s%s [nickname]"
-            .format(settings.prefix, event.aux));
+            .format(plugin.state.settings.prefix, event.aux));
         return;
     }
 
@@ -347,7 +347,8 @@ in (targetChannel.length, "Tried to handle phrases with an empty target channel 
         if (!slice.length)
         {
             privmsg(plugin.state, event.channel, event.sender.nickname,
-                "Usage: %s%s %s [phrase]".format(settings.prefix, event.aux, verb));
+                "Usage: %s%s %s [phrase]"
+                .format(plugin.state.settings.prefix, event.aux, verb));
             return;
         }
 
@@ -361,7 +362,8 @@ in (targetChannel.length, "Tried to handle phrases with an empty target channel 
         if (!slice.length)
         {
             privmsg(plugin.state, event.channel, event.sender.nickname,
-                "Usage: %s%s %s [phrase index]".format(settings.prefix, event.aux, verb));
+                "Usage: %s%s %s [phrase index]"
+                .format(plugin.state.settings.prefix, event.aux, verb));
             return;
         }
 
@@ -439,7 +441,7 @@ in (targetChannel.length, "Tried to handle phrases with an empty target channel 
                 {
                     privmsg(plugin.state, event.channel, event.sender.nickname,
                         "Usage: %s%s %s [optional starting position number]"
-                        .format(settings.prefix, event.aux, verb));
+                        .format(plugin.state.settings.prefix, event.aux, verb));
                     //version(PrintStacktraces) logger.trace(e.info);
                     return;
                 }
@@ -474,7 +476,8 @@ in (targetChannel.length, "Tried to handle phrases with an empty target channel 
 
     default:
         privmsg(plugin.state, event.channel, event.sender.nickname,
-            "Usage: %s%s [ban|unban|list|clear]".format(settings.prefix, event.aux));
+            "Usage: %s%s [ban|unban|list|clear]"
+            .format(plugin.state.settings.prefix, event.aux));
         break;
     }
 }
@@ -521,7 +524,7 @@ in (targetChannel.length, "Tried to handle timers with an empty target channel s
     {
         privmsg(plugin.state, event.channel, event.sender.nickname,
             "Usage: %s%s %s [message threshold] [time threshold] [stagger seconds] [text]"
-            .format(settings.prefix, event.aux, verb));
+            .format(plugin.state.settings.prefix, event.aux, verb));
     }
 
     switch (verb)
@@ -586,7 +589,7 @@ in (targetChannel.length, "Tried to handle timers with an empty target channel s
         if (!slice.length)
         {
             privmsg(plugin.state, event.channel, event.sender.nickname,
-                "Usage: %s%s del [timer index]".format(settings.prefix, event.aux));
+                "Usage: %s%s del [timer index]".format(plugin.state.settings.prefix, event.aux));
             return;
         }
 
@@ -667,7 +670,7 @@ in (targetChannel.length, "Tried to handle timers with an empty target channel s
                 {
                     privmsg(plugin.state, event.channel, event.sender.nickname,
                         "Usage: %s%s list [optional starting position number]"
-                        .format(settings.prefix, event.aux));
+                        .format(plugin.state.settings.prefix, event.aux));
                     return;
                 }
             }
@@ -1596,11 +1599,13 @@ private:
         {
             import lu.string : beginsWith;
 
-            if (event.content.beginsWith(settings.prefix) &&
-                (event.content.length > settings.prefix.length))
+            immutable prefix = this.state.settings.prefix;
+
+            if (event.content.beginsWith(prefix) &&
+                (event.content.length > prefix.length))
             {
                 // Specialcase prefixed "enable"
-                if (event.content[settings.prefix.length..$] == "enable")
+                if (event.content[prefix.length..$] == "enable")
                 {
                     // Always pass through
                     return onEventImpl(event);

--- a/source/kameloso/plugins/webtitles.d
+++ b/source/kameloso/plugins/webtitles.d
@@ -115,10 +115,10 @@ struct TitleLookupRequest
 @(ChannelPolicy.home)
 void onMessage(WebtitlesPlugin plugin, const IRCEvent event)
 {
-    import kameloso.common : findURLs, settings;
+    import kameloso.common : findURLs;
     import lu.string : beginsWith;
 
-    if (event.content.beginsWith(settings.prefix)) return;
+    if (event.content.beginsWith(plugin.state.settings.prefix)) return;
 
     string[] urls = findURLs(event.content);  // mutable so nom works
     if (!urls.length) return;
@@ -136,7 +136,7 @@ void onMessage(WebtitlesPlugin plugin, const IRCEvent event)
  +/
 void lookupURLs(WebtitlesPlugin plugin, const IRCEvent event, string[] urls)
 {
-    import kameloso.common : Tint, logger, settings;
+    import kameloso.common : Tint, logger;
     import lu.string : beginsWith, contains, nom;
 
     bool[string] duplicates;
@@ -174,12 +174,12 @@ void lookupURLs(WebtitlesPlugin plugin, const IRCEvent event, string[] urls)
             if (request.results.youtubeTitle.length)
             {
                 reportDispatch(&reportYouTubeTitle, request,
-                    plugin.webtitlesSettings, settings.colouredOutgoing);
+                    plugin.webtitlesSettings, plugin.state.settings.colouredOutgoing);
             }
             else
             {
                 reportDispatch(&reportTitle, request,
-                    plugin.webtitlesSettings, settings.colouredOutgoing);
+                    plugin.webtitlesSettings, plugin.state.settings.colouredOutgoing);
             }
             continue;
         }
@@ -188,7 +188,7 @@ void lookupURLs(WebtitlesPlugin plugin, const IRCEvent event, string[] urls)
         enum delayMsecs = 250;
 
         spawn(&worker, cast(shared)request, plugin.cache, i*delayMsecs,
-            plugin.webtitlesSettings, settings.colouredOutgoing);
+            plugin.webtitlesSettings, plugin.state.settings.colouredOutgoing);
     }
 }
 


### PR DESCRIPTION
This adds experimental support for servers that don't support authentication via services. Much more testing is needed before it can be considered a first-class citizen.

So far basic authentication works, as does enlisting (and presumably delisting?) whitelists/operators/blacklists. Everything that specifically uses `IRCUser.account` will have to be altered to use `idOf`. WHOIS still works and remains necessary to look up unseen users, but it won't have to be done as often (as a single non-target event is enough to get the hostmask).

Some extra refactoring snuck in, particularly such that made plugins use a new `IRCPluginState.settings` , as well as more top-level stuff using `Kameloso.settings`, instead of the global `kameloso.common.settings`. We can't completely get rid of the latter without making more drastic changes, but its use is now minimised.