### PR TITLE
Twitch implicit flow

### DIFF
--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -13,7 +13,7 @@ install_deps() {
     # fingerprint 0xEBCF975E5BA24D5E
     sudo apt install -y --allow-unauthenticated --reinstall d-apt-keyring
     sudo apt update
-    sudo apt install -y dmd-compiler dub
+    sudo apt install -y --allow-unauthenticated dmd-compiler dub
 
     #git clone https://github.com/zorael/lu.git
     #git clone https://github.com/zorael/dialect.git

--- a/source/kameloso/logger.d
+++ b/source/kameloso/logger.d
@@ -185,6 +185,12 @@ final class KamelosoLogger : Logger
     version(Colours)
     {
         /// Provides easy way to get a log tint.
+        auto tracetint() const @property @nogc { return tintImpl!(LogLevel.trace); }
+
+        /// Convenience alias to `tracetint`.
+        alias resettint = tracetint;
+
+        /// Provides easy way to get a log tint.
         auto logtint() const @property @nogc { return tintImpl!(LogLevel.all); }
 
         /// Provides easy way to get an info tint.

--- a/source/kameloso/plugins/twitchbot/apifeatures.d
+++ b/source/kameloso/plugins/twitchbot/apifeatures.d
@@ -262,7 +262,7 @@ in (Fiber.getThis, "Tried to call `queryTwitch` from outside a Fiber")
     }
     else
     {
-        spawn(&queryTwitchImpl, url, plugin.headers, plugin.bucket);
+        spawn(&queryTwitchImpl, url, headers, plugin.bucket);
     }
 
     delay(plugin, plugin.approximateQueryTime, Yes.msecs, Yes.yield);
@@ -432,7 +432,8 @@ in (Fiber.getThis, "Tried to call `onFollowAgeImpl` from outside a Fiber")
                     scope(failure) plugin.useAPIFeatures = false;
 
                     const response = queryTwitch(plugin, url,
-                        plugin.twitchBotSettings.singleWorkerThread);
+                        plugin.twitchBotSettings.singleWorkerThread,
+                        plugin.headers);
 
                     if (!response.str.length)
                     {
@@ -716,7 +717,8 @@ void onRoomStateImpl(TwitchBotPlugin plugin, const IRCEvent event)
         try
         {
             const response = queryTwitch(plugin, url,
-                plugin.twitchBotSettings.singleWorkerThread);
+                plugin.twitchBotSettings.singleWorkerThread,
+                plugin.headers);
             const broadcasterJSON = parseUserFromResponse(response.str);
             channel.broadcasterDisplayName = broadcasterJSON["display_name"].str;
         }
@@ -839,7 +841,7 @@ in (Fiber.getThis, "Tried to call `cacheFollows` from outside a Fiber")
         scope(failure) plugin.useAPIFeatures = false;
 
         const response = queryTwitch(plugin, paginatedURL,
-            plugin.twitchBotSettings.singleWorkerThread);
+            plugin.twitchBotSettings.singleWorkerThread, plugin.headers);
 
         auto followsJSON = parseJSON(response.str);
         const cursor = "cursor" in followsJSON["pagination"];

--- a/source/kameloso/plugins/twitchbot/apifeatures.d
+++ b/source/kameloso/plugins/twitchbot/apifeatures.d
@@ -831,7 +831,7 @@ void onEndOfMotdImpl(TwitchBotPlugin plugin)
             immutable expiresIn = validation["expires_in"].integer;
             immutable expiresWhen = SysTime.fromUnixTime(Clock.currTime.toUnixTime + expiresIn);
 
-            logger.infof("Your authorisation keys will expire on %s%02d-%02d-%02d %02d:%02d",
+            logger.infof("Your Twitch authorisation key will expire on %s%02d-%02d-%02d %02d:%02d",
                 Tint.log, expiresWhen.year, expiresWhen.month, expiresWhen.day,
                 expiresWhen.hour, expiresWhen.minute);
         }

--- a/source/kameloso/plugins/twitchbot/apifeatures.d
+++ b/source/kameloso/plugins/twitchbot/apifeatures.d
@@ -1057,3 +1057,42 @@ in (Fiber.getThis, "Tried to call `waitForQueryResponse` from outside a Fiber")
 
     return *response;
 }
