### PR TITLE
Static awareness

### DIFF
--- a/source/kameloso/plugins/awareness.d
+++ b/source/kameloso/plugins/awareness.d
@@ -280,6 +280,9 @@ mixin template UserAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home,
     }
 
 
+    @safe:
+
+
     // onUserAwarenessQuitMixin
     /++
      +  Proxies to `kameloso.plugins.awareness.onUserAwarenessQuit`.
@@ -362,7 +365,7 @@ mixin template UserAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home,
     @(IRCEvent.Type.RPL_ENDOFNAMES)
     @(IRCEvent.Type.RPL_ENDOFWHO)
     @channelPolicy
-    void onUserAwarenessEndOfListMixin(IRCPlugin plugin, const IRCEvent event)
+    void onUserAwarenessEndOfListMixin(IRCPlugin plugin, const IRCEvent event) @system
     {
         return kameloso.plugins.awareness.onUserAwarenessEndOfList(plugin, event);
     }
@@ -375,7 +378,7 @@ mixin template UserAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home,
     @(Awareness.early)
     @(Chainable)
     @(IRCEvent.Type.PING)
-    void onUserAwarenessPingMixin(IRCPlugin plugin)
+    void onUserAwarenessPingMixin(IRCPlugin plugin) @system
     {
         return kameloso.plugins.awareness.onUserAwarenessPing(plugin,
             mixin(pingRehashVariableName));
@@ -664,6 +667,10 @@ mixin template ChannelAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home
             "(needed for `ChannelAwareness`)")
             .format(module_));
     }
+
+
+    @safe:
+
 
     // onChannelAwarenessSelfjoinMixin
     /++

--- a/source/kameloso/plugins/awareness.d
+++ b/source/kameloso/plugins/awareness.d
@@ -39,9 +39,10 @@ version(WithPlugins):
 
 private:
 
-import kameloso.plugins.core : ChannelPolicy;
+import kameloso.plugins.core;
+import dialect.defs;
 
-public:
+package:
 
 @safe:
 
@@ -81,7 +82,8 @@ enum Awareness
 
 // MinimalAuthentication
 /++
- +  Implements triggering of queued events in a plugin module.
+ +  Implements triggering of queued events in a plugin module by proxying calls
+ +  to related module-level functions in `kameloso.plugins.awareness`.
  +
  +  Most of the time a plugin doesn't require a full `UserAwareness`; only
  +  those that need looking up users outside of the current event do. The
