### PR TITLE
Fix CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,15 +3,18 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cimg/base:2020.01
+      - image: cimg/base:2021.11
     steps:
       - checkout
       - run:
           name: Install compilers
           command: ./.circleci/run.sh install-deps
       - run:
-          name: Build (dub)
-          command: ./.circleci/run.sh build
+          name: Build and test (dmd)
+          command: ./.circleci/run.sh build-dmd
+      - run:
+          name: Build and test (ldc)
+          command: ./.circleci/run.sh build-ldc
       - store_artifacts:
           path: ./artifacts
 

--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -117,7 +117,7 @@ case $1 in
         #use_lu_master
         #use_dialect_master
 
-        time build dmd x86 "" --build-mode=singleFile
+        #time build dmd x86 "" --build-mode=singleFile  # no 32-bit libs?
         time build dmd x86_64 "" --build-mode=singleFile
         ;;
 

--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -2,8 +2,8 @@
 
 set -uexo pipefail
 
-DMD_VERSION="2.098.0"
-LDC_VERSION="1.28.0"
+#DMD_VERSION="2.098.0"
+#LDC_VERSION="1.28.0"
 CURL_USER_AGENT="CirleCI $(curl --version | head -n 1)"
 
 update_repos() {
@@ -32,9 +32,13 @@ download_install_script() {
 }
 
 install_and_activate_compiler() {
-    local COMPILER=$1
-    local COMPILER_VER=$2
-    source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash install.sh $COMPILER-$COMPILER_VER --activate)"
+    local compiler compiler_version_ext compiler_build
+
+    compiler=$1
+    [[ $# -gt 1 ]] && compiler_version_ext="-$2" || compiler_version_ext=""
+    compiler_build="${compiler}${compiler_version_ext}"
+
+    source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash install.sh $compiler_build --activate)"
 }
 
 use_lu_master() {
@@ -109,7 +113,7 @@ case $1 in
         ;;
 
     build-dmd)
-        install_and_activate_compiler dmd "$DMD_VERSION"
+        install_and_activate_compiler dmd #"$DMD_VERSION"
         dmd --version
         dub --version
 
@@ -121,7 +125,7 @@ case $1 in
         ;;
 
     build-ldc)
-        install_and_activate_compiler ldc "$LDC_VERSION"
+        install_and_activate_compiler ldc #"$LDC_VERSION"
         ldc2 --version
         dub --version
 

--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -117,7 +117,7 @@ case $1 in
         #use_lu_master
         #use_dialect_master
 
-        #time build dmd x86 "" --build-mode=singleFile  # no 32-bit libs?
+        time build dmd x86 "" --build-mode=singleFile
         time build dmd x86_64 "" --build-mode=singleFile
         ;;
 

--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -123,14 +123,14 @@ case $1 in
 
     build-ldc)
         install_and_activate_compiler ldc "$LDC_VERSION"
-        ldc --version
+        ldc2 --version
         dub --version
 
         #use_lu_master
         #use_dialect_master
 
-        #time build ldc x86 lowmem  # no 32-bit libs?
-        time build ldc x86_64 lowmem
+        #time build ldc2 x86 lowmem  # no 32-bit libs?
+        time build ldc2 x86_64 lowmem
         ;;
 
     *)