+
+
+// TwitchQueryException
+/++
+ +  Exception, to be thrown when an API query to the Twitch servers failed,
+ +  for whatever reason.
+ +
+ +  It is a normal `object.Exception` but with attached metadata.
+ +/
+final class TwitchQueryException : Exception
+{
+@safe:
+    /// The response body that was received.
+    string responseBody;
+
+    /// The HTTP code that was received.
+    uint code;
+
+    /++
+     +  Create a new `TwitchQueryException`, attaching a response body and a
+     +  HTTP return code.
+     +/
+    this(const string message, const string responseBody, const uint code,
+        const string file = __FILE__, const size_t line = __LINE__) pure nothrow @nogc
+    {
+        this.responseBody = responseBody;
+        this.code = code;
+        super(message, file, line);
+    }
+
+    /++
+     +  Create a new `TwitchQueryException`, without attaching anything.
+     +/
+    this(const string message, const string file = __FILE__,
+        const size_t line = __LINE__) pure nothrow @nogc
+    {
+        super(message, file, line);
+    }
+}

--- a/source/kameloso/plugins/twitchbot/apifeatures.d
+++ b/source/kameloso/plugins/twitchbot/apifeatures.d
@@ -118,14 +118,14 @@ void onCAPImpl(TwitchBotPlugin plugin)
     import std.concurrency : prioritySend;
     import std.stdio : readln, stdin, stdout, write, writefln, writeln;
 
-    if (!plugin.twitchBotSettings.generateKey) return;
+    if (!plugin.twitchBotSettings.keyGenerationMode) return;
 
     writeln();
     logger.info("-- Twitch authorisation key generation mode --");
     writeln();
-    writefln("You are here because you passed %s--set twitchbot.generateKey%s",
+    writefln("You are here because you passed %s--set twitchbot.keyGenerationMode%s",
         Tint.info, Tint.reset);
-    writefln("or because you have %sgenerateKey%s persistently set to %1$strue%2$s ",
+    writefln("or because you have %skeyGenerationMode%s persistently set to %1$strue%2$s ",
         Tint.info, Tint.reset);
     writeln("in the configuration file (which you really shouldn't set).");
     writeln();
@@ -214,7 +214,7 @@ void onCAPImpl(TwitchBotPlugin plugin)
     writeln(Tint.warning, "This will need to be repeated once every 60 days.", Tint.reset);
     writeln();
 
-    plugin.twitchBotSettings.generateKey = false;
+    plugin.twitchBotSettings.keyGenerationMode = false;
     plugin.state.botUpdated = true;
     plugin.state.mainThread.prioritySend(ThreadMessage.Quit(), string.init, Yes.quiet);
 }

--- a/source/kameloso/plugins/twitchbot/apifeatures.d
+++ b/source/kameloso/plugins/twitchbot/apifeatures.d
@@ -710,23 +710,11 @@ void onRoomStateImpl(TwitchBotPlugin plugin, const IRCEvent event)
     {
         immutable url = "https://api.twitch.tv/helix/users?id=" ~ event.aux;
 
-        try
-        {
-            const response = queryTwitch(plugin, url,
-                plugin.twitchBotSettings.singleWorkerThread,
-                plugin.headers);
-            const broadcasterJSON = parseUserFromResponse(response.str);
-            channel.broadcasterDisplayName = broadcasterJSON["display_name"].str;
-        }
-        catch (Exception e)
-        {
-            if (!plugin.useAPIFeatures) return;  // Already errored
-
-            // Something is deeply wrong.
-            logger.error("Failed to fetch broadcaster information. Disabling API features.");
-            plugin.useAPIFeatures = false;
-            return;
-        }
+        const response = queryTwitch(plugin, url,
+            plugin.twitchBotSettings.singleWorkerThread,
+            plugin.headers);
+        const broadcasterJSON = parseUserFromResponse(response.str);
+        channel.broadcasterDisplayName = broadcasterJSON["display_name"].str;
     }
 
     Fiber getDisplayNameFiber = new Fiber(&getDisplayNameDg);

--- a/source/kameloso/plugins/twitchbot/apifeatures.d
+++ b/source/kameloso/plugins/twitchbot/apifeatures.d
@@ -152,7 +152,7 @@ void onCAPImpl(TwitchBotPlugin plugin)
     writeln();
 
     immutable url = "https://id.twitch.tv/oauth2/authorize?response_type=token" ~
-        "&client_id=tjyryd2ojnqr8a51ml19kn1yi2n0v1" ~
+        "&client_id=" ~ TwitchBotPlugin.clientID ~
         "&redirect_uri=http://localhost" ~
         "&scope=channel:moderate+chat:edit+chat:read+whispers:edit+whispers:read+" ~
         "channel:read:subscriptions+bits:read+user:edit:broadcast+channel_editor" ~

--- a/source/kameloso/plugins/twitchbot/apifeatures.d
+++ b/source/kameloso/plugins/twitchbot/apifeatures.d
@@ -120,6 +120,13 @@ void onCAPImpl(TwitchBotPlugin plugin)
 
     if (!plugin.twitchBotSettings.keyGenerationMode) return;
 
+    scope(exit)
+    {
+        plugin.twitchBotSettings.keyGenerationMode = false;
+        plugin.state.botUpdated = true;
+        plugin.state.mainThread.prioritySend(ThreadMessage.Quit(), string.init, Yes.quiet);
+    }
+
     writeln();
     logger.info("-- Twitch authorisation key generation mode --");
     writeln();
@@ -213,10 +220,6 @@ void onCAPImpl(TwitchBotPlugin plugin)
     writeln();
     writeln(Tint.warning, "This will need to be repeated once every 60 days.", Tint.reset);
     writeln();
-
-    plugin.twitchBotSettings.keyGenerationMode = false;
-    plugin.state.botUpdated = true;
-    plugin.state.mainThread.prioritySend(ThreadMessage.Quit(), string.init, Yes.quiet);
 }
 
 