@@ -98,7 +100,7 @@ enum Awareness
  +/
 mixin template MinimalAuthentication(bool debug_ = false, string module_ = __MODULE__)
 {
-    private import kameloso.plugins.awareness : Awareness;
+    private import kameloso.plugins.awareness;
     private import lu.traits : MixinConstraints, MixinScope;
 
     mixin MixinConstraints!(MixinScope.module_, "MinimalAuthentication");
@@ -117,17 +119,7 @@ mixin template MinimalAuthentication(bool debug_ = false, string module_ = __MOD
 
     // onMinimalAuthenticationAccountInfoTargetMixin
     /++
-     +  Replays any queued `kameloso.plugins.core.Replay`s awaiting the result
-     +  of a WHOIS query. Before that, records the user's services account by
-     +  saving it to the user's `dialect.defs.IRCClient` in the `IRCPlugin`'s
-     +  `IRCPluginState.users` associative array.
-     +
-     +  `dialect.defs.IRCEvent.Type.RPL_ENDOFWHOIS` is also handled, to
-     +  cover the case where a user without an account triggering `PrivilegeLevel.anyone`-
-     +  or `PrivilegeLevel.ignored`-level commands.
-     +
-     +  This function was part of `UserAwareness` but triggering queued replays
-     +  is too common to conflate with it.
+     +  Proxies to `kameloso.plugins.awareness.onMinimalAuthenticationAccountInfoTarget`.
      +/
     @(Awareness.early)
     @(Chainable)
@@ -136,88 +128,120 @@ mixin template MinimalAuthentication(bool debug_ = false, string module_ = __MOD
     @(IRCEvent.Type.RPL_ENDOFWHOIS)
     void onMinimalAuthenticationAccountInfoTargetMixin(IRCPlugin plugin, const IRCEvent event)
     {
-        import kameloso.plugins.common : Repeater, catchUser;
-        // Catch the user here, before replaying anything.
-        plugin.catchUser(event.target);
-
-        mixin Repeater;
-
-        // See if there are any queued replays to trigger
-        auto replaysForNickname = event.target.nickname in plugin.state.replays;
-
-        if (replaysForNickname)
-        {
-            size_t[] garbageIndexes;
-
-            foreach (immutable i, replay; *replaysForNickname)
-            {
-                import kameloso.constants : Timeout;
-                import std.algorithm.searching : canFind;
-
-                scope(exit) garbageIndexes ~= i;
-
-                if ((event.time - replay.when) > Timeout.whoisRetry)
-                {
-                    // Entry is too old, replay timed out. Flag it for removal.
-                    continue;
-                }
-
-                repeat(replay);
-            }
-
-            foreach_reverse (immutable i; garbageIndexes)
-            {
-                import std.algorithm.mutation : SwapStrategy, remove;
-                *replaysForNickname = (*replaysForNickname).remove!(SwapStrategy.unstable)(i);
-            }
-        }
-
-        if (replaysForNickname && !replaysForNickname.length)
-        {
-            plugin.state.replays.remove(event.target.nickname);
-        }
+        return kameloso.plugins.awareness.onMinimalAuthenticationAccountInfoTarget(plugin, event);
     }
 
 
-    // onMinimalAuthenticationUnknownCommandWHOIS
+    // onMinimalAuthenticationUnknownCommandWHOISMixin
     /++
-     +  Clears all queued `kameloso.plugins.core.Replay`s if the server says
-     +  it doesn't support WHOIS at all.
-     +
-     +  This is the case with Twitch servers.
+     +  Proxies to 'kameloso.plugins.awareness.onMinimalAuthenticationUnknownCommandWHOIS`.
      +/
     @(Awareness.early)
     @(Chainable)
     @(IRCEvent.Type.ERR_UNKNOWNCOMMAND)
     void onMinimalAuthenticationUnknownCommandWHOIS(IRCPlugin plugin, const IRCEvent event)
     {
-        import kameloso.plugins.common : Repeater;
+        return kameloso.plugins.awareness.onMinimalAuthenticationUnknownCommandWHOIS(plugin, event);
+    }
+}
 
-        if (event.aux != "WHOIS") return;
 
-        // We're on a server that doesn't support WHOIS
-        // Trigger queued replays of a PrivilegeLevel.anyone nature, since
-        // they're just PrivilegeLevel.ignore plus a WHOIS lookup just in case
-        // Then clear everything
+// onMinimalAuthenticationAccountInfoTarget
+/++
+ +  Replays any queued `kameloso.plugins.core.Replay`s awaiting the result
+ +  of a WHOIS query. Before that, records the user's services account by
+ +  saving it to the user's `dialect.defs.IRCClient` in the `IRCPlugin`'s
+ +  `IRCPluginState.users` associative array.
+ +
+ +  `dialect.defs.IRCEvent.Type.RPL_ENDOFWHOIS` is also handled, to
+ +  cover the case where a user without an account triggering `PrivilegeLevel.anyone`-
+ +  or `PrivilegeLevel.ignored`-level commands.
+ +
+ +  This function was part of `UserAwareness` but triggering queued replays
+ +  is too common to conflate with it.
+ +/
+void onMinimalAuthenticationAccountInfoTarget(IRCPlugin plugin, const IRCEvent event) @system
+{
+    import kameloso.plugins.common : Repeater, catchUser;
 
-        mixin Repeater;
+    // Catch the user here, before replaying anything.
+    plugin.catchUser(event.target);
 
-        foreach (replaysForNickname; plugin.state.replays)
+    mixin Repeater;
+
+    // See if there are any queued replays to trigger
+    auto replaysForNickname = event.target.nickname in plugin.state.replays;
+
+    if (replaysForNickname)
+    {
+        size_t[] garbageIndexes;
+
+        foreach (immutable i, replay; *replaysForNickname)
         {
-            foreach (replay; replaysForNickname)
+            import kameloso.constants : Timeout;
+            import std.algorithm.searching : canFind;
+
+            scope(exit) garbageIndexes ~= i;
+
+            if ((event.time - replay.when) > Timeout.whoisRetry)
             {
-                repeat(replay);
+                // Entry is too old, replay timed out. Flag it for removal.
+                continue;
             }
+
+            repeat(replay);
         }
 
-        plugin.state.replays.clear();
+        foreach_reverse (immutable i; garbageIndexes)
+        {
+            import std.algorithm.mutation : SwapStrategy, remove;
+            *replaysForNickname = (*replaysForNickname).remove!(SwapStrategy.unstable)(i);
+        }
     }
+
+    if (replaysForNickname && !replaysForNickname.length)
+    {
+        plugin.state.replays.remove(event.target.nickname);
+    }
+}
+
+
+// onMinimalAuthenticationUnknownCommandWHOIS
+/++
+ +  Clears all queued `kameloso.plugins.core.Replay`s if the server says
+ +  it doesn't support WHOIS at all.
+ +
+ +  This is the case with Twitch servers.
+ +/
+void onMinimalAuthenticationUnknownCommandWHOIS(IRCPlugin plugin, const IRCEvent event) @system
+{
+    import kameloso.plugins.common : Repeater;
+
+    if (event.aux != "WHOIS") return;
+
+    // We're on a server that doesn't support WHOIS
+    // Trigger queued replays of a PrivilegeLevel.anyone nature, since
+    // they're just PrivilegeLevel.ignore plus a WHOIS lookup just in case
+    // Then clear everything
+
+    mixin Repeater;
+
+    foreach (replaysForNickname; plugin.state.replays)
+    {
+        foreach (replay; replaysForNickname)
+        {
+            repeat(replay);
+        }
+    }
+
+    plugin.state.replays.clear();
 }
 
 
 // UserAwareness
 /++
- +  Implements *user awareness* in a plugin module.
+ +  Implements *user awareness* in a plugin module by proxying calls to related
+ +  module-level functions in `kameloso.plugins.awareness`.
  +
  +  Plugins that deal with users in any form will need event handlers to handle
  +  people joining and leaving channels, disconnecting from the server, and
@@ -234,7 +258,7 @@ mixin template MinimalAuthentication(bool debug_ = false, string module_ = __MOD
 mixin template UserAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home,
     bool debug_ = false, string module_ = __MODULE__)
 {
-    private import kameloso.plugins.awareness : Awareness, MinimalAuthentication;
+    private import kameloso.plugins.awareness;
     private import lu.traits : MixinConstraints, MixinScope;
 
     mixin MixinConstraints!(MixinScope.module_, "UserAwareness");
@@ -258,48 +282,33 @@ mixin template UserAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home,
 
     // onUserAwarenessQuitMixin
     /++
-     +  Removes a user's `dialect.defs.IRCUser` entry from a plugin's user
-     +  list upon them disconnecting.
+     +  Proxies to `kameloso.plugins.awareness.onUserAwarenessQuit`.
      +/
     @(Awareness.cleanup)
     @(Chainable)
     @(IRCEvent.Type.QUIT)
     void onUserAwarenessQuitMixin(IRCPlugin plugin, const IRCEvent event)
     {
-        plugin.state.users.remove(event.sender.nickname);
+        return kameloso.plugins.awareness.onUserAwarenessQuit(plugin, event);
     }
 
 
     // onUserAwarenessNickMixin
     /++
-     +  Upon someone changing nickname, update their entry in the `IRCPlugin`'s
-     +  `IRCPluginState.users` array to point to the new nickname.
-     +
-     +  Removes the old entry after assigning it to the new key.
+     +  Proxies to `kameloso.plugins.awareness.onUserAwarenessNick`.
      +/
     @(Awareness.early)
     @(Chainable)
     @(IRCEvent.Type.NICK)
     void onUserAwarenessNickMixin(IRCPlugin plugin, const IRCEvent event)
     {
-        if (auto oldUser = event.sender.nickname in plugin.state.users)
-        {
-            plugin.state.users[event.target.nickname] = *oldUser;
-            plugin.state.users.remove(event.sender.nickname);
-        }
+        return kameloso.plugins.awareness.onUserAwarenessNick(plugin, event);
     }
 
 
     // onUserAwarenessCatchTargetMixin
     /++
-     +  Catches a user's information and saves it in the plugin's
-     +  `IRCPluginState.users` array of `dialect.defs.IRCUser`s.
-     +
-     +  `dialect.defs.IRCEvent.Type.RPL_WHOISUSER` events carry values in
-     +  the `dialect.defs.IRCUser.updated` field that we want to store.
-     +
-     +  `dialect.defs.IRCEvent.Type.CHGHOST` occurs when a user changes host
-     +  on some servers that allow for custom host addresses.
+     +  Proxies to `kameloso.plugins.awareness.onUserAwarenessCatchTarget`.
      +/
     @(Awareness.early)
     @(Chainable)
@@ -309,19 +318,13 @@ mixin template UserAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home,
     @channelPolicy
     void onUserAwarenessCatchTargetMixin(IRCPlugin plugin, const IRCEvent event)
     {
-        import kameloso.plugins.common : catchUser;
-        plugin.catchUser(event.target);
+        return kameloso.plugins.awareness.onUserAwarenessCatchTarget(plugin, event);
     }
 
 
     // onUserAwarenessCatchSenderMixin
     /++
-     +  Adds a user to the `IRCPlugin`'s `IRCPluginState.users` array,
-     +  potentially including their services account name.
-     +
-     +  Servers with the (enabled) capability `extended-join` will include the
-     +  account name of whoever joins in the event string. If it's there, catch
-     +  the user into the user array so we don't have to WHOIS them later.
+     +  Proxies to `kameloso.plugins.awareness.onUserAwarenessCatchSender`.
      +/
     @(Awareness.setup)
     @(Chainable)
@@ -332,62 +335,13 @@ mixin template UserAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home,
     @channelPolicy
     void onUserAwarenessCatchSenderMixin(IRCPlugin plugin, const IRCEvent event)
     {
-        import kameloso.plugins.common : catchUser;
-
-        with (IRCEvent.Type)
-        switch (event.type)
-        {
-        case ACCOUNT:
-        case AWAY:
-        case BACK:
-            static if (channelPolicy == ChannelPolicy.home)
-            {
-                // These events don't carry a channel.
-                // Catch if there's already an entry. Trust that it's supposed
-                // to be there if it's there. (RPL_NAMREPLY probably populated it)
-
-                if (event.sender.nickname in plugin.state.users)
-                {
-                    plugin.catchUser(event.sender);
-                    break;
-                }
-
-                static if (__traits(compiles, .hasChannelAwareness))
-                {
-                    // Catch the user if it's visible in some channel we're in.
-
-                    foreach (const channel; plugin.state.channels)
-                    {
-                        if (event.sender.nickname in channel.users)
-                        {
-                            // event is from a user that's in a relevant channel
-                            return plugin.catchUser(event.sender);
-                        }
-                    }
-                }
-            }
-            else /*static if (channelPolicy == ChannelPolicy.any)*/
-            {
-                // Catch everyone on ChannelPolicy.any
-                plugin.catchUser(event.sender);
-            }
-            break;
-
-        //case JOIN:
-        default:
-            return plugin.catchUser(event.sender);
-        }
+        return kameloso.plugins.awareness.onUserAwarenessCatchSender!channelPolicy(plugin, event);
     }
 
 
     // onUserAwarenessNamesReplyMixin
     /++
-     +  Catch users in a reply for the request for a NAMES list of all the
-     +  participants in a channel, if they are expressed in the full
-     +  `user!ident@address` form.
-     +
-     +  Freenode only sends a list of the nicknames but SpotChat sends the full
-     +  information.
+     +  Proxies to `kameloso.plugins.awareness.onUserAwarenessNamesReply`.
      +/
     @(Awareness.early)
     @(Chainable)
@@ -395,59 +349,13 @@ mixin template UserAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home,
     @channelPolicy
     void onUserAwarenessNamesReplyMixin(IRCPlugin plugin, const IRCEvent event)
     {
-        import kameloso.plugins.common : catchUser;
-        import kameloso.irccolours : stripColours;
-        import dialect.common : IRCControlCharacter, stripModesign;
-        import lu.string : contains, nom;
-        import std.algorithm.iteration : splitter;
-
-        auto names = event.content.splitter(' ');
-
-        foreach (immutable userstring; names)
-        {
-            string slice = userstring;
-            IRCUser newUser;
-
-            if ((plugin.state.server.daemon == IRCServer.Daemon.twitch) ||
-                !slice.contains('!')) // || !slice.contains('@'))  // No need to check for both
-            {
-                // Freenode-like, only nicknames with possible modesigns
-                immutable nickname = slice.stripModesign(plugin.state.server);
-
-                if (nickname == plugin.state.client.nickname) continue;
-
-                newUser.nickname = nickname;
-            }
-            else
-            {
-                // SpotChat-like, names are in full nick!ident@address form
-                immutable signed = slice.nom('!');
-                immutable nickname = signed.stripModesign(plugin.state.server);
-                if (nickname == plugin.state.client.nickname) continue;
-
-                immutable ident = slice.nom('@');
-
-                // Do addresses ever contain bold, italics, underlined?
-                immutable address = slice.contains(IRCControlCharacter.colour) ?
-                    stripColours(slice) : slice;
-
-                newUser = IRCUser(nickname, ident, address);
-            }
-
-            plugin.catchUser(newUser);
-        }
+        return kameloso.plugins.awareness.onUserAwarenessNamesReply(plugin, event);
     }
 
 
     // onUserAwarenessEndOfListMixin
     /++
-     +  Rehashes, or optimises, the `IRCPlugin`'s `IRCPluginState.users`
-     +  associative array upon the end of a WHO or a NAMES list.
-     +
-     +  These replies can list hundreds of users depending on the size of the
-     +  channel. Once an associative array has grown sufficiently, it becomes
-     +  inefficient. Rehashing it makes it take its new size into account and
-     +  makes lookup faster.
+     +  Proxies to `kameloso.plugins.awareness.onUserAwarenessEndOfList`.
      +/
     @(Awareness.early)
     @(Chainable)
@@ -456,53 +364,21 @@ mixin template UserAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home,
     @channelPolicy
     void onUserAwarenessEndOfListMixin(IRCPlugin plugin, const IRCEvent event)
     {
-        import kameloso.plugins.common : rehashUsers;
-
-        // Pass a channel name so only that channel is rehashed
-        plugin.rehashUsers(event.channel);
+        return kameloso.plugins.awareness.onUserAwarenessEndOfList(plugin, event);
     }
 
 
     // onUserAwarenessPingMixin
     /++
-     +  Rehash the internal `IRCPluginState.users` associative array of
-     +  `dialect.defs.IRCUser`s, once every `hoursBetweenRehashes` hours.
-     +
-     +  We ride the periodicity of `dialect.defs.IRCEvent.Type.PING` to get
-     +  a natural cadence without having to resort to queued
-     +  `kameloso.thread.ScheduledFiber`s.
-     +
-     +  The number of hours is so far hardcoded but can be made configurable if
-     +  there's a use-case for it.
-     +
-     +  This re-implements `IRCPlugin.periodically`.
+     +  Proxies to `kameloso.plugins.awareness.onUserAwarenessPing`.
      +/
     @(Awareness.early)
     @(Chainable)
     @(IRCEvent.Type.PING)
     void onUserAwarenessPingMixin(IRCPlugin plugin)
     {
-        import std.datetime.systime : Clock;
-
-        enum minutesBeforeInitialRehash = 5;
-        enum hoursBetweenRehashes = 12;
-
-        immutable now = Clock.currTime.toUnixTime;
-
-        if (mixin(pingRehashVariableName) == 0L)
-        {
-            // First PING encountered
-            // Delay rehashing to let the client join all channels
-            mixin(pingRehashVariableName) = now + (minutesBeforeInitialRehash * 60);
-        }
-        else if (now >= mixin(pingRehashVariableName))
-        {
-            import kameloso.plugins.common : rehashUsers;
-
-            // Once every `hoursBetweenRehashes` hours, rehash the `users` array.
-            plugin.rehashUsers();
-            mixin(pingRehashVariableName) = now + (hoursBetweenRehashes * 3600);
-        }
+        return kameloso.plugins.awareness.onUserAwarenessPing(plugin,
+            mixin(pingRehashVariableName));
     }
 
 
@@ -519,9 +395,230 @@ mixin template UserAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home,
 }
 
 
+// onUserAwarenessQuit
+/++
+ +  Removes a user's `dialect.defs.IRCUser` entry from a plugin's user
+ +  list upon them disconnecting.
+ +/
+void onUserAwarenessQuit(IRCPlugin plugin, const IRCEvent event)
+{
+    plugin.state.users.remove(event.sender.nickname);
+}
+
+
+// onUserAwarenessNick
+/++
+ +  Upon someone changing nickname, update their entry in the `IRCPlugin`'s
+ +  `IRCPluginState.users` array to point to the new nickname.
+ +
+ +  Removes the old entry after assigning it to the new key.
+ +/
+void onUserAwarenessNick(IRCPlugin plugin, const IRCEvent event)
+{
+    if (auto oldUser = event.sender.nickname in plugin.state.users)
+    {
+        plugin.state.users[event.target.nickname] = *oldUser;
+        plugin.state.users.remove(event.sender.nickname);
+    }
+}
+
+
+// onUserAwarenessCatchTarget
+/++
+ +  Catches a user's information and saves it in the plugin's
+ +  `IRCPluginState.users` array of `dialect.defs.IRCUser`s.
+ +
+ +  `dialect.defs.IRCEvent.Type.RPL_WHOISUSER` events carry values in
+ +  the `dialect.defs.IRCUser.updated` field that we want to store.
+ +
+ +  `dialect.defs.IRCEvent.Type.CHGHOST` occurs when a user changes host
+ +  on some servers that allow for custom host addresses.
+ +/
+void onUserAwarenessCatchTarget(IRCPlugin plugin, const IRCEvent event)
+{
+    import kameloso.plugins.common : catchUser;
+    plugin.catchUser(event.target);
+}
+
+
+// onUserAwarenessCatchSender
+/++
+ +  Adds a user to the `IRCPlugin`'s `IRCPluginState.users` array,
+ +  potentially including their services account name.
+ +
+ +  Servers with the (enabled) capability `extended-join` will include the
+ +  account name of whoever joins in the event string. If it's there, catch
+ +  the user into the user array so we don't have to WHOIS them later.
+ +/
+void onUserAwarenessCatchSender(ChannelPolicy channelPolicy)
+    (IRCPlugin plugin, const IRCEvent event)
+{
+    import kameloso.plugins.common : catchUser;
+
+    with (IRCEvent.Type)
+    switch (event.type)
+    {
+    case ACCOUNT:
+    case AWAY:
+    case BACK:
+        static if (channelPolicy == ChannelPolicy.home)
+        {
+            // These events don't carry a channel.
+            // Catch if there's already an entry. Trust that it's supposed
+            // to be there if it's there. (RPL_NAMREPLY probably populated it)
+
+            if (event.sender.nickname in plugin.state.users)
+            {
+                plugin.catchUser(event.sender);
+                break;
+            }
+
+            static if (__traits(compiles, .hasChannelAwareness))
+            {
+                // Catch the user if it's visible in some channel we're in.
+
+                foreach (const channel; plugin.state.channels)
+                {
+                    if (event.sender.nickname in channel.users)
+                    {
+                        // event is from a user that's in a relevant channel
+                        return plugin.catchUser(event.sender);
+                    }
+                }
+            }
+        }
+        else /*static if (channelPolicy == ChannelPolicy.any)*/
+        {
+            // Catch everyone on ChannelPolicy.any
+            plugin.catchUser(event.sender);
+        }
+        break;
+
+    //case JOIN:
+    default:
+        return plugin.catchUser(event.sender);
+    }
+}
+
+
+// onUserAwarenessNamesReply
+/++
+ +  Catch users in a reply for the request for a NAMES list of all the
+ +  participants in a channel, if they are expressed in the full
+ +  `user!ident@address` form.
+ +
+ +  Freenode only sends a list of the nicknames but SpotChat sends the full
+ +  information.
+ +/
+void onUserAwarenessNamesReply(IRCPlugin plugin, const IRCEvent event)
+{
+    import kameloso.plugins.common : catchUser;
+    import kameloso.irccolours : stripColours;
+    import dialect.common : IRCControlCharacter, stripModesign;
+    import lu.string : contains, nom;
+    import std.algorithm.iteration : splitter;
+
+    auto names = event.content.splitter(' ');
+
+    foreach (immutable userstring; names)
+    {
+        string slice = userstring;
+        IRCUser newUser;
+
+        if ((plugin.state.server.daemon == IRCServer.Daemon.twitch) ||
+            !slice.contains('!')) // || !slice.contains('@'))  // No need to check for both
+        {
+            // Freenode-like, only nicknames with possible modesigns
+            immutable nickname = slice.stripModesign(plugin.state.server);
+
+            if (nickname == plugin.state.client.nickname) continue;
+
+            newUser.nickname = nickname;
+        }
+        else
+        {
+            // SpotChat-like, names are in full nick!ident@address form
+            immutable signed = slice.nom('!');
+            immutable nickname = signed.stripModesign(plugin.state.server);
+            if (nickname == plugin.state.client.nickname) continue;
+
+            immutable ident = slice.nom('@');
+
+            // Do addresses ever contain bold, italics, underlined?
+            immutable address = slice.contains(IRCControlCharacter.colour) ?
+                stripColours(slice) : slice;
+
+            newUser = IRCUser(nickname, ident, address);
+        }
+
+        plugin.catchUser(newUser);
+    }
+}
+
+
+// onUserAwarenessEndOfList
+/++
+ +  Rehashes, or optimises, the `IRCPlugin`'s `IRCPluginState.users`
+ +  associative array upon the end of a WHO or a NAMES list.
+ +
+ +  These replies can list hundreds of users depending on the size of the
+ +  channel. Once an associative array has grown sufficiently, it becomes
+ +  inefficient. Rehashing it makes it take its new size into account and
+ +  makes lookup faster.
+ +/
+void onUserAwarenessEndOfList(IRCPlugin plugin, const IRCEvent event) @system
+{
+    import kameloso.plugins.common : rehashUsers;
+
+    // Pass a channel name so only that channel is rehashed
+    plugin.rehashUsers(event.channel);
+}
+
+
+// onUserAwarenessPingMixin
+/++
+ +  Rehash the internal `IRCPluginState.users` associative array of
+ +  `dialect.defs.IRCUser`s, once every `hoursBetweenRehashes` hours.
+ +
+ +  We ride the periodicity of `dialect.defs.IRCEvent.Type.PING` to get
+ +  a natural cadence without having to resort to queued
+ +  `kameloso.thread.ScheduledFiber`s.
+ +
+ +  The number of hours is so far hardcoded but can be made configurable if
+ +  there's a use-case for it.
+ +
+ +  This re-implements `IRCPlugin.periodically`.
+ +/
+void onUserAwarenessPing(IRCPlugin plugin, ref long pingRehash) @system
+{
+    import std.datetime.systime : Clock;
+
+    enum minutesBeforeInitialRehash = 5;
+    enum hoursBetweenRehashes = 12;
+
+    immutable now = Clock.currTime.toUnixTime;
+
+    if (pingRehash == 0L)
+    {
+        // First PING encountered
+        // Delay rehashing to let the client join all channels
+        pingRehash = now + (minutesBeforeInitialRehash * 60);
+    }
+    else if (now >= pingRehash)
+    {
+        import kameloso.plugins.common : rehashUsers;
+
+        // Once every `hoursBetweenRehashes` hours, rehash the `users` array.
+        plugin.rehashUsers();
+        pingRehash = now + (hoursBetweenRehashes * 3600);
+    }
+}
+
+
 // ChannelAwareness
 /++
- +  Implements *channel awareness* in a plugin module.
+ +  Implements *channel awareness* in a plugin module by proxying calls to related
+ +  module-level functions in `kameloso.plugins.awareness`.
  +
  +  Plugins that need to track channels and the users in them need some event
  +  handlers to handle the bookkeeping. Notably when the bot joins and leaves
@@ -544,7 +641,7 @@ version(WithPlugins)
 mixin template ChannelAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home,
     bool debug_ = false, string module_ = __MODULE__)
 {
-    private import kameloso.plugins.awareness : Awareness;
+    private import kameloso.plugins.awareness;
     private import lu.traits : MixinConstraints, MixinScope;
 
     mixin MixinConstraints!(MixinScope.module_, "ChannelAwareness");
@@ -570,8 +667,7 @@ mixin template ChannelAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home
 
     // onChannelAwarenessSelfjoinMixin
     /++
-     +  Create a new `dialect.defs.IRCChannel` in the the `IRCPlugin`'s
-     +  `IRCPluginState.channels` associative array when the bot joins a channel.
+     +  Proxies to `kameloso.plugins.awareness.onChannelAwarenessSelfjoin`.
      +/
     @(Awareness.setup)
     @(Chainable)
@@ -579,23 +675,13 @@ mixin template ChannelAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home
     @channelPolicy
     void onChannelAwarenessSelfjoinMixin(IRCPlugin plugin, const IRCEvent event)
     {
-        if (event.channel in plugin.state.channels) return;
-
-        plugin.state.channels[event.channel] = IRCChannel.init;
-        plugin.state.channels[event.channel].name = event.channel;
+        return kameloso.plugins.awareness.onChannelAwarenessSelfjoin(plugin, event);
     }
 
 
     // onChannelAwarenessSelfpartMixin
     /++
-     +  Removes an `dialect.defs.IRCChannel` from the internal list when the
-     +  bot leaves it.
-     +
-     +  Remove users from the `plugin.state.users` array if, by leaving, it left
-     +  the last channel we can observe it from, so as not to leak users. It can
-     +  be argued that this should be part of user awareness, however this would
-     +  not be possible if it were not for channel-tracking. As such keep the
-     +  behaviour in channel awareness.
+     +  Proxies to `kameloso.plugins.awareness.onChannelAwarenessSelfpart`.
      +/
     @(Awareness.cleanup)
     @(Chainable)
@@ -604,29 +690,13 @@ mixin template ChannelAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home
     @channelPolicy
     void onChannelAwarenessSelfpartMixin(IRCPlugin plugin, const IRCEvent event)
     {
-        // On Twitch SELFPART may occur on untracked channels
-        auto channel = event.channel in plugin.state.channels;
-        if (!channel) return;
-
-        nickloop:
-        foreach (immutable nickname; channel.users.byKey)
-        {
-            foreach (const stateChannel; plugin.state.channels)
-            {
-                if (nickname in stateChannel.users) continue nickloop;
-            }
-
-            // nickname is not in any of our other tracked channels; remove
-            plugin.state.users.remove(nickname);
-        }
-
-        plugin.state.channels.remove(event.channel);
+        return kameloso.plugins.awareness.onChannelAwarenessSelfpart(plugin, event);
     }
 
 
     // onChannelAwarenessJoinMixin
     /++
-     +  Adds a user as being part of a channel when they join one.
+     +  Proxies to `kameloso.plugins.awareness.onChannelAwarenessJoin`.
      +/
     @(Awareness.setup)
     @(Chainable)
@@ -634,22 +704,13 @@ mixin template ChannelAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home
     @channelPolicy
     void onChannelAwarenessJoinMixin(IRCPlugin plugin, const IRCEvent event)
     {
-        auto channel = event.channel in plugin.state.channels;
-        if (!channel) return;
-
-        channel.users[event.sender.nickname] = true;
+        return kameloso.plugins.awareness.onChannelAwarenessJoin(plugin, event);
     }
 
 
     // onChannelAwarenessPartMixin
     /++
-     +  Removes a user from being part of a channel when they leave one.
-     +
-     +  Remove the user from the `plugin.state.users` array if, by leaving, it
-     +  left the last channel we can observe it from, so as not to leak users.
-     +  It can be argued that this should be part of user awareness, however
-     +  this would not be possible if it were not for channel-tracking. As such
-     +  keep the behaviour in channel awareness.
+     +  Proxies to `kameloso.plugins.awareness.onChannelAwarenessPart`.
      +/
     @(Awareness.late)
     @(Chainable)
@@ -657,102 +718,39 @@ mixin template ChannelAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home
     @channelPolicy
     void onChannelAwarenessPartMixin(IRCPlugin plugin, const IRCEvent event)
     {
-        auto channel = event.channel in plugin.state.channels;
-        if (!channel) return;
-
-        if (event.sender.nickname !in channel.users)
-        {
-            // On Twitch servers with no NAMES on joining a channel, users
-            // that you haven't seen may leave despite never having been seen
-            return;
-        }
-
-        channel.users.remove(event.sender.nickname);
-
-        // Remove entries in the mods AA (ops, halfops, voice, ...)
-        foreach (ref modUsers; channel.mods)
-        {
-            import std.algorithm.mutation : SwapStrategy, remove;
-
-            // There should only be at most one index, but this is easy enough.
-            size_t[] garbage;
-
-            foreach (immutable i, modNickname; modUsers)
-            {
-                if (modNickname == event.sender.nickname)
-                {
-                    garbage ~= i;
-                }
-            }
-
-            foreach_reverse (immutable i; garbage)
-            {
-                modUsers = modUsers.remove!(SwapStrategy.unstable)(i);
-            }
-        }
-
-        foreach (const foreachChannel; plugin.state.channels)
-        {
-            if (event.sender.nickname in foreachChannel.users) return;
-        }
-
-        // event.sender is not in any of our tracked channels; remove
-        plugin.state.users.remove(event.sender.nickname);
+        return kameloso.plugins.awareness.onChannelAwarenessPart(plugin, event);
     }
 
 
     // onChannelAwarenessNickMixin
     /++
-     +  Upon someone changing nickname, update their entry in the
-     +  `IRCPluginState.users` associative array point to the new nickname.
-     +
-     +  Does *not* add a new entry if one doesn't exits, to counter the fact
-     +  that `dialect.defs.IRCEvent.Type.NICK` events don't belong to a channel,
-     +  and as such can't be regulated with `ChannelPolicy` annotations. This way
-     +  the user will only be moved if it was already added elsewhere. Else we'll leak users.
-     +
-     +  Removes the old entry after assigning it to the new key.
+     +  Proxies to `kameloso.plugins.awareness.onChannelAwarenessNick`.
      +/
     @(Awareness.setup)
     @(Chainable)
     @(IRCEvent.Type.NICK)
     void onChannelAwarenessNickMixin(IRCPlugin plugin, const IRCEvent event)
     {
-        // User awareness bits take care of the IRCPluginState.users AA
-
-        foreach (ref channel; plugin.state.channels)
-        {
-            if (event.sender.nickname !in channel.users) continue;
-
-            channel.users.remove(event.sender.nickname);
-            channel.users[event.target.nickname] = true;
-        }
+        return kameloso.plugins.awareness.onChannelAwarenessNick(plugin, event);
     }
 
 
     // onChannelAwarenessQuitMixin
     /++
-     +  Removes a user from all tracked channels if they disconnect.
-     +
-     +  Does not touch the internal list of users; the user awareness bits are
-     +  expected to take care of that.
+     +  Proxies to `kameloso.plugins.awareness.onChannelAwarenessQuit`.
      +/
     @(Awareness.late)
     @(Chainable)
     @(IRCEvent.Type.QUIT)
     void onChannelAwarenessQuitMixin(IRCPlugin plugin, const IRCEvent event)
     {
-        foreach (ref channel; plugin.state.channels)
-        {
-            channel.users.remove(event.sender.nickname);
-        }
+        return kameloso.plugins.awareness.onChannelAwarenessQuit(plugin, event);
     }
 
 
     // onChannelAwarenessTopicMixin
     /++
-     +  Update the entry for an `dialect.defs.IRCChannel` if someone changes
-     +  the topic of it.
+     +  Proxies to `kameloso.plugins.awareness.onChannelAwarenessTopic`.
      +/
     @(Awareness.early)
     @(Chainable)
@@ -761,16 +759,13 @@ mixin template ChannelAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home
     @channelPolicy
     void onChannelAwarenessTopicMixin(IRCPlugin plugin, const IRCEvent event)
     {
-        auto channel = event.channel in plugin.state.channels;
-        if (!channel) return;
-
-        channel.topic = event.content;
+        return kameloso.plugins.awareness.onChannelAwarenessTopic(plugin, event);
     }
 
 
     // onChannelAwarenessCreationTimeMixin
     /++
-     +  Stores the timestamp of when a channel was created.
+     +  Proxies to `kameloso.plugins.awareness.onChannelAwarenessCreationTime`.
      +/
     @(Awareness.early)
     @(Chainable)
@@ -778,19 +773,13 @@ mixin template ChannelAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home
     @channelPolicy
     void onChannelAwarenessCreationTimeMixin(IRCPlugin plugin, const IRCEvent event)
     {
-        auto channel = event.channel in plugin.state.channels;
-        if (!channel) return;
-
-        channel.created = event.count;
+        return kameloso.plugins.awareness.onChannelAwarenessCreationTime(plugin, event);
     }
 
 
     // onChannelAwarenessModeMixin
     /++
-     +  Sets a mode for a channel.
-     +
-     +  Most modes replace others of the same type, notable exceptions being
-     +  bans and mode exemptions. We let `dialect.common.setMode` take care of that.
+     +  Proxies to `kameloso.plugins.awareness.onChannelAwarenessMode`.
      +/
     @(Awareness.early)
     @(Chainable)
@@ -798,30 +787,13 @@ mixin template ChannelAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home
     @channelPolicy
     void onChannelAwarenessModeMixin(IRCPlugin plugin, const IRCEvent event)
     {
-        version(TwitchSupport)
-        {
-            if (plugin.state.server.daemon == IRCServer.Daemon.twitch)
-            {
-                // Twitch modes are unpredictable. Ignore and rely on badges instead.
-                return;
-            }
-        }
-
-        auto channel = event.channel in plugin.state.channels;
-        if (!channel) return;
-
-        import dialect.common : setMode;
-        (*channel).setMode(event.aux, event.content, plugin.state.server);
+        return kameloso.plugins.awareness.onChannelAwarenessMode(plugin, event);
     }
 
 
     // onChannelAwarenessWhoReplyMixin
     /++
-     +  Adds a user as being part of a channel upon receiving the reply from the
-     +  request for info on all the participants.
-     +
-     +  This events includes all normal fields like ident and address, but not
-     +  their channel modes (e.g. `@` for operator).
+     +  Proxies to `kameloso.plugins.awareness.onChannelAwarenessWhoReply`.
      +/
     @(Awareness.early)
     @(Chainable)
@@ -829,49 +801,13 @@ mixin template ChannelAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home
     @channelPolicy
     void onChannelAwarenessWhoReplyMixin(IRCPlugin plugin, const IRCEvent event)
     {
-        import std.string : representation;
-
-        auto channel = event.channel in plugin.state.channels;
-        if (!channel) return;
-
-        // User awareness bits add the IRCUser
-        if (event.aux.length)
-        {
-            // Register operators, half-ops, voiced etc
-            // Can be more than one if multi-prefix capability is enabled
-            // Server-sent string, can assume ASCII (@,%,+...) and go char by char
-            foreach (immutable modesign; event.aux.representation)
-            {
-                if (const modechar = modesign in plugin.state.server.prefixchars)
-                {
-                    import dialect.common : setMode;
-                    import std.conv : to;
-
-                    immutable modestring = (*modechar).to!string;
-                    (*channel).setMode(modestring, event.target.nickname, plugin.state.server);
-                }
-                else
-                {
-                    //logger.warning("Invalid modesign in RPL_WHOREPLY: ", modesign);
-                }
-            }
-        }
-
-        if (event.target.nickname == plugin.state.client.nickname) return;
-
-        // In case no mode was applied
-        channel.users[event.target.nickname] = true;
+        return kameloso.plugins.awareness.onChannelAwarenessWhoReply(plugin, event);
     }
 
 
     // onChannelAwarenessNamesReplyMixin
     /++
-     +  Adds users as being part of a channel upon receiving the reply from the
-     +  request for a list of all the participants.
-     +
-     +  On some servers this does not include information about the users, only
-     +  their nickname and their channel mode (e.g. `@` for operator), but other
-     +  servers express the users in the full `user!ident@address` form.
+     +  Proxies to `kameloso.plugins.awareness.onChannelAwarenessNamesReply`.
      +/
     @(Awareness.early)
     @(Chainable)
@@ -879,69 +815,13 @@ mixin template ChannelAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home
     @channelPolicy
     void onChannelAwarenessNamesReplyMixin(IRCPlugin plugin, const IRCEvent event)
     {
-        import lu.string : contains;
-        import std.algorithm.iteration : splitter;
-
-        if (!event.content.length) return;
-
-        auto channel = event.channel in plugin.state.channels;
-        if (!channel) return;
-
-        auto names = event.content.splitter(' ');
-
-        foreach (immutable userstring; names)
-        {
-            string slice = userstring;
-            string nickname;
-
-            if (userstring.contains('!'))// && userstring.contains('@'))  // No need to check both
-            {
-                import lu.string : nom;
-                // SpotChat-like, names are in full nick!ident@address form
-                nickname = slice.nom('!');
-            }
-            else
-            {
-                // Freenode-like, only a nickname with possible @%+ prefix
-                nickname = userstring;
-            }
-
-            import dialect.common : stripModesign;
-
-            string modesigns;
-            nickname = nickname.stripModesign(plugin.state.server, modesigns);
-
-            // Register operators, half-ops, voiced etc
-            // Can be more than one if multi-prefix capability is enabled
-            // Server-sent string, can assume ASCII (@,%,+...) and go char by char
-            import std.string : representation;
-            foreach (immutable modesign; modesigns.representation)
-            {
-                if (const modechar = modesign in plugin.state.server.prefixchars)
-                {
-                    import dialect.common : setMode;
-                    import std.conv : to;
-
-                    immutable modestring = (*modechar).to!string;
-                    (*channel).setMode(modestring, nickname, plugin.state.server);
-                }
-                else
-                {
-                    //logger.warning("Invalid modesign in RPL_NAMREPLY: ", modesign);
-                }
-            }
-
-            channel.users[nickname] = true;
-        }
+        return kameloso.plugins.awareness.onChannelAwarenessNamesReply(plugin, event);
     }
 
 
     // onChannelAwarenessModeListsMixin
     /++
-     +  Adds the list of banned users to a tracked channel's list of modes.
-     +
-     +  Bans are just normal A-mode channel modes that are paired with a user
-     +  and that don't overwrite other bans (can be stacked).
+     +  Proxies to `kameloso.plugins.awareness.onChannelAwarenessModeLists`.
      +/
     @(Awareness.early)
     @(Chainable)
@@ -953,58 +833,13 @@ mixin template ChannelAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home
     @channelPolicy
     void onChannelAwarenessModeListsMixin(IRCPlugin plugin, const IRCEvent event)
     {
-        import dialect.common : setMode;
-        import std.conv : to;
-
-        // :kornbluth.freenode.net 367 kameloso #flerrp huerofi!*@* zorael!~NaN@2001:41d0:2:80b4:: 1513899527
-        // :kornbluth.freenode.net 367 kameloso #flerrp harbl!harbl@snarbl.com zorael!~NaN@2001:41d0:2:80b4:: 1513899521
-        // :niven.freenode.net 346 kameloso^ #flerrp asdf!fdas@asdf.net zorael!~NaN@2001:41d0:2:80b4:: 1514405089
-        // :niven.freenode.net 728 kameloso^ #flerrp q qqqq!*@asdf.net zorael!~NaN@2001:41d0:2:80b4:: 1514405101
-
-        auto channel = event.channel in plugin.state.channels;
-        if (!channel) return;
-
-        with (IRCEvent.Type)
-        {
-            string modestring;
-
-            switch (event.type)
-            {
-            case RPL_BANLIST:
-                modestring = "b";
-                break;
-
-            case RPL_EXCEPTLIST:
-                modestring = (plugin.state.server.exceptsChar == 'e') ?
-                    "e" : plugin.state.server.exceptsChar.to!string;
-                break;
-
-            case RPL_INVITELIST:
-                modestring = (plugin.state.server.invexChar == 'I') ?
-                    "I" : plugin.state.server.invexChar.to!string;
-                break;
-
-            case RPL_REOPLIST:
-                modestring = "R";
-                break;
-
-            case RPL_QUIETLIST:
-                modestring = "q";
-                break;
-
-            default:
-                assert(0, "Unexpected IRC event type annotation on " ~
-                    "`onChannelAwarenessModeListMixin`");
-            }
-
-            (*channel).setMode(modestring, event.content, plugin.state.server);
-        }
+        return kameloso.plugins.awareness.onChannelAwarenessModeLists(plugin, event);
     }
 
 
     // onChannelAwarenessChannelModeIsMixin
     /++
-     +  Adds the modes of a channel to a tracked channel's mode list.
+     +  Proxies to `kameloso.plugins.awareness.onChannelAwarenessChannelModeIs`.
      +/
     @(Awareness.early)
     @(Chainable)
@@ -1012,19 +847,412 @@ mixin template ChannelAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home
     @channelPolicy
     void onChannelAwarenessChannelModeIsMixin(IRCPlugin plugin, const IRCEvent event)
     {
-        auto channel = event.channel in plugin.state.channels;
-        if (!channel) return;
-
-        import dialect.common : setMode;
-        // :niven.freenode.net 324 kameloso^ ##linux +CLPcnprtf ##linux-overflow
-        (*channel).setMode(event.aux, event.content, plugin.state.server);
+        return kameloso.plugins.awareness.onChannelAwarenessChannelModeIs(plugin, event);
     }
+}
+
+
+// onChannelAwarenessSelfjoin
+/++
+ +  Create a new `dialect.defs.IRCChannel` in the the `IRCPlugin`'s
+ +  `IRCPluginState.channels` associative array when the bot joins a channel.
+ +/
+void onChannelAwarenessSelfjoin(IRCPlugin plugin, const IRCEvent event)
+{
+    if (event.channel in plugin.state.channels) return;
+
+    plugin.state.channels[event.channel] = IRCChannel.init;
+    plugin.state.channels[event.channel].name = event.channel;
+}
+
+
+// onChannelAwarenessSelfpart
+/++
+ +  Removes an `dialect.defs.IRCChannel` from the internal list when the
+ +  bot leaves it.
+ +
+ +  Remove users from the `plugin.state.users` array if, by leaving, it left
+ +  the last channel we can observe it from, so as not to leak users. It can
+ +  be argued that this should be part of user awareness, however this would
+ +  not be possible if it were not for channel-tracking. As such keep the
+ +  behaviour in channel awareness.
+ +/
+void onChannelAwarenessSelfpart(IRCPlugin plugin, const IRCEvent event)
+{
+    // On Twitch SELFPART may occur on untracked channels
+    auto channel = event.channel in plugin.state.channels;
+    if (!channel) return;
+
+    nickloop:
+    foreach (immutable nickname; channel.users.byKey)
+    {
+        foreach (const stateChannel; plugin.state.channels)
+        {
+            if (nickname in stateChannel.users) continue nickloop;
+        }
+
+        // nickname is not in any of our other tracked channels; remove
+        plugin.state.users.remove(nickname);
+    }
+
+    plugin.state.channels.remove(event.channel);
+}
+
+
+// onChannelAwarenessJoin
+/++
+ +  Adds a user as being part of a channel when they join one.
+ +/
+void onChannelAwarenessJoin(IRCPlugin plugin, const IRCEvent event)
+{
+    auto channel = event.channel in plugin.state.channels;
+    if (!channel) return;
+
+    channel.users[event.sender.nickname] = true;
+}
+
+
+// onChannelAwarenessPart
+/++
+ +  Removes a user from being part of a channel when they leave one.
+ +
+ +  Remove the user from the `plugin.state.users` array if, by leaving, it
+ +  left the last channel we can observe it from, so as not to leak users.
+ +  It can be argued that this should be part of user awareness, however
+ +  this would not be possible if it were not for channel-tracking. As such
+ +  keep the behaviour in channel awareness.
+ +/
+void onChannelAwarenessPart(IRCPlugin plugin, const IRCEvent event)
+{
+    auto channel = event.channel in plugin.state.channels;
+    if (!channel) return;
+
+    if (event.sender.nickname !in channel.users)
+    {
+        // On Twitch servers with no NAMES on joining a channel, users
+        // that you haven't seen may leave despite never having been seen
+        return;
+    }
+
+    channel.users.remove(event.sender.nickname);
+
+    // Remove entries in the mods AA (ops, halfops, voice, ...)
+    foreach (ref modUsers; channel.mods)
+    {
+        import std.algorithm.mutation : SwapStrategy, remove;
+
+        // There should only be at most one index, but this is easy enough.
+        size_t[] garbage;
+
+        foreach (immutable i, modNickname; modUsers)
+        {
+            if (modNickname == event.sender.nickname)
+            {
+                garbage ~= i;
+            }
+        }
+
+        foreach_reverse (immutable i; garbage)
+        {
+            modUsers = modUsers.remove!(SwapStrategy.unstable)(i);
+        }
+    }
+
+    foreach (const foreachChannel; plugin.state.channels)
+    {
+        if (event.sender.nickname in foreachChannel.users) return;
+    }
+
+    // event.sender is not in any of our tracked channels; remove
+    plugin.state.users.remove(event.sender.nickname);
+}
+
+
+// onChannelAwarenessNick
+/++
+ +  Upon someone changing nickname, update their entry in the
+ +  `IRCPluginState.users` associative array point to the new nickname.
+ +
+ +  Does *not* add a new entry if one doesn't exits, to counter the fact
+ +  that `dialect.defs.IRCEvent.Type.NICK` events don't belong to a channel,
+ +  and as such can't be regulated with `ChannelPolicy` annotations. This way
+ +  the user will only be moved if it was already added elsewhere. Else we'll leak users.
+ +
+ +  Removes the old entry after assigning it to the new key.
+ +/
+void onChannelAwarenessNick(IRCPlugin plugin, const IRCEvent event)
+{
+    // User awareness bits take care of the IRCPluginState.users AA
+
+    foreach (ref channel; plugin.state.channels)
+    {
+        if (event.sender.nickname !in channel.users) continue;
+
+        channel.users.remove(event.sender.nickname);
+        channel.users[event.target.nickname] = true;
+    }
+}
+
+
+// onChannelAwarenessQuit
+/++
+ +  Removes a user from all tracked channels if they disconnect.
+ +
+ +  Does not touch the internal list of users; the user awareness bits are
+ +  expected to take care of that.
+ +/
+void onChannelAwarenessQuit(IRCPlugin plugin, const IRCEvent event)
+{
+    foreach (ref channel; plugin.state.channels)
+    {
+        channel.users.remove(event.sender.nickname);
+    }
+}
+
+
+// onChannelAwarenessTopic
+/++
+ +  Update the entry for an `dialect.defs.IRCChannel` if someone changes
+ +  the topic of it.
+ +/
+void onChannelAwarenessTopic(IRCPlugin plugin, const IRCEvent event)
+{
+    auto channel = event.channel in plugin.state.channels;
+    if (!channel) return;
+
+    channel.topic = event.content;
+}
+
+
+// onChannelAwarenessCreationTime
+/++
+ +  Stores the timestamp of when a channel was created.
+ +/
+void onChannelAwarenessCreationTime(IRCPlugin plugin, const IRCEvent event)
+{
+    auto channel = event.channel in plugin.state.channels;
+    if (!channel) return;
+
+    channel.created = event.count;
+}
+
+
+// onChannelAwarenessMode
+/++
+ +  Sets a mode for a channel.
+ +
+ +  Most modes replace others of the same type, notable exceptions being
+ +  bans and mode exemptions. We let `dialect.common.setMode` take care of that.
+ +/
+void onChannelAwarenessMode(IRCPlugin plugin, const IRCEvent event)
+{
+    version(TwitchSupport)
+    {
+        if (plugin.state.server.daemon == IRCServer.Daemon.twitch)
+        {
+            // Twitch modes are unpredictable. Ignore and rely on badges instead.
+            return;
+        }
+    }
+
+    auto channel = event.channel in plugin.state.channels;
+    if (!channel) return;
+
+    import dialect.common : setMode;
+    (*channel).setMode(event.aux, event.content, plugin.state.server);
+}
+
+
+// onChannelAwarenessWhoReply
+/++
+ +  Adds a user as being part of a channel upon receiving the reply from the
+ +  request for info on all the participants.
+ +
+ +  This events includes all normal fields like ident and address, but not
+ +  their channel modes (e.g. `@` for operator).
+ +/
+void onChannelAwarenessWhoReply(IRCPlugin plugin, const IRCEvent event)
+{
+    import std.string : representation;
+
+    auto channel = event.channel in plugin.state.channels;
+    if (!channel) return;
+
+    // User awareness bits add the IRCUser
+    if (event.aux.length)
+    {
+        // Register operators, half-ops, voiced etc
+        // Can be more than one if multi-prefix capability is enabled
+        // Server-sent string, can assume ASCII (@,%,+...) and go char by char
+        foreach (immutable modesign; event.aux.representation)
+        {
+            if (const modechar = modesign in plugin.state.server.prefixchars)
+            {
+                import dialect.common : setMode;
+                import std.conv : to;
+
+                immutable modestring = (*modechar).to!string;
+                (*channel).setMode(modestring, event.target.nickname, plugin.state.server);
+            }
+            else
+            {
+                //logger.warning("Invalid modesign in RPL_WHOREPLY: ", modesign);
+            }
+        }
+    }
+
+    if (event.target.nickname == plugin.state.client.nickname) return;
+
+    // In case no mode was applied
+    channel.users[event.target.nickname] = true;
+}
+
+
+// onChannelAwarenessNamesReply
+/++
+ +  Adds users as being part of a channel upon receiving the reply from the
+ +  request for a list of all the participants.
+ +
+ +  On some servers this does not include information about the users, only
+ +  their nickname and their channel mode (e.g. `@` for operator), but other
+ +  servers express the users in the full `user!ident@address` form.
+ +/
+void onChannelAwarenessNamesReply(IRCPlugin plugin, const IRCEvent event)
+{
+    import lu.string : contains;
+    import std.algorithm.iteration : splitter;
+
+    if (!event.content.length) return;
+
+    auto channel = event.channel in plugin.state.channels;
+    if (!channel) return;
+
+    auto names = event.content.splitter(' ');
+
+    foreach (immutable userstring; names)
+    {
+        string slice = userstring;
+        string nickname;
+
+        if (userstring.contains('!'))// && userstring.contains('@'))  // No need to check both
+        {
+            import lu.string : nom;
+            // SpotChat-like, names are in full nick!ident@address form
+            nickname = slice.nom('!');
+        }
+        else
+        {
+            // Freenode-like, only a nickname with possible @%+ prefix
+            nickname = userstring;
+        }
+
+        import dialect.common : stripModesign;
+
+        string modesigns;
+        nickname = nickname.stripModesign(plugin.state.server, modesigns);
+
+        // Register operators, half-ops, voiced etc
+        // Can be more than one if multi-prefix capability is enabled
+        // Server-sent string, can assume ASCII (@,%,+...) and go char by char
+        import std.string : representation;
+        foreach (immutable modesign; modesigns.representation)
+        {
+            if (const modechar = modesign in plugin.state.server.prefixchars)
+            {
+                import dialect.common : setMode;
+                import std.conv : to;
+
+                immutable modestring = (*modechar).to!string;
+                (*channel).setMode(modestring, nickname, plugin.state.server);
+            }
+            else
+            {
+                //logger.warning("Invalid modesign in RPL_NAMREPLY: ", modesign);
+            }
+        }
+
+        channel.users[nickname] = true;
+    }
+}
+
+
+// onChannelAwarenessModeLists
+/++
+ +  Adds the list of banned users to a tracked channel's list of modes.
+ +
+ +  Bans are just normal A-mode channel modes that are paired with a user
+ +  and that don't overwrite other bans (can be stacked).
+ +/
+void onChannelAwarenessModeLists(IRCPlugin plugin, const IRCEvent event)
+{
+    import dialect.common : setMode;
+    import std.conv : to;
+
+    // :kornbluth.freenode.net 367 kameloso #flerrp huerofi!*@* zorael!~NaN@2001:41d0:2:80b4:: 1513899527
+    // :kornbluth.freenode.net 367 kameloso #flerrp harbl!harbl@snarbl.com zorael!~NaN@2001:41d0:2:80b4:: 1513899521
+    // :niven.freenode.net 346 kameloso^ #flerrp asdf!fdas@asdf.net zorael!~NaN@2001:41d0:2:80b4:: 1514405089
+    // :niven.freenode.net 728 kameloso^ #flerrp q qqqq!*@asdf.net zorael!~NaN@2001:41d0:2:80b4:: 1514405101
+
+    auto channel = event.channel in plugin.state.channels;
+    if (!channel) return;
+
+    with (IRCEvent.Type)
+    {
+        string modestring;
+
+        switch (event.type)
+        {
+        case RPL_BANLIST:
+            modestring = "b";
+            break;
+
+        case RPL_EXCEPTLIST:
+            modestring = (plugin.state.server.exceptsChar == 'e') ?
+                "e" : plugin.state.server.exceptsChar.to!string;
+            break;
+
+        case RPL_INVITELIST:
+            modestring = (plugin.state.server.invexChar == 'I') ?
+                "I" : plugin.state.server.invexChar.to!string;
+            break;
+
+        case RPL_REOPLIST:
+            modestring = "R";
+            break;
+
+        case RPL_QUIETLIST:
+            modestring = "q";
+            break;
+
+        default:
+            assert(0, "Unexpected IRC event type annotation on " ~
+                "`onChannelAwarenessModeListMixin`");
+        }
+
+        (*channel).setMode(modestring, event.content, plugin.state.server);
+    }
+}
+
+
+// onChannelAwarenessChannelModeIs
+/++
+ +  Adds the modes of a channel to a tracked channel's mode list.
+ +/
+void onChannelAwarenessChannelModeIs(IRCPlugin plugin, const IRCEvent event)
+{
+    auto channel = event.channel in plugin.state.channels;
+    if (!channel) return;
+
+    import dialect.common : setMode;
+    // :niven.freenode.net 324 kameloso^ ##linux +CLPcnprtf ##linux-overflow
+    (*channel).setMode(event.aux, event.content, plugin.state.server);
 }
 
 
 // TwitchAwareness
 /++
- +  Implements scraping of Twitch message events for user details in a module.
+ +  Implements scraping of Twitch message events for user details in a module
+ +  by proxying calls to related module-level functions in `kameloso.plugins.awareness`.
  +
  +  Twitch doesn't always enumerate channel participants upon joining a channel.
  +  It seems to mostly be done on larger channels, and only rarely when the
@@ -1047,7 +1275,7 @@ version(TwitchSupport)
 mixin template TwitchAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home,
     bool debug_ = false, string module_ = __MODULE__)
 {
-    private import kameloso.plugins.awareness : Awareness;
+    private import kameloso.plugins.awareness;
     private import lu.traits : MixinConstraints, MixinScope;
 
     mixin MixinConstraints!(MixinScope.module_, "TwitchAwareness");
@@ -1072,17 +1300,9 @@ mixin template TwitchAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home,
     }
 
 