--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -7,11 +7,11 @@ LDC_VERSION="1.28.0"
 CURL_USER_AGENT="CirleCI $(curl --version | head -n 1)"
 
 update_repos() {
-    echo sudo apt-get update
+    sudo apt-get update
 }
 
 install_deps() {
-    echo sudo apt-get install g++-multilib
+    sudo apt-get install g++-multilib
 
     # required for: "core.time.TimeException@std/datetime/timezone.d(2073): Directory /usr/share/zoneinfo/ does not exist."
     #sudo apt-get install --reinstall tzdata gdb

--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -117,7 +117,7 @@ case $1 in
         #use_lu_master
         #use_dialect_master
 
-        time build dmd x86 "" --build-mode=singleFile
+        #time build dmd x86 "" --build-mode=singleFile  # no 32-bit libs?
         time build dmd x86_64 "" --build-mode=singleFile
         ;;
 
@@ -129,7 +129,7 @@ case $1 in
         #use_lu_master
         #use_dialect_master
 
-        #time build ldc x86 lowmem  # 32-bit libraries not included?
+        #time build ldc x86 lowmem  # no 32-bit libs?
         time build ldc x86_64 lowmem
         ;;
 

--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -52,7 +52,7 @@ use_dialect_master() {
 }
 
 build() {
-    local DC compiler_switch arch_switch build_ext arch_ext options
+    local DC compiler_switch arch_switch build_ext arch_ext
 
     DC="$1"
     [[ "$2" == "x86_64" ]] && arch_ext="" || arch_ext="-$2"
@@ -60,42 +60,41 @@ build() {
     compiler_switch="--compiler=$DC"
     arch_switch="--arch=$2"
 
-    shift 2
-    shift 1 || true
-    options="$@"
+    shift 2  # shift away compiler and arch
+    shift 1 || true  # shift away build extension iff supplied
+    # "$@" is now any extra parameters passed to build
 
     mkdir -p artifacts
     dub clean
 
     ## test
-    time dub test $compiler_switch $arch_switch $options -c unittest${build_ext}
-    options="$options --nodeps"
+    time dub test $compiler_switch $arch_switch "$@" -c unittest${build_ext}
 
 
     ## debug
-    time dub build $compiler_switch $arch_switch $options -b debug -c twitch${build_ext}
+    time dub build $compiler_switch $arch_switch "$@" --nodeps -b debug -c twitch${build_ext}
     mv kameloso "artifacts/kameloso-${DC}${arch_ext}"
 
-    time dub build $compiler_switch $arch_switch $options -b debug -c dev${build_ext}
+    time dub build $compiler_switch $arch_switch "$@" --nodeps -b debug -c dev${build_ext}
     mv kameloso "artifacts/kameloso-$DC-dev${arch_ext}"
 
 
     ## plain
-    #time dub build $compiler_switch $arch_switch $options -b plain -c twitch${build_ext} || true
+    #time dub build $compiler_switch $arch_switch "$@" -b plain -c twitch${build_ext} || true
     #mv kameloso "artifacts/kameloso-$DC-plain${arch_ext}" || \
     #    touch "artifacts/kameloso-$DC-plain${arch_ext}.failed"
 
-    time dub build $compiler_switch $arch_switch $options -b plain -c dev${build_ext} || true
+    time dub build $compiler_switch $arch_switch "$@" -b plain -c dev${build_ext} || true
     #mv kameloso "artifacts/kameloso-$DC-plain-dev${build_ext}${arch_ext}" || \
     #    touch "artifacts/kameloso-$DC-plain-dev${build_ext}${arch_ext}.failed"
 
 
     ## release
-    #time dub build $compiler_switch $arch_switch $options -b release -c twitch${build_ext} || true
+    #time dub build $compiler_switch $arch_switch "$@" -b release -c twitch${build_ext} || true
     #mv kameloso "artifacts/kameloso-$DC-release${arch_ext}" || \
     #    touch "artifacts/kameloso-$DC-release${arch_ext}.failed"
 
-    time dub build $compiler_switch $arch_switch $options -b release -c dev${build_ext} || true
+    time dub build $compiler_switch $arch_switch "$@" -b release -c dev${build_ext} || true
     #mv kameloso "artifacts/kameloso-$DC-release-dev${build_ext}${arch_ext}" || \
     #    touch "artifacts/kameloso-$DC-release-dev${build_ext}${arch_ext}.failed"
 }


### PR DESCRIPTION
This rewrites the `run.sh` CircleCI script to be more like [Phobos'](https://github.com/dlang/phobos/blob/master/.circleci/run.sh). Beyond the immediate advantage of *actually successfully completing tests*, it now also attempts to build with `-lowmem` ldc.

The base image was also updated to `2021.11`.