--- a/source/kameloso/plugins/twitchbot/apifeatures.d
+++ b/source/kameloso/plugins/twitchbot/apifeatures.d
@@ -352,11 +352,7 @@ void queryTwitchImpl(const string url, shared string[string] headers,
     response.code = res.code;
     immutable delta = (post - pre);
     response.msecs = delta.total!"msecs";
-
-    if (res.code < 400)
-    {
-        response.str = cast(string)res.responseBody.data.idup;
-    }
+    response.str = cast(string)res.responseBody.data.idup;
 
     synchronized //()
     {

--- a/source/kameloso/plugins/twitchbot/apifeatures.d
+++ b/source/kameloso/plugins/twitchbot/apifeatures.d
@@ -819,26 +819,6 @@ in (Fiber.getThis, "Tried to call `getValidation` from outside a Fiber")
         throw new Exception("Error validating, unknown JSON");
     }
 
-    /*
-    {
-        "client_id": "tjyryd2ojnqr8a51ml19kn1yi2n0v1",
-        "expires_in": 5036421,
-        "login": "zorael",
-        "scopes": [
-            "bits:read",
-            "channel:moderate",
-            "channel:read:subscriptions",
-            "channel_editor",
-            "chat:edit",
-            "chat:read",
-            "user:edit:broadcast",
-            "whispers:edit",
-            "whispers:read"
-        ],
-        "user_id": "22216721"
-    }
-    */
-
     return validation;
 }
 

--- a/source/kameloso/plugins/twitchbot/package.d
+++ b/source/kameloso/plugins/twitchbot/package.d
@@ -62,12 +62,13 @@ import core.thread : Fiber;
     bool enableAPIFeatures = true;
 
     /++
-     +  Whether or not to start a captive session for generating a Twitch
-     +  authorisation key. Should not be permanently set in the configuration file!
+     +  Whether to use one persistent worker for Twitch queries or to use separate subthreads.
+     +
+     +  It's a trade-off. A single worker thread obviously spawns fewer threads,
+     +  which makes it a better choice on Windows systems where creating such is
+     +  comparatively expensive. On the other hand, it's also slower (likely due to
+     +  concurrency message passing overhead).
      +/