-    // onTwitchAwarenessSenderCarryingEvent
+    // onTwitchAwarenessSenderCarryingEventMixin
     /++
-     +  Catch senders from normal Twitch events.
-     +
-     +  This has to be done on certain Twitch channels whose participants are
-     +  not enumerated upon joining it, nor joins or parts announced. By
-     +  listening for any message and catching the user that way we ensure we
-     +  do our best to scrape the channels.
-     +
-     +  See_Also:
-     +      `onTwitchAwarenessTargetCarryingEvent`
+     +  Proxies to `kameloso.plugins.awareness.onTwitchAwarenessSenderCarryingEvent`.
      +/
     @(Awareness.early)
     @(Chainable)
@@ -1110,27 +1330,13 @@ mixin template TwitchAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home,
     @(IRCEvent.Type.TWITCH_SKIPSUBSMODEMESSAGE)
     @(IRCEvent.Type.CLEARMSG)
     @channelPolicy
-    void onTwitchAwarenessSenderCarryingEvent(IRCPlugin plugin, const IRCEvent event)
+    void onTwitchAwarenessSenderCarryingEventMixin(IRCPlugin plugin, const IRCEvent event)
     {
-        import kameloso.plugins.common : catchUser;
-
-        if (plugin.state.server.daemon != IRCServer.Daemon.twitch) return;
-
-        if (!event.sender.nickname) return;
-
-        auto channel = event.channel in plugin.state.channels;
-        if (!channel) return;
-
-        if (event.sender.nickname !in channel.users)
-        {
-            channel.users[event.sender.nickname] = true;
-        }
-
-        plugin.catchUser(event.sender);
+        return kameloso.plugins.awareness.onTwitchAwarenessSenderCarryingEvent(plugin, event);
     }
 
 
