### PR TITLE
errno

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,12 +51,6 @@ branches:
     - gh-pages
     - /dustmite-.*/
 
-artifacts:
-  - path: kameloso.exe
-    name: Full build
-  - path: kameloso-dev.exe
-    name: Development build
-
 install:
   - ps: function SetUpDCompiler
         {
@@ -129,3 +123,12 @@ test_script:
  - mv kameloso.exe kameloso-dev.exe
  - dub build --nodeps --arch=%Darch% --compiler=%DC% %dubArgs% -b debug -c twitch
  #- mv kameloso.exe kameloso-twitch.exe
+
+after_test:
+ - ps: if($env:APPVEYOR_REPO_TAG -eq "True"){
+         Push-AppveyorArtifact kameloso.exe -DeploymentName "Full build"
+         Push-AppveyorArtifact kameloso-dev.exe -DeploymentName "Development build";
+       }
+       else{
+         echo "Does not seem to be a tag so not pushing artifacts";
+       }

--- a/dub.sdl
+++ b/dub.sdl
@@ -59,8 +59,7 @@ versions \
     "PrefixedCommandsFallBackToNickname" \
     "SanitizeAndRetryOnUnicodeException" \
     "TwitchAPIFeatures" \
-    "CtTints" \
-    "PrintErrnos"
+    "CtTints"
 
 /**
     Non-default features.
@@ -77,7 +76,8 @@ versions \
     "OSXTMPDIR" \
     "OmniscientQueries" \
     "TraceWhois" \
-    "ProfileGC"
+    "ProfileGC" \
+    "PrintErrnos"
 */
 
 configuration "application" {

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -1257,7 +1257,15 @@ unittest
         static if (symname[0] == 'E')
         {
             immutable idx = __traits(getMember, core.stdc.errno, symname);
-            errnoStrings[idx] = symname;
+
+            if (errnoStrings[idx].length)
+            {
+                writefln("%s DUPLICATE %d", symname, idx);
+            }
+            else
+            {
+                errnoStrings[idx] = symname;
+            }
         }
     }
 
@@ -1273,6 +1281,7 @@ unittest
     ---
  +/
 version(Posix)
+version(PrintErrnos)
 static immutable string[134] errnoStrings =
 [
     1   : "EPERM",
@@ -1285,7 +1294,7 @@ static immutable string[134] errnoStrings =
     8   : "ENOEXEC",
     9   : "EBADF",
     10  : "ECHILD",
-    11  : "EWOULDBLOCK",
+    11  : "EAGAIN",  // duplicate EWOULDBLOCK
     12  : "ENOMEM",
     13  : "EACCES",
     14  : "EFAULT",
@@ -1309,7 +1318,7 @@ static immutable string[134] errnoStrings =
     32  : "EPIPE",
     33  : "EDOM",
     34  : "ERANGE",
-    35  : "EDEADLOCK",
+    35  : "EDEADLK",  // duplicate EDEADLOCK
     36  : "ENAMETOOLONG",
     37  : "ENOLCK",
     38  : "ENOSYS",
@@ -1367,7 +1376,7 @@ static immutable string[134] errnoStrings =
     92  : "ENOPROTOOPT",
     93  : "EPROTONOSUPPORT",
     94  : "ESOCKTNOSUPPORT",
-    95  : "ENOTSUP",
+    95  : "EOPNOTSUPP",  // duplicate ENOTSUPP
     96  : "EPFNOSUPPORT",
     97  : "EAFNOSUPPORT",
     98  : "EADDRINUSE",

--- a/source/kameloso/main.d
+++ b/source/kameloso/main.d
@@ -118,7 +118,7 @@ void signalHandler(int sig) nothrow @nogc @system
         "SYS\0",
     ];
 
-    printf("...caught signal SIG%s! (%d)\n", signalNames.ptr[sig-1], sig);
+    printf("...caught signal SIG%s!\n", signalNames.ptr[sig-1]);
     rawAbort = true;
 
     version(Posix)

--- a/source/kameloso/main.d
+++ b/source/kameloso/main.d
@@ -1901,7 +1901,7 @@ Next tryConnect(ref Kameloso instance)
             goto case delayThenReconnect;
 
         case error:
-            logger.error("Failed to connect: ", attempt.error);
+            logger.error("Failed to connect: ", Tint.log, attempt.error);
             return Next.returnFailure;
         }
     }