-    bool generateKey = false;
-
-    /// Whether to use one persistent worker for Twitch queries or to use separate subthreads.
     version(Windows)
     {
         bool singleWorkerThread = true;
@@ -76,6 +77,12 @@ import core.thread : Fiber;
     {
         bool singleWorkerThread = false;
     }
+
+    /++
+     +  Whether or not to start a captive session for generating a Twitch
+     +  authorisation key. Should not be permanently set in the configuration file!
+     +/
+    bool generateKey = false;
 }
 
 

--- a/source/kameloso/plugins/twitchbot/package.d
+++ b/source/kameloso/plugins/twitchbot/package.d
@@ -82,7 +82,7 @@ import core.thread : Fiber;
      +  Whether or not to start a captive session for generating a Twitch
      +  authorisation key. Should not be permanently set in the configuration file!
      +/
-    bool generateKey = false;
+    bool keyGenerationMode = false;
 }
 
 

--- a/source/kameloso/plugins/twitchbot/package.d
+++ b/source/kameloso/plugins/twitchbot/package.d
@@ -1286,6 +1286,9 @@ package:
          +/
         shared string[string] headers;
 
+        /// The bot's numeric account/ID.
+        string userID;
+
         /++
          +  How long a Twitch HTTP query usually takes.
          +

--- a/source/kameloso/plugins/twitchbot/package.d
+++ b/source/kameloso/plugins/twitchbot/package.d
@@ -58,6 +58,9 @@ import core.thread : Fiber;
     /// Whether or not a link permit should be for one link only or for any number in 60 seconds.
     bool permitOneLinkOnly = true;
 
+    /// Whether or not to use features dependent on the Twitch API.
+    bool enableAPIFeatures = true;
+
     /++
      +  Whether or not to start a captive session for generating a Twitch
      +  authorisation key. Should not be permanently set in the configuration file!

--- a/source/kameloso/plugins/twitchbot/package.d
+++ b/source/kameloso/plugins/twitchbot/package.d
@@ -1332,9 +1332,10 @@ package:
      +/
     override public void onEvent(const IRCEvent event)
     {
-        if (state.server.daemon != IRCServer.Daemon.twitch)
+        if ((state.server.daemon != IRCServer.Daemon.unset) &&
+            (state.server.daemon != IRCServer.Daemon.twitch))
         {
-            // Daemon known and not Twitch
+            // Daemon unknown or not Twitch
             return;
         }
 

--- a/source/kameloso/plugins/twitchbot/package.d
+++ b/source/kameloso/plugins/twitchbot/package.d
@@ -1289,13 +1289,13 @@ package:
         long approximateQueryTime = 700;
 
         /++
-         +  The multiplier of how much the `approximateQueryTime` should increase
+         +  The multiplier of how much the query time should temporarily increase
          +  when it turned out to be a bit short.
          +/
         enum approximateQueryGrowthMultiplier = 1.1;
 
         /++
-         +  The divisor of how much to wait before retrying, after `approximateQueryTime`
+         +  The divisor of how much to wait before retrying a query, after the timed waited
          +  turned out to be a bit short.
          +/
         enum approximateQueryRetryTimeDivisor = 3;
@@ -1322,7 +1322,7 @@ package:
         /// The thread ID of the persistent worker thread.
         Tid persistentWorkerTid;
 
-        /// Results of async HTTP queries.
+        /// Associative array of responses from async HTTP queries.
         shared QueryResponse[string] bucket;
     }
 

--- a/source/kameloso/plugins/twitchbot/package.d
+++ b/source/kameloso/plugins/twitchbot/package.d
@@ -921,6 +921,23 @@ void onEndOfMotd(TwitchBotPlugin plugin)
 }
 
 
+// onCAP
+/++
+ +  Start the captive key generation routine at the earliest possible moment,
+ +  which are the CAP events.
+ +
+ +  We can't do it in `start` since the calls to save and exit would go unheard,
+ +  as `start` happens before the main loop starts. It would then immediately
+ +  fail to read if too much time has passed, and nothing would be saved.
+ +/
+version(TwitchAPIFeatures)
+@(IRCEvent.Type.CAP)
+void onCAP(TwitchBotPlugin plugin)
+{
+    return plugin.onCAPImpl();
+}
+
+
 // reload
 /++
  +  Reloads resources from disk.