-    // onTwitchAwarenessTargetCarryingEvent
+    // onTwitchAwarenessTargetCarryingEventMixin
     /++
      +  Catch targets from normal Twitch events.
      +
@@ -1152,24 +1358,77 @@ mixin template TwitchAwareness(ChannelPolicy channelPolicy = ChannelPolicy.home,
     @(IRCEvent.Type.TWITCH_GIFTRECEIVED)
     @(IRCEvent.Type.TWITCH_PAYFORWARD)
     @channelPolicy
-    void onTwitchAwarenessTargetCarryingEvent(IRCPlugin plugin, const IRCEvent event)
+    void onTwitchAwarenessTargetCarryingEventMixin(IRCPlugin plugin, const IRCEvent event)
     {
-        import kameloso.plugins.common : catchUser;
-
-        if (plugin.state.server.daemon != IRCServer.Daemon.twitch) return;
-
-        if (!event.target.nickname) return;
-
-        auto channel = event.channel in plugin.state.channels;
-        if (!channel) return;
-
-        if (event.target.nickname !in channel.users)
-        {
-            channel.users[event.target.nickname] = true;
-        }
-
-        plugin.catchUser(event.target);
+        return kameloso.plugins.awareness.onTwitchAwarenessTargetCarryingEvent(plugin, event);
     }
+}
+
+
+// onTwitchAwarenessSenderCarryingEvent
+/++
+ +  Catch senders from normal Twitch events.
+ +
+ +  This has to be done on certain Twitch channels whose participants are
+ +  not enumerated upon joining it, nor joins or parts announced. By
+ +  listening for any message and catching the user that way we ensure we
+ +  do our best to scrape the channels.
+ +
+ +  See_Also:
+ +      `onTwitchAwarenessTargetCarryingEvent`
+ +/
+version(TwitchSupport)
+void onTwitchAwarenessSenderCarryingEvent(IRCPlugin plugin, const IRCEvent event)
+{
+    import kameloso.plugins.common : catchUser;
+
+    if (plugin.state.server.daemon != IRCServer.Daemon.twitch) return;
+
+    if (!event.sender.nickname) return;
+
+    auto channel = event.channel in plugin.state.channels;
+    if (!channel) return;
+
+    if (event.sender.nickname !in channel.users)
+    {
+        channel.users[event.sender.nickname] = true;
+    }
+
+    plugin.catchUser(event.sender);
+}
+
+
+// onTwitchAwarenessTargetCarryingEvent
+/++
+ +  Catch targets from normal Twitch events by proxying calls to related
+ +  module-level functions in `kameloso.plugins.awareness`.
+ +
+ +  This has to be done on certain Twitch channels whose participants are
+ +  not enumerated upon joining it, nor joins or parts announced. By
+ +  listening for any message with targets and catching that user that way
+ +  we ensure we do our best to scrape the channels.
+ +
+ +  See_Also:
+ +      `onTwitchAwarenessSenderCarryingEvent`
+ +/
+version(TwitchSupport)
+void onTwitchAwarenessTargetCarryingEvent(IRCPlugin plugin, const IRCEvent event)
+{
+    import kameloso.plugins.common : catchUser;
+
+    if (plugin.state.server.daemon != IRCServer.Daemon.twitch) return;
+
+    if (!event.target.nickname) return;
+
+    auto channel = event.channel in plugin.state.channels;
+    if (!channel) return;
+
+    if (event.target.nickname !in channel.users)
+    {
+        channel.users[event.target.nickname] = true;
+    }
+
+    plugin.catchUser(event.target);
 }
 
 


### PR DESCRIPTION
This moves the implementation of {Channel,User,Twitch}Awareness from functions in template mixins to module-level functions that those functions proxy calls toward.

This lowers compilation memory use slightly and shrinks the binary some. The previous approach was somewhat wasteful.