### PR TITLE
Replace a lot of boilerplate with a `Wrap` template

### DIFF
--- a/source/kameloso/plugins/common/misc.d
+++ b/source/kameloso/plugins/common/misc.d
@@ -561,23 +561,23 @@ Replay replay(Plugin, Fun)(Plugin plugin, const ref IRCEvent event,
             version(ExplainReplay) explainReplay();
 
             static if (
-                TakesParams!(Fun, AliasSeq!(Plugin, IRCEvent)) ||
-                TakesParams!(Fun, AliasSeq!(IRCPlugin, IRCEvent)))
+                TakesParams!(fun, AliasSeq!(Plugin, IRCEvent)) ||
+                TakesParams!(fun, AliasSeq!(IRCPlugin, IRCEvent)))
             {
                 fun(plugin, replay.event);
             }
             else static if (
-                TakesParams!(Fun, Plugin) ||
-                TakesParams!(Fun, IRCPlugin))
+                TakesParams!(fun, Plugin) ||
+                TakesParams!(fun, IRCPlugin))
             {
                 fun(plugin);
             }
             else static if (
-                TakesParams!(Fun, IRCEvent))
+                TakesParams!(fun, IRCEvent))
             {
                 fun(replay.event);
             }
-            else static if (arity!Fun == 0)
+            else static if (arity!fun == 0)
             {
                 fun();
             }

--- a/source/kameloso/traits.d
+++ b/source/kameloso/traits.d
@@ -321,9 +321,7 @@ unittest
  +/
 mixin template Wrap(string newName, alias symbol)
 {
-    private import std.format : format;
-    private import std.range.primitives : ElementEncodingType;
-    private import std.traits : fullyQualifiedName, isArray, isSomeString;
+    private import std.traits : isArray, isSomeString;
 
     static if (!__traits(compiles, __traits(identifier, symbol)))
     {
@@ -340,6 +338,9 @@ mixin template Wrap(string newName, alias symbol)
 
     static if (isArray!(typeof(symbol)) && !isSomeString!(typeof(symbol)))
     {
+        private import std.range.primitives : ElementEncodingType;
+        private import std.traits : fullyQualifiedName;
+
         mixin(
 "ref auto " ~ newName ~ '(' ~ fullyQualifiedName!(ElementEncodingType!(typeof(symbol))) ~ " newVal)
 {

--- a/source/kameloso/traits.d
+++ b/source/kameloso/traits.d
@@ -344,7 +344,7 @@ mixin template Wrap(string newName, alias symbol)
         mixin(
 "ref auto " ~ newName ~ '(' ~ fullyQualifiedName!(ElementEncodingType!(typeof(symbol))) ~ " newVal)
 {
-    " ~ symbol.stringof ~ " ~= newVal;
+    " ~ __traits(identifier, symbol) ~ " ~= newVal;
     return this;
 }");
     }
@@ -353,7 +353,7 @@ mixin template Wrap(string newName, alias symbol)
         mixin(
 "ref auto " ~ newName ~ '(' ~ typeof(symbol).stringof ~ " newVal)
 {
-    " ~ symbol.stringof ~ " = newVal;
+    " ~ __traits(identifier, symbol) ~ " = newVal;
     return this;
 }");
     }

--- a/source/kameloso/traits.d
+++ b/source/kameloso/traits.d
@@ -306,3 +306,88 @@ unittest
     enum longestUnserialisable = longestUnserialisableMemberTypeName!S1;
     assert((longestUnserialisable == "string[][string]"), longestUnserialisable);
 }
+
+
+// Wrap
+/++
+    Wraps a value by generating a mutator with a specified name.
+
+    The wrapper returns `this` by reference, allowing for chaining calls.
+    Values are assigned, arrays are appended to.
+
+    Params:
+        newName = Name of mutator symbol to generate and mix in.
+        symbol = Symbol to wrap.
+ +/
+mixin template Wrap(string newName, alias symbol)
+{
+    private import std.format : format;
+    private import std.range.primitives : ElementEncodingType;
+    private import std.traits : fullyQualifiedName, isArray, isSomeString;
+
+    static if (!__traits(compiles, __traits(identifier, symbol)))
+    {
+        static assert(0, "Failed to wrap symbol: symbol could not be resolved");
+    }
+    else static if (!newName.length)
+    {
+        static assert(0, "Failed to wrap symbol: name to generate is empty");
+    }
+    else static if (__traits(compiles, mixin(newName)))
+    {
+        static assert(0, "Failed to wrap symbol: symbol `" ~ newName ~ "` already exists");
+    }
+
+    static if (isArray!(typeof(symbol)) && !isSomeString!(typeof(symbol)))
+    {
+        mixin(
+"ref auto " ~ newName ~ '(' ~ fullyQualifiedName!(ElementEncodingType!(typeof(symbol))) ~ " newVal)
+{
+    " ~ symbol.stringof ~ " ~= newVal;
+    return this;
+}");
+    }
+    else
+    {
+        mixin(
+"ref auto " ~ newName ~ '(' ~ typeof(symbol).stringof ~ " newVal)
+{
+    " ~ symbol.stringof ~ " = newVal;
+    return this;
+}");
+    }
+}
+
+///
+unittest
+{
+    //import dialect.defs : IRCEvent;
+
+    struct Foo
+    {
+        IRCEvent.Type[] _acceptedEventTypes;
+        bool _verbose;
+        bool _chainable;
+
+        mixin Wrap!("onEvent", _acceptedEventTypes);
+        mixin Wrap!("verbose", _verbose);
+        mixin Wrap!("chainable", _chainable);
+    }
+
+    auto f = Foo()
+        .onEvent(IRCEvent.Type.CHAN)
+        .onEvent(IRCEvent.Type.EMOTE)
+        .onEvent(IRCEvent.Type.QUERY)
+        .chainable(true)
+        .verbose(false);
+
+    assert(f._acceptedEventTypes == [ IRCEvent.Type.CHAN, IRCEvent.Type.EMOTE, IRCEvent.Type.QUERY ]);
+    assert(f._chainable);
+    assert(!f._verbose);
+}
+
+// So the above unittest works.
+version(unittest)
+{
+    import dialect.defs;
+}


### PR DESCRIPTION
With our new `IRCEventHandler` UDA scheme, there was a *lot* of manual boilerplate involved in defining the various methods; `.onEvent`, `.channelPolicy`, `.chainable` and so forth. But they really only did two things; take the passed value and save it somewhere else, then return `this` by reference.

```d
bool _chainable;

ref auto chainable(bool newValue)
{
    this._chainable = newValue;
    return this;
}
```

Now it's done with a mixin template `Wrap` that automatically generates them.

```d
bool _chainable;

mixin Wrap!("chainable", _chainable);
```

Compilation memory went up some, but marginally.

`IRCEventHandler.Regex.expression` is an exception in that it not only saves the passed expression, but also instantiates the regex engine. So it was left as-was.