### PR TITLE
New hostmasks mode

### DIFF
--- a/source/kameloso/plugins/admin/base.d
+++ b/source/kameloso/plugins/admin/base.d
@@ -984,6 +984,10 @@ void listHostmaskDefinitions(AdminPlugin plugin, const ref IRCEvent event)
     string[string] aa;
     aa.populateFromJSON(json);
 
+    // Remove any placeholder examples
+    enum examplePlaceholderKey = "<nickname>!<ident>@<address>";
+    aa.remove(examplePlaceholderKey);
+
     if (aa.length)
     {
         import std.conv : to;

--- a/source/kameloso/plugins/admin/base.d
+++ b/source/kameloso/plugins/admin/base.d
@@ -541,11 +541,11 @@ void onCommandBlacklist(AdminPlugin plugin, const ref IRCEvent event)
 @(ChannelPolicy.home)
 @BotCommand(PrefixPolicy.prefixed, "reload")
 @Description("Asks plugins to reload their resources and/or configuration as they see fit.")
-void onCommandReload(AdminPlugin plugin)
+void onCommandReload(AdminPlugin plugin, const ref IRCEvent event)
 {
     import kameloso.thread : ThreadMessage;
 
-    logger.info("Reloading plugins.");
+    privmsg(plugin.state, event.channel, event.sender.nickname, "Reloading plugins.");
     plugin.state.mainThread.send(ThreadMessage.Reload());
 }
 

--- a/source/kameloso/plugins/admin/classifiers.d
+++ b/source/kameloso/plugins/admin/classifiers.d
@@ -521,7 +521,8 @@ in (list.among!("whitelist", "blacklist", "operator", "staff"),
         }
 
         // Remove placeholder example since there should now be at least one true entry
-        json[list].object.remove("<channel>");
+        enum examplePlaceholderKey = "<#channel>";
+        json[list].object.remove(examplePlaceholderKey);
     }
     else
     {

--- a/source/kameloso/plugins/admin/classifiers.d
+++ b/source/kameloso/plugins/admin/classifiers.d
@@ -483,7 +483,7 @@ enum AlterationResult
         [AlterationResult.success] if enlisting or delisting succeeded.
  +/
 AlterationResult alterAccountClassifier(AdminPlugin plugin, const Flag!"add" add,
-    const string list, const string account, const string channel)
+    const string list, const string account, const string channelName)
 in (list.among!("whitelist", "blacklist", "operator", "staff"),
     list ~ " is not whitelist, operator, staff nor blacklist")
 {
@@ -502,39 +502,43 @@ in (list.among!("whitelist", "blacklist", "operator", "staff"),
 
         immutable accountAsJSON = JSONValue(account);
 
-        if (channel in json[list].object)
+        if (channelName in json[list].object)
         {
-            if (json[list][channel].array.canFind(accountAsJSON))
+            if (json[list][channelName].array.canFind(accountAsJSON))
             {
                 return AlterationResult.alreadyInList;
             }
             else
             {
-                json[list][channel].array ~= accountAsJSON;
+                json[list][channelName].array ~= accountAsJSON;
             }
         }
         else
         {
-            json[list][channel] = null;
-            json[list][channel].array = null;
-            json[list][channel].array ~= accountAsJSON;
+            json[list][channelName] = null;
+            json[list][channelName].array = null;
+            json[list][channelName].array ~= accountAsJSON;
         }
+
+        // Remove placeholder example since there should now be at least one true entry
+        json[list].object.remove("<channel>");
     }
     else
     {
         import std.algorithm.mutation : SwapStrategy, remove;
         import std.algorithm.searching : countUntil;
 
-        if (channel in json[list].object)
+        if (channelName in json[list].object)
         {
-            immutable index = json[list][channel].array.countUntil(JSONValue(account));
+            immutable index = json[list][channelName].array.countUntil(JSONValue(account));
 
             if (index == -1)
             {
                 return AlterationResult.noSuchAccount;
             }
 
-            json[list][channel] = json[list][channel].array.remove!(SwapStrategy.unstable)(index);
+            json[list][channelName] = json[list][channelName].array
+                .remove!(SwapStrategy.unstable)(index);
         }
         else
         {
@@ -592,6 +596,10 @@ void modifyHostmaskDefinition(AdminPlugin plugin, const Flag!"add" add,
 
         aa[mask] = account;
         didSomething = true;
+
+        // Remove placeholder example since there should now be at least one true entry
+        aa.remove("<nickname>!<ident>@<address>");
+
         json.reset();
         json = JSONValue(aa);
     }

--- a/source/kameloso/plugins/admin/classifiers.d
+++ b/source/kameloso/plugins/admin/classifiers.d
@@ -598,7 +598,8 @@ void modifyHostmaskDefinition(AdminPlugin plugin, const Flag!"add" add,
         didSomething = true;
 
         // Remove placeholder example since there should now be at least one true entry
-        aa.remove("<nickname>!<ident>@<address>");
+        enum examplePlaceholderKey = "<nickname>!<ident>@<address>";
+        aa.remove(examplePlaceholderKey);
 
         json.reset();
         json = JSONValue(aa);

--- a/source/kameloso/plugins/services/connect.d
+++ b/source/kameloso/plugins/services/connect.d
@@ -929,6 +929,15 @@ void onWelcome(ConnectService service, const ref IRCEvent event)
     {
         import kameloso.plugins.common.delayawait : await, unawait;
 
+        if (service.state.settings.preferHostmasks &&
+            !service.state.settings.force)
+        {
+            // We already infer account by username on Twitch;
+            // hostmasks mode makes no sense there. So disable it.
+            service.state.settings.preferHostmasks = false;
+            service.state.settingsUpdated = true;
+        }
+
         static immutable IRCEvent.Type[2] endOfMotdEventTypes =
         [
             IRCEvent.Type.RPL_ENDOFMOTD,

--- a/source/kameloso/plugins/services/persistence.d
+++ b/source/kameloso/plugins/services/persistence.d
@@ -466,7 +466,8 @@ void reloadHostmasksFromDisk(PersistenceService service)
     string[string] accountByHostmask;
     accountByHostmask.populateFromJSON(hostmasksJSON);
 
-    service.hostmaskNicknameAccountCache = typeof(service.hostmaskNicknameAccountCache).init;
+    service.hostmaskUsers = typeof(service.hostmaskUsers).init;
+    service.hostmaskNicknameAccountCache.clear();
 
     foreach (immutable hostmask, immutable account; accountByHostmask)
     {

--- a/source/kameloso/plugins/services/persistence.d
+++ b/source/kameloso/plugins/services/persistence.d
@@ -575,6 +575,10 @@ void initAccountResources(PersistenceService service)
         {
             json[liststring] = null;
             json[liststring].object = null;
+            json[liststring]["<channel>"] = null;
+            json[liststring]["<channel>"].array = null;
+            json[liststring]["<channel>"].array ~= JSONValue("<nickname1>");
+            json[liststring]["<channel>"].array ~= JSONValue("<nickname2>");
         }
         else
         {
@@ -629,6 +633,13 @@ void initHostmaskResources(PersistenceService service)
 
         version(PrintStacktraces) logger.trace(e);
         throw new IRCPluginInitialisationException(service.hostmasksFile.baseName ~ " may be malformed.");
+    }
+
+    if (json.length == 0)
+    {
+        json["<nickname>!<ident>@<address>"] = null;
+        json["<nickname>!<ident>@<address>"].str = null;
+        json["<nickname>!<ident>@<address>"].str = "<account>";
     }
 
     // Let other Exceptions pass.

--- a/source/kameloso/plugins/services/persistence.d
+++ b/source/kameloso/plugins/services/persistence.d
@@ -87,7 +87,7 @@ void postprocess(PersistenceService service, ref IRCEvent event)
  +/
 void postprocessCommon(PersistenceService service, ref IRCEvent event)
 {
-    static void postprocessImpl(PersistenceService service, ref IRCEvent event, ref IRCUser user)
+    static void postprocessImpl(PersistenceService service, const ref IRCEvent event, ref IRCUser user)
     {
         import std.algorithm.searching : canFind;
 

--- a/source/kameloso/plugins/services/persistence.d
+++ b/source/kameloso/plugins/services/persistence.d
@@ -362,7 +362,7 @@ void onWelcome(PersistenceService service)
     import core.thread : Fiber;
 
     service.reloadAccountClassifiersFromDisk();
-    service.reloadHostmasksFromDisk();
+    if (service.state.settings.preferHostmasks) service.reloadHostmasksFromDisk();
 
     void periodicallyDg()
     {
@@ -387,7 +387,7 @@ void reload(PersistenceService service)
 {
     service.state.users = service.state.users.rehash();
     service.reloadAccountClassifiersFromDisk();
-    service.reloadHostmasksFromDisk();
+    if (service.state.settings.preferHostmasks) service.reloadHostmasksFromDisk();
 }
 
 

--- a/source/kameloso/plugins/services/persistence.d
+++ b/source/kameloso/plugins/services/persistence.d
@@ -637,7 +637,7 @@ void initHostmaskResources(PersistenceService service)
         throw new IRCPluginInitialisationException(service.hostmasksFile.baseName ~ " may be malformed.");
     }
 
-    if (json.length == 0)
+    if (json.object.length == 0)
     {
         json["<nickname>!<ident>@<address>"] = null;
         json["<nickname>!<ident>@<address>"].str = null;

--- a/source/kameloso/plugins/services/persistence.d
+++ b/source/kameloso/plugins/services/persistence.d
@@ -64,9 +64,12 @@ void postprocess(PersistenceService service, ref IRCEvent event)
             }
         }
 
-        if (const channelName = event.sender.nickname in service.userClassCurrentChannelCache)
+        if (!service.state.settings.preferHostmasks)
         {
-            service.userClassCurrentChannelCache[event.target.nickname] = *channelName;
+            if (const channelName = event.sender.nickname in service.userClassCurrentChannelCache)
+            {
+                service.userClassCurrentChannelCache[event.target.nickname] = *channelName;
+            }
         }
 
         goto default;

--- a/source/kameloso/plugins/services/persistence.d
+++ b/source/kameloso/plugins/services/persistence.d
@@ -418,16 +418,20 @@ void reloadAccountClassifiersFromDisk(PersistenceService service)
 
         try
         {
-            foreach (immutable channel, const channelAccountJSON; listFromJSON.object)
+            foreach (immutable channelName, const channelAccountJSON; listFromJSON.object)
             {
+                import lu.string : beginsWith;
+
+                if (channelName.beginsWith('<')) continue;
+
                 foreach (immutable userJSON; channelAccountJSON.array)
                 {
-                    if (channel !in service.channelUsers)
+                    if (channelName !in service.channelUsers)
                     {
-                        service.channelUsers[channel] = (IRCUser.Class[string]).init;
+                        service.channelUsers[channelName] = (IRCUser.Class[string]).init;
                     }
 
-                    service.channelUsers[channel][userJSON.str] = class_;
+                    service.channelUsers[channelName][userJSON.str] = class_;
                 }
             }
         }
@@ -571,7 +575,7 @@ void initAccountResources(PersistenceService service)
 
     foreach (liststring; only("staff", "operator", "whitelist", "blacklist"))
     {
-        if (liststring !in json)
+        if ((liststring !in json) || !json[liststring].object.length)
         {
             json[liststring] = null;
             json[liststring].object = null;

--- a/source/kameloso/plugins/services/persistence.d
+++ b/source/kameloso/plugins/services/persistence.d
@@ -58,7 +58,9 @@ void postprocess(PersistenceService service, ref IRCEvent event)
             if (service.state.settings.preferHostmasks)
             {
                 // Have the account get looked up in postprocessHostmasks
+                newUser.class_ = IRCUser.Class.unset;
                 newUser.account = string.init;
+                newUser.updated = 0L;
             }
         }
 

--- a/source/kameloso/plugins/services/persistence.d
+++ b/source/kameloso/plugins/services/persistence.d
@@ -470,10 +470,11 @@ void reloadHostmasksFromDisk(PersistenceService service)
 
     foreach (immutable hostmask, immutable account; accountByHostmask)
     {
-        import lu.string : beginsWith;
+        import lu.string : contains;
         import std.format : FormatException;
 
-        if (hostmask.beginsWith('<')) continue;  // "<hostmask>"
+        enum examplePlaceholderKey = "<nickname>!<ident>@<address>";
+        if (hostmask == examplePlaceholderKey) continue;
 
         try
         {
@@ -481,7 +482,7 @@ void reloadHostmasksFromDisk(PersistenceService service)
             user.account = account;
             service.hostmaskUsers ~= user;
 
-            if (user.nickname.length)
+            if (user.nickname.length && !user.nickname.contains('*'))
             {
                 service.hostmaskNicknameAccountCache[user.nickname] = user.account;
             }

--- a/source/kameloso/plugins/services/persistence.d
+++ b/source/kameloso/plugins/services/persistence.d
@@ -276,6 +276,10 @@ void postprocessCommon(PersistenceService service, ref IRCEvent event)
         {
             stored.class_ = IRCUser.Class.admin;
         }
+        else if (stored.class_ == IRCUser.Class.unset)
+        {
+            applyClassifiers(service, event, *stored);
+        }
         else if (!event.channel.length || !service.state.bot.homeChannels.canFind(event.channel))
         {
             // Not a channel or not a home. Additionally not an admin nor us

--- a/source/kameloso/plugins/services/persistence.d
+++ b/source/kameloso/plugins/services/persistence.d
@@ -576,24 +576,31 @@ void initAccountResources(PersistenceService service)
 
     foreach (liststring; only("staff", "operator", "whitelist", "blacklist"))
     {
-        if ((liststring !in json) || !json[liststring].object.length)
+        enum examplePlaceholderKey = "<channel>";
+
+        if (liststring !in json)
         {
             json[liststring] = null;
             json[liststring].object = null;
-            json[liststring]["<channel>"] = null;
-            json[liststring]["<channel>"].array = null;
-            json[liststring]["<channel>"].array ~= JSONValue("<nickname1>");
-            json[liststring]["<channel>"].array ~= JSONValue("<nickname2>");
+            json[liststring][examplePlaceholderKey] = null;
+            json[liststring][examplePlaceholderKey].array = null;
+            json[liststring][examplePlaceholderKey].array ~= JSONValue("<nickname1>");
+            json[liststring][examplePlaceholderKey].array ~= JSONValue("<nickname2>");
         }
         else
         {
+            if ((json[liststring].object.length > 1) &&
+                (examplePlaceholderKey in json[liststring].object))
+            {
+                json[liststring].object.remove(examplePlaceholderKey);
+            }
+
             try
             {
-                foreach (immutable channel, ref channelAccountsJSON; json[liststring].object)
+                foreach (immutable channelName, ref channelAccountsJSON; json[liststring].object)
                 {
-                    import lu.string : beginsWith;
-                    if (channel.beginsWith('<')) continue;
-                    channelAccountsJSON = deduplicate(json[liststring][channel]);
+                    if (channelName == examplePlaceholderKey) continue;
+                    channelAccountsJSON = deduplicate(json[liststring][channelName]);
                 }
             }
             catch (JSONException e)

--- a/source/kameloso/plugins/services/persistence.d
+++ b/source/kameloso/plugins/services/persistence.d
@@ -29,7 +29,7 @@ import dialect.defs;
     [dialect.defs.IRCEvent.target] fields, so that things like account names
     that are only sent sometimes carry over.
 
-    Merely leverages [postprocessAccounts] and [postprocessHostmasks].
+    Merely leverages [postprocessCommon].
  +/
 void postprocess(PersistenceService service, ref IRCEvent event)
 {
@@ -48,44 +48,39 @@ void postprocess(PersistenceService service, ref IRCEvent event)
         // Clone the stored sender into a new stored target.
         // Don't delete the old user yet.
 
-        if (service.state.settings.preferHostmasks)
-        {
-            if (const account = event.sender.nickname in service.accountByUser)
-            {
-                service.accountByUser[event.target.nickname] = *account;
-                //service.accountByUser.remove(event.sender.nickname);
-            }
-        }
-        else if (const stored = event.sender.nickname in service.state.users)
+        if (const stored = event.sender.nickname in service.state.users)
         {
             service.state.users[event.target.nickname] = *stored;
-            service.state.users[event.target.nickname].nickname = event.target.nickname;
-        }
 
-        //service.state.users.remove(event.sender.nickname);
+            auto newUser = event.target.nickname in service.state.users;
+            newUser.nickname = event.target.nickname;
+
+            if (service.state.settings.preferHostmasks)
+            {
+                // Have the account get looked up in postprocessHostmasks
+                newUser.account = string.init;
+            }
+        }
 
         if (const channelName = event.sender.nickname in service.userClassCurrentChannelCache)
         {
             service.userClassCurrentChannelCache[event.target.nickname] = *channelName;
-            //service.userClassCurrentChannelCache.remove(event.sender.nickname);
         }
 
         goto default;
 
     default:
-        return service.state.settings.preferHostmasks ?
-            postprocessHostmasks(service, event) :
-            postprocessAccounts(service, event);
+        return postprocessCommon(service, event);
     }
 }
 
 
-// postprocessAccounts
+
+// postprocessCommon
 /++
-    Postprocesses an [dialect.defs.IRCEvent] from an account perspective, e.g.
-    where a user may be logged onto services.
+    Postprocessing implementation common for service and hostmasks mode.
  +/
-void postprocessAccounts(PersistenceService service, ref IRCEvent event)
+void postprocessCommon(PersistenceService service, ref IRCEvent event)
 {
     static void postprocessImpl(PersistenceService service, ref IRCEvent event, ref IRCUser user)
     {
@@ -95,6 +90,32 @@ void postprocessAccounts(PersistenceService service, ref IRCEvent event)
         if (!user.nickname.length || (user.nickname == "*")) return;
 
         /++
+            Returns the recorded "account" of a user. For use in hostmasks mode.
+         +/
+        static string getAccount(PersistenceService service, const IRCUser user)
+        {
+            if (const cachedAccount = user.nickname in service.hostmaskNicknameAccountCache)
+            {
+                return *cachedAccount;
+            }
+
+            foreach (const storedUser; service.hostmaskUsers)
+            {
+                import dialect.common : matchesByMask;
+
+                if (!storedUser.account.length) continue;
+
+                if (matchesByMask(user, storedUser))
+                {
+                    service.hostmaskNicknameAccountCache[user.nickname] = storedUser.account;
+                    return storedUser.account;
+                }
+            }
+
+            return string.init;
+        }
+
+        /++
             Tries to apply any permanent class for a user in a channel, and if
             none available, tries to set one that seems to apply based on what
             the user looks like.
@@ -102,14 +123,21 @@ void postprocessAccounts(PersistenceService service, ref IRCEvent event)
         static void applyClassifiers(PersistenceService service,
             const ref IRCEvent event, ref IRCUser user)
         {
-            bool set;
-
             if (user.class_ == IRCUser.Class.admin)
             {
                 // Do nothing, admin is permanent and program-wide
                 return;
             }
-            else if (!user.account.length || (user.account == "*"))
+
+            if (service.state.settings.preferHostmasks && !user.account.length)
+            {
+                user.account = getAccount(service, user);
+                if (user.account.length) user.updated = event.time;
+            }
+
+            bool set;
+
+            if (!user.account.length || (user.account == "*"))
             {
                 // No account means it's just a random
                 user.class_ = IRCUser.Class.anyone;
@@ -154,28 +182,31 @@ void postprocessAccounts(PersistenceService service, ref IRCEvent event)
             stored = user.nickname in service.state.users;
         }
 
-        if (service.state.server.daemon != IRCServer.Daemon.twitch)
+        if (!service.state.settings.preferHostmasks)
         {
-            // Apply class here on events that carry new account information.
-
-            with (IRCEvent.Type)
-            switch (event.type)
+            if (service.state.server.daemon != IRCServer.Daemon.twitch)
             {
-            case JOIN:
-            case ACCOUNT:
-            case RPL_WHOISACCOUNT:
-            case RPL_WHOISUSER:
-            case RPL_WHOISREGNICK:
-                applyClassifiers(service, event, user);
-                break;
+                // Apply class here on events that carry new account information.
 
-            default:
-                if (user.account.length && (user.account != "*") && !stored.account.length)
+                with (IRCEvent.Type)
+                switch (event.type)
                 {
-                    // Unexpected event bearing new account
-                    goto case RPL_WHOISACCOUNT;
+                case JOIN:
+                case ACCOUNT:
+                case RPL_WHOISACCOUNT:
+                case RPL_WHOISUSER:
+                case RPL_WHOISREGNICK:
+                    applyClassifiers(service, event, user);
+                    break;
+
+                default:
+                    if (user.account.length && (user.account != "*") && !stored.account.length)
+                    {
+                        // Unexpected event bearing new account
+                        goto case RPL_WHOISACCOUNT;
+                    }
+                    break;
                 }
-                break;
             }
         }
 
@@ -200,7 +231,8 @@ void postprocessAccounts(PersistenceService service, ref IRCEvent event)
             }
         }
 
-        if (service.state.server.daemon != IRCServer.Daemon.twitch)
+        if ((service.state.server.daemon != IRCServer.Daemon.twitch) &&
+            service.state.settings.preferHostmasks)
         {
             if ((event.type == IRCEvent.Type.RPL_WHOISACCOUNT) ||
                 (event.type == IRCEvent.Type.RPL_WHOISREGNICK) ||
@@ -213,203 +245,10 @@ void postprocessAccounts(PersistenceService service, ref IRCEvent event)
             {
                 // An account of "*" means the user logged out of services
                 // It's not strictly true but consider him/her as unknown again.
-
                 stored.account = string.init;
                 stored.class_ = IRCUser.Class.anyone;
                 stored.updated = 1L;  // To facilitate melding
                 service.userClassCurrentChannelCache.remove(stored.nickname);
-            }
-        }
-
-        version(TwitchSupport)
-        {
-            // Clear badges if it has the empty placeholder asterisk
-            if ((service.state.server.daemon == IRCServer.Daemon.twitch) &&
-                (stored.badges == "*"))
-            {
-                stored.badges = string.init;
-            }
-        }
-
-        if (stored.class_ == IRCUser.Class.admin)
-        {
-            // Do nothing, admin is permanent and program-wide
-        }
-        else if ((service.state.server.daemon == IRCServer.Daemon.twitch) &&
-            (stored.nickname == service.state.client.nickname))
-        {
-            stored.class_ = IRCUser.Class.admin;
-        }
-        else if (!event.channel.length || !service.state.bot.homeChannels.canFind(event.channel))
-        {
-            // Not a channel or not a home. Additionally not an admin nor us
-            stored.class_ = IRCUser.Class.anyone;
-            service.userClassCurrentChannelCache.remove(user.nickname);
-        }
-        else
-        {
-            const cachedChannel = stored.nickname in service.userClassCurrentChannelCache;
-
-            if (!cachedChannel || (*cachedChannel != event.channel))
-            {
-                // User has no cached channel. Alternatively, user's cached channel
-                // is different from this one; class likely differs.
-                applyClassifiers(service, event, *stored);
-            }
-        }
-
-        // Inject the modified user into the event
-        user = *stored;
-    }
-
-    postprocessImpl(service, event, event.sender);
-    postprocessImpl(service, event, event.target);
-}
-
-
-// postprocessHostmasks
-/++
-    Postprocesses an [dialect.defs.IRCEvent] from a hostmask perspective, e.g.
-    where no services are available and users are identified by their hostmasks.
- +/
-void postprocessHostmasks(PersistenceService service, ref IRCEvent event)
-{
-    static void postprocessImpl(PersistenceService service, ref IRCEvent event, ref IRCUser user)
-    {
-        import std.algorithm.searching : canFind;
-
-        // Ignore server events and certain pre-registration events where our nick is unknown
-        if (!user.nickname.length || (user.nickname == "*")) return;
-
-        static string getAccount(const IRCUser user, ref string[string] aa)
-        {
-            import dialect.common : matchesByMask;
-            import lu.string : contains;
-
-            string[] invalidHostmasks;
-
-            foreach (immutable hostmask, immutable account; aa)
-            {
-                import std.format : FormatException;
-
-                if (!hostmask.contains('!'))
-                {
-                    // Cannot possibly be a valid hostmask
-                    invalidHostmasks ~= hostmask;
-                    continue;
-                }
-
-                try
-                {
-                    if (matchesByMask(user, IRCUser(hostmask))) return account;
-                }
-                catch (FormatException e)
-                {
-                    // Malformed entry in some way not caught above.
-                    invalidHostmasks ~= hostmask;
-                }
-            }
-
-            if (invalidHostmasks.length)
-            {
-                foreach (hostmaskKey; invalidHostmasks)
-                {
-                    aa.remove(hostmaskKey);
-                }
-            }
-
-            return string.init;
-        }
-
-        /++
-            Tries to apply any permanent class for a user in a channel, and if
-            none available, tries to set one that seems to apply based on what
-            the user looks like.
-         +/
-        static void applyClassifiers(PersistenceService service,
-            const ref IRCEvent event, ref IRCUser user)
-        {
-            if (user.class_ == IRCUser.Class.admin)
-            {
-                // Do nothing, admin is permanent and program-wide
-                return;
-            }
-
-            if (!user.account)
-            {
-                user.account = getAccount(user, service.accountByUser);
-            }
-
-            bool set;
-
-            if (!user.account.length || (user.account == "*"))  // FIXME
-            {
-                // No account means it's just a random
-                user.class_ = IRCUser.Class.anyone;
-                set = true;
-            }
-            else if (service.state.bot.admins.canFind(user.account))
-            {
-                // admin discovered
-                user.class_ = IRCUser.Class.admin;
-                return;
-            }
-            else if (event.channel.length)
-            {
-                if (const classAccounts = event.channel in service.channelUsers)
-                {
-                    if (const definedClass = user.account in *classAccounts)
-                    {
-                        // Permanent class is defined, so apply it
-                        user.class_ = *definedClass;
-                        set = true;
-                    }
-                }
-            }
-
-            if (!set)
-            {
-                // All else failed, consider it a random
-                user.class_ = IRCUser.Class.anyone;
-            }
-
-            // Record this channel as being the one the current class_ applies to.
-            // That way we only have to look up a class_ when the channel has changed.
-            service.userClassCurrentChannelCache[user.nickname] = event.channel;
-        }
-
-        auto stored = user.nickname in service.state.users;
-        immutable foundNoStored = stored is null;
-
-        if (foundNoStored)
-        {
-            service.state.users[user.nickname] = user;
-            stored = user.nickname in service.state.users;
-        }
-
-        import lu.meld : MeldingStrategy, meldInto;
-
-        // Meld into the stored user, and store the union in the event
-        // Skip if the current stored is just a direct copy of user
-        if (!foundNoStored)
-        {
-            // Store initial class and restore after meld.
-            immutable preMeldClass = stored.class_;
-
-            user.meldInto!(MeldingStrategy.aggressive)(*stored);
-
-            if (stored.class_ == IRCUser.Class.unset)
-            {
-                // The class was not changed, restore the previously saved one
-                stored.class_ = preMeldClass;
-            }
-        }
-
-        if (service.state.server.daemon != IRCServer.Daemon.twitch)
-        {
-            if (stored.account == "*")
-            {
-                stored.account = string.init;
             }
         }
 
@@ -472,7 +311,7 @@ void onQuit(PersistenceService service, const ref IRCEvent event)
 {
     if (service.state.settings.preferHostmasks)
     {
-        service.accountByUser.remove(event.sender.nickname);
+        service.hostmaskNicknameAccountCache.remove(event.sender.nickname);
     }
 
     service.state.users.remove(event.sender.nickname);
@@ -619,9 +458,37 @@ void reloadHostmasksFromDisk(PersistenceService service)
 
     JSONStorage hostmasksJSON;
     hostmasksJSON.load(service.hostmasksFile);
-    //service.accountByUser.clear();
-    service.accountByUser.populateFromJSON(hostmasksJSON);
-    service.accountByUser = service.accountByUser.rehash();
+
+    string[string] accountByHostmask;
+    accountByHostmask.populateFromJSON(hostmasksJSON);
+
+    service.hostmaskNicknameAccountCache = typeof(service.hostmaskNicknameAccountCache).init;
+
+    foreach (immutable hostmask, immutable account; accountByHostmask)
+    {
+        import lu.string : beginsWith;
+        import std.format : FormatException;
+
+        if (hostmask.beginsWith('<')) continue;  // "<hostmask>"
+
+        try
+        {
+            auto user = IRCUser(hostmask);
+            user.account = account;
+            service.hostmaskUsers ~= user;
+
+            if (user.nickname.length)
+            {
+                service.hostmaskNicknameAccountCache[user.nickname] = user.account;
+            }
+        }
+        catch (FormatException e)
+        {
+            import kameloso.common : Tint, logger;
+            logger.warningf("Malformed hostmask in %s%s%s: %1$s%4$s",
+                Tint.log, service.hostmasksFile, Tint.warning, hostmask);
+        }
+    }
 }
 
 
@@ -806,11 +673,11 @@ private:
     /// Associative array of permanent user classifications, per account and channel name.
     IRCUser.Class[string][string] channelUsers;
 
-    /++
-        User "accounts" by hostmask. Future optimisation may involve making this
-        an associative array of [dialect.defs.IRCUser]s keyed by string instead.
-     +/
-    string[string] accountByUser;
+    /// Hostmask definitions as read from file. Should be considered read-only.
+    IRCUser[] hostmaskUsers;
+
+    /// Cached nicknames matched to defined hostmasks.
+    string[string] hostmaskNicknameAccountCache;
 
     /// Associative array of which channel the latest class lookup for an account related to.
     string[string] userClassCurrentChannelCache;

--- a/source/kameloso/plugins/services/persistence.d
+++ b/source/kameloso/plugins/services/persistence.d
@@ -649,11 +649,17 @@ void initHostmaskResources(PersistenceService service)
         throw new IRCPluginInitialisationException(service.hostmasksFile.baseName ~ " may be malformed.");
     }
 
+    enum examplePlaceholderKey = "<nickname>!<ident>@<address>";
+
     if (json.object.length == 0)
     {
-        json["<nickname>!<ident>@<address>"] = null;
-        json["<nickname>!<ident>@<address>"].str = null;
-        json["<nickname>!<ident>@<address>"].str = "<account>";
+        json[examplePlaceholderKey] = null;
+        json[examplePlaceholderKey].str = null;
+        json[examplePlaceholderKey].str = "<account>";
+    }
+    else if ((json.object.length > 1) && (examplePlaceholderKey in json))
+    {
+        json.object.remove(examplePlaceholderKey);
     }
 
     // Let other Exceptions pass.

--- a/source/kameloso/plugins/services/persistence.d
+++ b/source/kameloso/plugins/services/persistence.d
@@ -586,6 +586,8 @@ void initAccountResources(PersistenceService service)
             {
                 foreach (immutable channel, ref channelAccountsJSON; json[liststring].object)
                 {
+                    import lu.string : beginsWith;
+                    if (channel.beginsWith('<')) continue;
                     channelAccountsJSON = deduplicate(json[liststring][channel]);
                 }
             }

--- a/source/kameloso/plugins/services/persistence.d
+++ b/source/kameloso/plugins/services/persistence.d
@@ -586,7 +586,7 @@ void initAccountResources(PersistenceService service)
 
     foreach (liststring; only("staff", "operator", "whitelist", "blacklist"))
     {
-        enum examplePlaceholderKey = "<channel>";
+        enum examplePlaceholderKey = "<#channel>";
 
         if (liststring !in json)
         {


### PR DESCRIPTION
This revamps hostmasks mode into something actually usable.

`hostmasks.json` is a file with a JSON `string[string]` associative array of account *values* and hostmask *keys*.

```json
{
    "kameloso*!kameloso@123.123.*": "kameloso",
    "zorael*!~NaN@*": "zorael"
}
```

`user.json` remains a file with a `string[][string][string]` array with the top keys `staff`, `operator`, `whitelist` and `blacklist`.

```json
{
    "staff":
    {
        "#channel1": [
            "ray",
            "steve"
        ]
    },
    "operator":
    {},
    "whitelist":
    {},
    "blacklist":
    {
        "<channel>": [
            "<nickname1>",
            "<nickname2>"
        ]
    }
}
```

Upon connection, `hostmasks.json` is read and cached in a runtime array. When a new user is spotted, this gets iterated and the hostmasks therein compared to the user (using `dialect.common.matchesByMask`). If they match, the user gets assigned the account listed as the value of the hostmask key. The pairing is then further cached in a separate runtime array, to speed up future lookups. (The cache entry is properly invalidated on `NICK` and such.)

It seems to work -- at least better than it did before, which was just broken.