--- a/source/kameloso/plugins/twitchbot/package.d
+++ b/source/kameloso/plugins/twitchbot/package.d
@@ -1143,10 +1143,12 @@ version(TwitchAPIFeatures)
 void teardown(TwitchBotPlugin plugin)
 {
     import kameloso.thread : ThreadMessage;
-    import std.concurrency : send;
+    import std.concurrency : Tid, send;
 
-    if (plugin.twitchBotSettings.singleWorkerThread)
+    if (plugin.twitchBotSettings.singleWorkerThread &&
+        (plugin.persistentWorkerTid != Tid.init))
     {
+        // It may not have been started if we're aborting pre-endofmotd.
         plugin.persistentWorkerTid.send(ThreadMessage.Teardown());
     }
 }

--- a/source/kameloso/plugins/twitchbot/package.d
+++ b/source/kameloso/plugins/twitchbot/package.d
@@ -1253,6 +1253,9 @@ package:
     {
         import std.concurrency : Tid;
 
+        /// The Twitch application ID for kameloso.
+        enum clientID = "tjyryd2ojnqr8a51ml19kn1yi2n0v1";
+
         /// Whether or not to use features requiring querying Twitch API.
         bool useAPIFeatures = true;
 

--- a/source/kameloso/plugins/twitchbot/package.d
+++ b/source/kameloso/plugins/twitchbot/package.d
@@ -58,11 +58,11 @@ import core.thread : Fiber;
     /// Whether or not a link permit should be for one link only or for any number in 60 seconds.
     bool permitOneLinkOnly = true;
 
-    /// Client-ID key to use when querying Twitch servers for information.
-    string clientKey;
-
-    /// Client secret to use when querying Twitch servers for information.
-    string secretKey;
+    /++
+     +  Whether or not to start a captive session for generating a Twitch
+     +  authorisation key. Should not be permanently set in the configuration file!
+     +/
+    bool generateKey = false;
 
     /// Whether to use one persistent worker for Twitch queries or to use separate subthreads.
     version(Windows)

--- a/source/kameloso/plugins/twitchbot/package.d
+++ b/source/kameloso/plugins/twitchbot/package.d
@@ -1152,6 +1152,7 @@ void start(TwitchBotPlugin plugin)
 {
     import std.datetime.systime : Clock;
     plugin.state.nextPeriodical = Clock.currTime.toUnixTime + 60;
+    plugin.useAPIFeatures = plugin.twitchBotSettings.enableAPIFeatures;
 }
 
 

--- a/source/kameloso/plugins/twitchbot/package.d
+++ b/source/kameloso/plugins/twitchbot/package.d
@@ -1028,15 +1028,6 @@ void initResources(TwitchBotPlugin plugin)
 
     bannedPhrasesJSON.save(plugin.bannedPhrasesFile);
     timersJSON.save(plugin.timersFile);
-
-    version(TwitchAPIFeatures)
-    {
-        if (!plugin.keyFile.exists)
-        {
-            auto file = File(plugin.keyFile, "w");
-            file.writeln();
-        }
-    }
 }
 
 
@@ -1333,9 +1324,6 @@ package:
 
         /// Results of async HTTP queries.
         shared QueryResponse[string] bucket;
-
-        /// The file containing the bearer authorization key.
-        @Resource string keyFile = "twitch.key";
     }
 
     mixin IRCPluginImpl;


### PR DESCRIPTION
This finally adds proper Twitch authorisation.

What we used to do was to use a third-party site to generate an OAuth key to use as pass and connect with, and we were content. Then we found out about the richr API, and to use it the key has to be *paired* with the application's client ID.

This adds a captive session that guides the user toward generating a new key that properly works with kameloso (and only kameloso), by authorising it via a Twitch login form on Twitch's own site. It's scary but it's safe. Presently the user has to copy a resulting URL and paste it into the waiting program, but it works.

Not sure it's worth going beyond that; read: create a small web server to automatically catch the URL so the user doesn't have to copy/paste.