--- a/source/kameloso/main.d
+++ b/source/kameloso/main.d
@@ -983,13 +983,13 @@ Next listenAttemptToNext(ref Kameloso instance, const ListenAttempt attempt)
 
         version(PrintErrnosPosix)
         {
-            logger.warningf("Connection error! (%s%s%s: %1$s%4$s%3$s)",
-                Tint.log, errnoStrings[attempt.errno], attempt.error, Tint.warning);
+            logger.warningf("Connection error! (%s%s%s) (%1$s%4$s%3$s)",
+                Tint.log, attempt.error, Tint.warning, errnoStrings[attempt.errno]);
         }
         else version(PrintErrnosWindows)
         {
-            logger.warningf("Connection error! (%s%d%s: %1$s%4$s%3$s)",
-                Tint.log, attempt.errno, attempt.error, Tint.warning);
+            logger.warningf("Connection error! (%s%s%s) (%1$s%4$d%3$s)",
+                Tint.log, attempt.error, Tint.warning, attempt.errno);
         }
         else
         {
@@ -1029,13 +1029,13 @@ Next listenAttemptToNext(ref Kameloso instance, const ListenAttempt attempt)
         {
             version(PrintErrnosPosix)
             {
-                logger.errorf("Connection error: invalid server response! (%s%s%s: %1$s%4$s%3$s)",
-                    Tint.log, errnoStrings[attempt.errno], Tint.error, attempt.error);
+                logger.errorf("Connection error: invalid server response! (%s%s%s) (%1$s%4$s%3$s)",
+                    Tint.log, attempt.error, Tint.error, errnoStrings[attempt.errno]);
             }
             else version(PrintErrnosWindows)
             {
-                logger.errorf("Connection error: invalid server response! (%s%d%s: %1$s%4$s%3$s)",
-                    Tint.log, attempt.errno, Tint.error, attempt.error);
+                logger.errorf("Connection error: invalid server response! (%s%s%s) (%1$s%4$d%3$s)",
+                    Tint.log, attempt.error, Tint.error, attempt.errno);
             }
             else
             {
@@ -1891,7 +1891,7 @@ Next tryConnect(ref Kameloso instance)
             }
             else version(PrintErrnosWindows)
             {
-                logger.warningf("Connection failed with %s%d%s: %1$s%4$s",
+                logger.warningf("Connection failed with error %s%d%s: %1$s%4$s",
                     Tint.log, attempt.errno, Tint.warning, attempt.error);
             }
 
@@ -1936,7 +1936,7 @@ Next tryConnect(ref Kameloso instance)
                 }
                 else version(PrintErrnosWindows)
                 {
-                    logger.warning("IPv6 connection failed with %s%d%s: %1$s%4$s",
+                    logger.warning("IPv6 connection failed with error %s%d%s: %1$s%4$s",
                         Tint.log, attempt.errno, Tint.warning, attempt.error);
                 }
 
@@ -1958,13 +1958,13 @@ Next tryConnect(ref Kameloso instance)
         case error:
             version(PrintErrnosPosix)
             {
-                logger.errorf("Failed to connect (%s%s%s): %1$s%4$s",
-                    Tint.log, errnoStrings[attempt.errno], Tint.error, attempt.error);
+                logger.errorf("Failed to connect: %s%s%s (%1$s%4$s%3$s)",
+                    Tint.log, attempt.error, Tint.error, errnoStrings[attempt.errno]);
             }
             else version(PrintErrnosWindows)
             {
-                logger.errorf("Failed to connect (%s%d%s): %1$s%4$s",
-                    Tint.log, attempt.errno, Tint.error, attempt.error);
+                logger.errorf("Failed to connect: %s%s%s (%1$s%4$d%3$s)",
+                    Tint.log, attempt.error, Tint.error, attempt.errno);
             }
             else
             {
@@ -2046,8 +2046,8 @@ Next tryResolve(ref Kameloso instance, Flag!"firstConnect" firstConnect)
         case exception:
             version(PrintErrnos)
             {
-                logger.warningf("Could not resolve server address. (%s%d%s: %1$s%4$s%3$s)",
-                    Tint.log, attempt.errno, Tint.warning, attempt.error);
+                logger.warningf("Could not resolve server address. (%s%s%s) (%1$s%4$d%3$s)",
+                    Tint.log, attempt.error, Tint.warning, attempt.errno);
             }
             else
             {
@@ -2062,8 +2062,8 @@ Next tryResolve(ref Kameloso instance, Flag!"firstConnect" firstConnect)
         case error:
             version(PrintErrnos)
             {
-                logger.errorf("Could not resolve server address. (%s%d%s: %1$s%4$s%3$s)",
-                    Tint.log, attempt.errno, Tint.error, attempt.error);
+                logger.errorf("Could not resolve server address. (%s%s%s) (%1$s%4$d%3$s)",
+                    Tint.log, attempt.error, Tint.error, attempt.errno);
             }
             else
             {

--- a/source/kameloso/main.d
+++ b/source/kameloso/main.d
@@ -977,7 +977,7 @@ Next listenAttemptToNext(ref Kameloso instance, const ListenAttempt attempt)
 
         version(ShouldPrintErrnos)
         {
-            logger.warningf("Connection error! (%s%s: %s%s)",
+            logger.warningf("Connection error! (%s%s: %1$s%4$s%3$s)",
                 Tint.log, errnoStrings[attempt.errno], attempt.error, Tint.warning);
         }
         else
@@ -1013,8 +1013,8 @@ Next listenAttemptToNext(ref Kameloso instance, const ListenAttempt attempt)
         {
             version(ShouldPrintErrnos)
             {
-                logger.errorf("Connection error: invalid server response! (%s%s: %s%s)",
-                    Tint.log, errnoStrings[attempt.errno], attempt.error, Tint.error);
+                logger.errorf("Connection error: invalid server response! (%s%s%s: %1$s%4$s%3$s)",
+                    Tint.log, errnoStrings[attempt.errno], Tint.error, attempt.error);
             }
             else
             {
@@ -1865,7 +1865,7 @@ Next tryConnect(ref Kameloso instance)
 
             version(ShouldPrintErrnos)
             {
-                logger.warningf("Connection failed with %s%s%s: %4$s",
+                logger.warningf("Connection failed with %s%s%s: %1$s%4$s",
                     Tint.log, errnoStrings[attempt.errno], Tint.warning, attempt.error);
             }
 
@@ -1903,7 +1903,7 @@ Next tryConnect(ref Kameloso instance)
         case ipv6Failure:
             version(ShouldPrintErrnos)
             {
-                logger.warning("IPv6 connection failed with %s%s%s: %4$s",
+                logger.warning("IPv6 connection failed with %s%s%s: %1$s%4$s",
                     Tint.log, errnoStrings[attempt.errno], Tint.warning, attempt.error);
                 logger.warning("Disabling IPv6.");
             }

--- a/source/kameloso/main.d
+++ b/source/kameloso/main.d
@@ -2206,8 +2206,18 @@ void resolveResourceDirectory(ref Kameloso instance)
     import std.path : buildNormalizedPath, dirName;
 
     // Resolve and create the resource directory
-    instance.settings.resourceDirectory = buildNormalizedPath(instance.settings.resourceDirectory,
-        "server", instance.parser.server.address);
+    version(Windows)
+    {
+        import std.string : replace;
+        instance.settings.resourceDirectory = buildNormalizedPath(instance.settings.resourceDirectory,
+            "server", instance.parser.server.address.replace(":", "_"));
+    }
+    else
+    {
+        instance.settings.resourceDirectory = buildNormalizedPath(instance.settings.resourceDirectory,
+            "server", instance.parser.server.address);
+    }
+
     instance.settings.configDirectory = instance.settings.configFile.dirName;
 
     if (!instance.settings.resourceDirectory.exists)

--- a/source/kameloso/main.d
+++ b/source/kameloso/main.d
@@ -2006,8 +2006,8 @@ Next tryResolve(ref Kameloso instance, Flag!"firstConnect" firstConnect)
         case exception:
             version(ShouldPrintErrnos)
             {
-                logger.warningf("Could not resolve server address. (%s%s%s: %s)",
-                    Tint.log, errnoStrings[attempt.errno], Tint.warning, attempt.error);
+                logger.warningf("Could not resolve server address. (%s%d%s: %1$s%4$s%3$s)",
+                    Tint.log, attempt.errno, Tint.warning, attempt.error);
             }
             else
             {
@@ -2022,8 +2022,8 @@ Next tryResolve(ref Kameloso instance, Flag!"firstConnect" firstConnect)
         case error:
             version(ShouldPrintErrnos)
             {
-                logger.errorf("Could not resolve server address. (%s%s%s: %s)",
-                    Tint.log, errnoStrings[attempt.errno], Tint.error, attempt.error);
+                logger.errorf("Could not resolve server address. (%s%d%s: %1$s%4$s%3$s)",
+                    Tint.log, attempt.errno, Tint.error, attempt.error);
             }
             else
             {

--- a/source/kameloso/main.d
+++ b/source/kameloso/main.d
@@ -2816,6 +2816,7 @@ int initBot(string[] args)
     {
         import kameloso.thread : ThreadMessage;
         import std.concurrency : receiveTimeout;
+        import std.variant : Variant;
         import core.time : seconds;
 
         // Connected and aborting
@@ -2830,6 +2831,7 @@ int initBot(string[] args)
                 reason = givenReason;
                 quiet = givenQuiet;
             },
+            (Variant v) scope {},
         );
 
         if (!received) reason = instance.bot.quitReason;

--- a/source/kameloso/net.d
+++ b/source/kameloso/net.d
@@ -690,7 +690,7 @@ in ((connectionLost > 0), "Tried to set up a listening fiber with connection tim
                 enum Errno
                 {
                     timedOut = EAGAIN,
-                    //wouldBlock = EWOULDBLOCK,
+                    wouldBlock = EWOULDBLOCK,
                     netDown = ENETDOWN,
                     netUnreachable = ENETUNREACH,
                     endpointNotConnected = ENOTCONN,
@@ -708,7 +708,7 @@ in ((connectionLost > 0), "Tried to set up a listening fiber with connection tim
                 enum Errno
                 {
                     timedOut = WSAETIMEDOUT,
-                    //wouldBlock = WSAEWOULDBLOCK,
+                    wouldBlock = WSAEWOULDBLOCK,
                     netDown = WSAENETDOWN,
                     netUnreachable = WSAENETUNREACH,
                     endpointNotConnected = WSAENOTCONN,
@@ -730,18 +730,23 @@ in ((connectionLost > 0), "Tried to set up a listening fiber with connection tim
                     properly respond after a period of time, or established connection
                     failed because connected host has failed to respond.
                  */
-            //case wouldBlock:  // duplicate case!
-                /+
-                    Portability Note: In many older Unix systems ...
-                    [EWOULDBLOCK was] a distinct error code different from
-                    EAGAIN. To make your program portable, you should check
-                    for both codes and treat them the same.
-                 +/
-                // A non-blocking socket operation could not be completed immediately.
                 // Timed out, nothing received
                 attempt.state = State.isEmpty;
                 yield(attempt);
                 continue;
+
+            static if (int(timedOut) != int(wouldBlock))
+            {
+                case wouldBlock:
+                    /+
+                        Portability Note: In many older Unix systems ...
+                        [EWOULDBLOCK was] a distinct error code different from
+                        EAGAIN. To make your program portable, you should check
+                        for both codes and treat them the same.
+                     +/
+                    // A non-blocking socket operation could not be completed immediately.
+                    goto case timedOut;
+            }
 
             case netDown:
             case netUnreachable:

--- a/source/kameloso/net.d
+++ b/source/kameloso/net.d
@@ -955,7 +955,8 @@ in ((conn.ips.length > 0), "Tried to connect to an unresolved connection")
                 {
                     version(Posix)
                     {
-                        import core.stdc.errno;
+                        import core.stdc.errno : EAFNOSUPPORT, ECONNREFUSED,
+                            EHOSTUNREACH, ENETUNREACH, errno;
 
                         // https://www-numi.fnal.gov/offline_software/srt_public_context/WebDocs/Errors/unix_system_errors.html
 
@@ -963,22 +964,23 @@ in ((conn.ips.length > 0), "Tried to connect to an unresolved connection")
                         {
                             addressFamilyNoSupport = EAFNOSUPPORT,
                             connectionRefused = ECONNREFUSED,
-                            //noRouteToHost = EHOSTUNREACH,
-                            //networkUnreachable = ENETUNREACH,
+                            noRouteToHost = EHOSTUNREACH,
+                            networkUnreachable = ENETUNREACH,
                         }
 
                         attempt.errno = errno;
                     }
                     else version(Windows)
                     {
-                        import core.sys.windows.winsock2;
+                        import core.sys.windows.winsock2 : WSAEAFNOSUPPORT, WSAECONNREFUSED,
+                            WSAEHOSTUNREACH, WSAENETUNREACH, WSAGetLastError;
 
                         enum Errno
                         {
                             addressFamilyNoSupport = WSAEAFNOSUPPORT,
                             connectionRefused = WSAECONNREFUSED,
-                            //noRouteToHost = WSAEHOSTUNREACH,
-                            //networkUnreachable = WSAENETUNREACH,
+                            noRouteToHost = WSAEHOSTUNREACH,
+                            networkUnreachable = WSAENETUNREACH,
                         }
 
                         attempt.errno = WSAGetLastError();

--- a/source/kameloso/net.d
+++ b/source/kameloso/net.d
@@ -1205,7 +1205,8 @@ in (address.length, "Tried to set up a resolving fiber on an empty address")
 
             version(Posix)
             {
-                import core.sys.posix.netdb : EAI_AGAIN, EAI_FAIL, EAI_FAMILY, EAI_NONAME, EAI_SOCKTYPE;
+                import core.sys.posix.netdb : EAI_AGAIN, EAI_FAIL, EAI_FAMILY,
+                    EAI_NONAME, EAI_SOCKTYPE, EAI_SYSTEM;
 
                 enum EAI_NODATA = -5;
 
@@ -1220,10 +1221,10 @@ in (address.length, "Tried to set up a resolving fiber on an empty address")
                     noData      = EAI_NODATA,       /** No address associated with NAME. (GNU) */
                     family      = EAI_FAMILY,       /** `ai_family` not supported. */
                     sockType    = EAI_SOCKTYPE,     /** `ai_socktype` not supported. */
-                    //service   = EAI_SERVICE,      /** SERVICE not supported for `ai_socktype`. */
+                    //service     = EAI_SERVICE,    /** SERVICE not supported for `ai_socktype`. */
                     //addrFamily= EAI_ADDRFAMILY,   /** Address family for NAME not supported. (GNU) */
                     //memory    = EAI_MEMORY,       /** Memory allocation failure. */
-                    //system    = EAI_SYSTEM,       /** System error returned in `errno`. */
+                    system      = EAI_SYSTEM,       /** System error returned in `errno`. */
                     //overflow  = EAI_OVERFLOW,     /** Argument buffer overflow. */
                 }
             }
@@ -1266,18 +1267,13 @@ in (address.length, "Tried to set up a resolving fiber on an empty address")
                 yield(attempt);
                 continue;
 
-            /*case system:
-                version(Posix)
-                {
+            version(Posix)
+            {
+                case system:
                     import core.stdc.errno : errno;
                     attempt.errno = errno;
-                }
-                else version(Windows)
-                {
-                    import core.sys.windows.winsock2 : WSAGetLastError;
-                    attempt.errno = WSAGetLastError();
-                }
-                goto default;*/
+                    goto default;
+            }
 
             //case noData:
             //case fail:

--- a/source/kameloso/net.d
+++ b/source/kameloso/net.d
@@ -745,19 +745,6 @@ in ((connectionLost > 0), "Tried to set up a listening fiber with connection tim
             default:
                 attempt.error = lastSocketError;
                 attempt.state = State.warning;
-
-                import std.stdio;
-
-                version(Posix)
-                {
-                    import kameloso.common : errnoStrings;
-                    writeln(attempt.errno, " ", errnoStrings[attempt.errno], " - ", attempt.error);
-                }
-                else version(Windows)
-                {
-                    writeln(attempt.errno, " - ", attempt.error);
-                }
-
                 yield(attempt);
                 continue;
             }
@@ -1037,18 +1024,6 @@ in ((conn.ips.length > 0), "Tried to connect to an unresolved connection")
                         // Network is unreachable
                         // A socket operation was attempted to an unreachable network.
                     default:
-                        import std.stdio;
-
-                        version(Posix)
-                        {
-                            import kameloso.common : errnoStrings;
-                            writeln(attempt.errno, " ", errnoStrings[attempt.errno], " - ", e.msg);
-                        }
-                        else version(Windows)
-                        {
-                            writeln(attempt.errno, " - ", attempt.error);
-                        }
-
                         // Don't delay for retrying on the last retry, drop down below
                         if (retry+1 < connectionRetries)
                         {

--- a/source/kameloso/net.d
+++ b/source/kameloso/net.d
@@ -1028,6 +1028,7 @@ in ((conn.ips.length > 0), "Tried to connect to an unresolved connection")
                         if (retry+1 < connectionRetries)
                         {
                             attempt.state = State.delayThenReconnect;
+                            attempt.error = e.msg;
                             yield(attempt);
                         }
                         break;

--- a/source/kameloso/net.d
+++ b/source/kameloso/net.d
@@ -1199,9 +1199,7 @@ in (address.length, "Tried to set up a resolving fiber on an empty address")
         }
         catch (SocketOSException e)
         {
-            import std.stdio;
             attempt.errno = e.errorCode;
-            writeln(attempt.errno);
 
             version(Posix)
             {

--- a/source/kameloso/net.d
+++ b/source/kameloso/net.d
@@ -1289,9 +1289,11 @@ in (address.length, "Tried to set up a resolving fiber on an empty address")
         }
     }
 
-    ResolveAttempt endAttempt;
+    // This doesn't really happen at present. Subject to change, so keep it here.
+    /*ResolveAttempt endAttempt;
     endAttempt.state = State.failure;
-    yield(endAttempt);
+    yield(endAttempt);*/
+    assert(0, "Broke out of unending `for` loop in `resolveFiber`");
 }
 
 

--- a/source/kameloso/net.d
+++ b/source/kameloso/net.d
@@ -1230,7 +1230,7 @@ in (address.length, "Tried to set up a resolving fiber on an empty address")
             else version(Windows)
             {
                 import core.sys.windows.winsock2 : WSAEAFNOSUPPORT, WSAESOCKTNOSUPPORT,
-                    WSAHOST_NOT_FOUND, WSANO_RECOVERY, WSATRY_AGAIN;
+                    WSAHOST_NOT_FOUND, WSANO_DATA, WSANO_RECOVERY, WSATRY_AGAIN;
 
                 // https://docs.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getaddrinfo
 

--- a/source/kameloso/net.d
+++ b/source/kameloso/net.d
@@ -660,7 +660,7 @@ in ((connectionLost > 0), "Tried to set up a listening fiber with connection tim
         else version(Windows)
         {
             import core.sys.windows.winsock2 : WSAECONNRESET, WSAEINTR, WSAENETDOWN,
-                WSAENETUNREACH, WSAENOTCONN, WSAETIMEDOUT, WSAEWOULDBLOCK, WSAGetLastEerror;
+                WSAENETUNREACH, WSAENOTCONN, WSAETIMEDOUT, WSAEWOULDBLOCK, WSAGetLastError;
 
             // https://www.hardhats.org/cs/broker/docs/winsock.html
             // https://infosys.beckhoff.com/english.php?content=../content/1033/tcpipserver/html/tcplclibtcpip_e_winsockerror.htm

--- a/source/kameloso/net.d
+++ b/source/kameloso/net.d
@@ -389,7 +389,7 @@ public:
     void sendline(uint maxLineLength = 512, Data...)(const Data data) @system
     in (connected, "Tried to send a line on an unconnected `Connection`")
     {
-        int remainingMaxLength = (maxLineLength - 1);
+        int remainingMaxLength = (maxLineLength - 2);
         bool justSentNewline;
 
         foreach (immutable piece; data)
@@ -418,12 +418,12 @@ public:
                         if (ssl)
                         {
                             openssl.SSL_write(sslInstance, cast(void*)&line[0], cast(int)end);
-                            openssl.SSL_write(sslInstance, cast(void*)&"\n"[0], 1);
+                            openssl.SSL_write(sslInstance, cast(void*)&"\r\n"[0], 2);
                         }
                         else
                         {
                             socket.send(line[0..end]);
-                            socket.send("\n");
+                            socket.send("\r\n");
                         }
 
                         justSentNewline = true;
@@ -440,7 +440,6 @@ public:
                     if (ssl)
                     {
                         openssl.SSL_write(sslInstance, cast(void*)&piece[0], cast(int)end);
-                        openssl.SSL_write(sslInstance, cast(void*)&"\n"[0], 1);
                     }
                     else
                     {
@@ -473,11 +472,11 @@ public:
         {
             if (ssl)
             {
-                openssl.SSL_write(sslInstance, cast(void*)&"\n"[0], 1);
+                openssl.SSL_write(sslInstance, cast(void*)&"\r\n"[0], 2);
             }
             else
             {
-                socket.send("\n");
+                socket.send("\r\n");
             }
         }
     }

--- a/source/kameloso/net.d
+++ b/source/kameloso/net.d
@@ -578,15 +578,15 @@ struct ListenAttempt
 
     Params:
         bufferSize = What size static array to use as buffer. Defaults to
-            twice of `kameloso.constants.BufferSize.socketReceive` for now.
-        conn = `Connection` whose `std.socket.Socket` it reads from the server with.
+            twice of $(REF kameloso.constants.BufferSize.socketReceive) for now.
+        conn = $(REF Connection) whose $(REF std.socket.Socket) it reads from the server with.
         abort = Reference "abort" flag, which -- if set -- should make the
-            function return and the `core.thread.fiber.Fiber` terminate.
+            function return and the $(REF core.thread.fiber.Fiber) terminate.
         connectionLost = How many seconds may pass before we consider the connection lost.
-            Optional, defaults to `kameloso.constants.Timeout.connectionLost`.
+            Optional, defaults to $(REF kameloso.constants.Timeout.connectionLost).
 
     Yields:
-        `ListenAttempt`s with information about the line receieved in its member values.
+        $(REF ListenAttempt)s with information about the line receieved in its member values.
  +/
 void listenFiber(size_t bufferSize = BufferSize.socketReceive*2)
     (Connection conn, ref bool abort, const int connectionLost = Timeout.connectionLost) @system
@@ -819,7 +819,7 @@ struct ConnectionAttempt
     /// $(REF core.stdc.errno.errno) at time of connect.
     int errno;
 
-    /// The number of retries so far towards this `ip`.
+    /// The number of retries so far towards this $(REF ip).
     uint retryNum;
 }
 
@@ -827,7 +827,7 @@ struct ConnectionAttempt
 // connectFiber
 /++
     Fiber function that tries to connect to IPs in the `ips` array of the passed
-    `Connection`, yielding at certain points throughout the process to let the
+    $(REF Connection), yielding at certain points throughout the process to let the
     calling function do stuff inbetween connection attempts.
 
     Example:
@@ -876,11 +876,11 @@ struct ConnectionAttempt
     ---
 
     Params:
-        conn = Reference to the current, unconnected `Connection`.
+        conn = Reference to the current, unconnected $(REF Connection).
         connectionRetries = How many times to attempt to connect before signaling
             that we should move on to the next IP.
         abort = Reference "abort" flag, which -- if set -- should make the
-            function return and the `core.thread.fiber.Fiber` terminate.
+            function return and the $(REF core.thread.fiber.Fiber) terminate.
  +/
 void connectFiber(ref Connection conn, const uint connectionRetries, ref bool abort) @system
 in (!conn.connected, "Tried to set up a connecting fiber on an already live connection")
@@ -1103,7 +1103,7 @@ struct ResolveAttempt
 // resolveFiber
 /++
     Given an address and a port, resolves these and populates the array of unique
-    `std.socket.Address` IPs inside the passed `Connection`.
+    `std.socket.Address` IPs inside the passed $(REF Connection).
 
     Example:
     ---
@@ -1153,12 +1153,12 @@ struct ResolveAttempt
     ---
 
     Params:
-        conn = Reference to the current `Connection`.
+        conn = Reference to the current $(REF Connection).
         address = String address to look up.
-        port = Remote port build into the `std.socket.Address`.
+        port = Remote port build into the $(REF std.socket.Address).
         useIPv6 = Whether to include resolved IPv6 addresses or not.
         abort = Reference "abort" flag, which -- if set -- should make the
-            function return and the `core.thread.fiber.Fiber` terminate.
+            function return and the $(REF core.thread.fiber.Fiber) terminate.
  +/
 void resolveFiber(ref Connection conn, const string address, const ushort port,
     const bool useIPv6, ref bool abort) @system
@@ -1212,18 +1212,18 @@ in (address.length, "Tried to set up a resolving fiber on an empty address")
 
                 enum AddrInfoErrors
                 {
-                    //badFlags  = EAI_BADFLAGS,     /** Invalid value for `ai_flags` field. */
-                    noName      = EAI_NONAME,       /** NAME or SERVICE is unknown. */
-                    again       = EAI_AGAIN,        /** Temporary failure in name resolution. */
-                    fail        = EAI_FAIL,         /** Non-recoverable failure in name res. */
-                    noData      = EAI_NODATA,       /** No address associated with NAME. (GNU) */
-                    family      = EAI_FAMILY,       /** `ai_family` not supported. */
-                    sockType    = EAI_SOCKTYPE,     /** `ai_socktype` not supported. */
-                    //service     = EAI_SERVICE,    /** SERVICE not supported for `ai_socktype`. */
-                    //addrFamily= EAI_ADDRFAMILY,   /** Address family for NAME not supported. (GNU) */
-                    //memory    = EAI_MEMORY,       /** Memory allocation failure. */
-                    system      = EAI_SYSTEM,       /** System error returned in `errno`. */
-                    //overflow  = EAI_OVERFLOW,     /** Argument buffer overflow. */
+                    //badFlags   = EAI_BADFLAGS,     /** Invalid value for `ai_flags` field. */
+                    noName       = EAI_NONAME,       /** NAME or SERVICE is unknown. */
+                    again        = EAI_AGAIN,        /** Temporary failure in name resolution. */
+                    fail         = EAI_FAIL,         /** Non-recoverable failure in name res. */
+                    noData       = EAI_NODATA,       /** No address associated with NAME. (GNU) */
+                    family       = EAI_FAMILY,       /** `ai_family` not supported. */
+                    sockType     = EAI_SOCKTYPE,     /** `ai_socktype` not supported. */
+                    //service    = EAI_SERVICE,      /** SERVICE not supported for `ai_socktype`. */
+                    //addrFamily = EAI_ADDRFAMILY,   /** Address family for NAME not supported. (GNU) */
+                    //memory     = EAI_MEMORY,       /** Memory allocation failure. */
+                    system       = EAI_SYSTEM,       /** System error returned in `errno`. */
+                    //overflow   = EAI_OVERFLOW,     /** Argument buffer overflow. */
                 }
             }
             else version(Windows)
@@ -1235,18 +1235,18 @@ in (address.length, "Tried to set up a resolving fiber on an empty address")
 
                 enum AddrInfoErrors
                 {
-                    //badFlags  = WSAEINVAL,            /** An invalid value was provided for the `ai_flags` member of the `pHints` parameter. */
-                    noName      = WSAHOST_NOT_FOUND,    /** The name does not resolve for the supplied parameters or the `pNodeName` and `pServiceName` parameters were not provided. */
-                    again       = WSATRY_AGAIN,         /** A temporary failure in name resolution occurred. */
-                    fail        = WSANO_RECOVERY,       /** A nonrecoverable failure in name resolution occurred. */
-                    noData      = WSANO_DATA,
-                    family      = WSAEAFNOSUPPORT,      /** The 'ai_family' member of the `pHints` parameter is not supported. */
-                    sockType    = WSAESOCKTNOSUPPORT,   /** The `ai_socktype` member of the `pHints` parameter is not supported. */
-                    //service   = WSATYPE_NOT_FOUND,    /** The `pServiceName` parameter is not supported for the specified `ai_socktype` member of the `pHints` parameter. */
-                    //addrFamily= ?,
-                    //memory    = WSANOT_ENOUGH_MEMORY, /** A memory allocation failure occurred. */
-                    //system    = ?,
-                    //overflow  = ?,
+                    //badFlags   = WSAEINVAL,            /** An invalid value was provided for the `ai_flags` member of the `pHints` parameter. */
+                    noName       = WSAHOST_NOT_FOUND,    /** The name does not resolve for the supplied parameters or the `pNodeName` and `pServiceName` parameters were not provided. */
+                    again        = WSATRY_AGAIN,         /** A temporary failure in name resolution occurred. */
+                    fail         = WSANO_RECOVERY,       /** A nonrecoverable failure in name resolution occurred. */
+                    noData       = WSANO_DATA,
+                    family       = WSAEAFNOSUPPORT,      /** The 'ai_family' member of the `pHints` parameter is not supported. */
+                    sockType     = WSAESOCKTNOSUPPORT,   /** The `ai_socktype` member of the `pHints` parameter is not supported. */
+                    //service    = WSATYPE_NOT_FOUND,    /** The `pServiceName` parameter is not supported for the specified `ai_socktype` member of the `pHints` parameter. */
+                    //addrFamily = ?,
+                    //memory     = WSANOT_ENOUGH_MEMORY, /** A memory allocation failure occurred. */
+                    //system     = ?,
+                    //overflow   = ?,
                 }
             }
             else


### PR DESCRIPTION
This changes how we detect failures when reading from the socket, from comparing highly locale-specific English-only error message strings to the considerably more generic Posix `errno` and Windows `WSAGetLastError`. Similarly `EAI_*` values when resolving the IP address.

https://en.wikipedia.org/wiki/Errno.h

Reproducing previous errors proved difficult so there may be edge cases where it previously took an exception in stride and now errors out instead. Regrettable, this close to 2.0.0, but this is an important change.