### PR TITLE
colour tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,13 @@ If there's anyone talking it should show up on your screen.
     * [**Except nothing happens**](#except-nothing-happens)
   * [Twitch](#twitch)
     * [Caveats](#caveats)
-    * [Fails to authenticate: *Improperly formatted auth*](#fails-to-authenticate-improperly-formatted-auth)
+    * [Fails to authenticate: "*Improperly formatted auth*"](#fails-to-authenticate-improperly-formatted-auth)
     * [Example configuration](#example-configuration)
     * [Streamer assistant bot](#streamer-assistant-bot)
   * [Further help](#further-help)
 * [Known issues](#known-issues)
   * [Windows](#windows)
+  * [Linux, MacOS or other Posix](#linux-macos-or-other-posix)
 * [Roadmap](#roadmap)
 * [Built with](#built-with)
 * [License](#license)
@@ -91,13 +92,7 @@ Grab a pre-compiled binary from under [Releases](https://github.com/zorael/kamel
 
 You need one based on D version **2.084** or later (January 2019). For **ldc** this is version **1.14**. Sadly, the stable release of the GCC-based [**gdc**](https://gdcproject.org/downloads) is currently based on version **2.076** and is thus too old to be used.
 
-> [**Compiling with ldc on Windows is currently broken**](https://github.com/ldc-developers/ldc/issues/3913) and requires a modified compiler with a larger stack to build. This should hopefully be resolved in **ldc 1.29**. Until such time please use **dmd** or download a pre-compiled binary.
->
-> Likewise, if **ldc** won't compile on Linux or MacOS, ensure that the stack size is set high enough with `ulimit -s`.
-> ```sh
-> $ ulimit -s 16384
-> $ dub build --compiler=ldc2
-> ```
+> [**Compiling with ldc on Windows is currently broken**](https://github.com/ldc-developers/ldc/issues/3913) and requires a modified compiler with a larger stack to build. See the [known issues](#known-issues) section for more details.
 
 If your repositories (or other software sources) don't have compilers new enough, you can use the official [`install.sh`](https://dlang.org/install.html) installation script to download current ones, or any version of choice.
 
@@ -354,6 +349,7 @@ Properly enabled and assuming a prefix of `!`, commands to test are:
 * `!start`, `!uptime`, `!stop`
 * `!timer`
 * `!followage`
+* `!shoutout`
 
 ...alongside `!operator`, `!whitelist`, `!blacklist`, `!oneliner`, `!poll`, `!counter`, `!stopwatch`, and other non-Twitch-specific commands.
 
@@ -372,20 +368,30 @@ If you still can't find what you're looking for, or if you have suggestions on h
 
 # Known issues
 
-Compiling in a non-`debug` build mode *may* fail (bug [#18026](https://issues.dlang.org/show_bug.cgi?id=18026)). Try `--build-mode=singleFile`, which compiles one file at a time and as such lowers memory requirements, but drastically increases build times.
-
 ## Windows
+
+[**Compiling with ldc on Windows is currently broken**](https://github.com/ldc-developers/ldc/issues/3913) and requires a modified compiler with a larger stack to build. This should hopefully be resolved in **ldc 1.29**. Until such time please use **dmd** or download a pre-compiled binary.
 
 If SSL doesn't work at all, you may simply be missing the required libraries. Download and install **OpenSSL** "Light" from [here](https://slproweb.com/products/Win32OpenSSL.html), and opt to install to system directories when asked.
 
 Even with SSL seemingly properly set up you may see errors of *"Peer certificates cannot be authenticated with given CA certificates"*. If this happens, download this [`cacert.pem`](https://curl.haxx.se/ca/cacert.pem) file, place it somewhere reasonable, and edit your configuration file to point to it; `caBundleFile` under `[Connection]`.
+
+## Linux, MacOS or other Posix
+
+If **ldc** won't compile on Linux or MacOS, ensure that the stack size is set high enough with `ulimit -s`.
+
+```sh
+$ ulimit -s 16384
+$ dub build --compiler=ldc2
+```
+
+`16384` should be enough, but go overboard and set it to `32768` if it isn't.
 
 # Roadmap
 
 * pipedream zero: **no compiler segfaults** ([#18026](https://issues.dlang.org/show_bug.cgi?id=18026), [#20562](https://issues.dlang.org/show_bug.cgi?id=20562))
 * pipedream: DCC
 * non-blocking FIFO
-* make plugins enabled/disabled on per-channel basis
 * more pairs of eyes
 
 # Built with

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -1362,7 +1362,6 @@ unittest
 
     static if ((LuSemVer.majorVersion >= 2) && (LuSemVer.minorVersion >= 5))
     {
-        pragma(msg, "blerp");
         {
             import std.conv : wtext;
 

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -1392,6 +1392,16 @@ unittest
             Tint.critical, "critical", Tint.off, "nothing<w>not warning");
         assert((replaced == expected), replaced);
     }
+    {
+        immutable line = "This is a line with no tags";
+        immutable replaced = line.expandTags;
+        assert(line is replaced);
+    }
+    {
+        immutable emptyLine = string.init;
+        immutable replaced = emptyLine.expandTags;
+        assert(replaced is emptyLine);
+    }
 }
 
 

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -1350,6 +1350,7 @@ T expandTags(T)(/*const*/ T line) @safe
 ///
 unittest
 {
+    import lu.semver;
     import std.conv : text, to;
 
     {
@@ -1358,22 +1359,28 @@ unittest
         immutable expected = text("This is a ", Tint.log, "log", Tint.off, " line.");
         assert((replaced == expected), replaced);
     }
-    {
-        import std.conv : wtext;
 
-        immutable line = "This is a <l>log</> line."w;
-        immutable replaced = line.expandTags;
-        immutable expected = wtext("This is a "w, Tint.log, "log"w, Tint.off, " line."w);
-        assert((replaced == expected), replaced.to!string);
-    }
+    static if ((LuSemVer.majorVersion >= 2) && (LuSemVer.minorVersion >= 5))
     {
-        import std.conv : dtext;
+        pragma(msg, "blerp");
+        {
+            import std.conv : wtext;
 
-        immutable line = "This is a <l>log</> line."d;
-        immutable replaced = line.expandTags;
-        immutable expected = dtext("This is a "d, Tint.log, "log"d, Tint.off, " line."d);
-        assert((replaced == expected), replaced.to!string);
+            immutable line = "This is a <l>log</> line."w;
+            immutable replaced = line.expandTags;
+            immutable expected = wtext("This is a "w, Tint.log, "log"w, Tint.off, " line."w);
+            assert((replaced == expected), replaced.to!string);
+        }
+        {
+            import std.conv : dtext;
+
+            immutable line = "This is a <l>log</> line."d;
+            immutable replaced = line.expandTags;
+            immutable expected = dtext("This is a "d, Tint.log, "log"d, Tint.off, " line."d);
+            assert((replaced == expected), replaced.to!string);
+        }
     }
+
     {
         immutable line = `<i>info</>nothing<c>critical</>nothing\<w>not warning`;
         immutable replaced = line.expandTags;

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -1280,6 +1280,110 @@ unittest
 }
 
 
+// expandTags
+/++
+    String-replaces `<tags>` in a string with the results from calls to `Tint`.
+
+    `<tags>` are the lowercase first letter of all
+    [std.experimental.logger.LogLevel|LogLevel]s; `<a>`, `<l>`, `<t>`, `<i>`,
+    `<w>`, `<e>`, `<c>` and `<f>`.
+
+    `</>` equals [std.experimental.logger.LogLevel.off|LogLevel.off] and terminates
+    the colour sequence.
+
+    This should hopefully make highlighted strings more readable.
+
+    Example:
+    ---
+    enum keyPattern = "
+        %1$sYour private authorisation key is: %2$s%3$s%4$s
+        It should be entered as %2$spass%4$s under %2$s[IRCBot]%4$s.
+        ";
+
+    enum keyPatternWithColoured = "
+        <l>Your private authorisation key is: <i>%s</>
+        It should be entered as <i>pass</> under <i>[IRCBot]</>
+        ";
+    ---
+
+    Params:
+        line = A line of text.
+ +/
+T expandTags(T)(/*const*/ T line) @safe
+{
+    import lu.string : contains;
+    import std.array : replace;
+
+    bool hasEscapes;
+
+    if (line.contains(`\<`))
+    {
+        // Avoid escaped tags by string replacing escapes into nonsense
+        hasEscapes = true;
+        line = line
+            .replace("\\\\", "\0\0")
+            .replace(`\<`, "\1\1");
+    }
+
+    line = line
+        //.replace("<a>", Tint.log)  // all...
+        .replace("<l>", Tint.log)
+        .replace("<t>", Tint.trace)
+        .replace("<i>", Tint.info)
+        .replace("<w>", Tint.warning)
+        .replace("<e>", Tint.error)
+        .replace("<c>", Tint.critical)
+        .replace("<f>", Tint.fatal)
+        .replace("</>", Tint.off);
+
+    if (hasEscapes)
+    {
+        // Restore nonsense to escapes
+        line = line
+            .replace("\0\0", "\\")
+            .replace("\1\1", `<`);
+    }
+
+    return line;
+}
+
+///
+unittest
+{
+    import std.conv : text, to;
+
+    {
+        immutable line = "This is a <l>log</> line.";
+        immutable replaced = line.expandTags;
+        immutable expected = text("This is a ", Tint.log, "log", Tint.off, " line.");
+        assert((replaced == expected), replaced);
+    }
+    {
+        import std.conv : wtext;
+
+        immutable line = "This is a <l>log</> line."w;
+        immutable replaced = line.expandTags;
+        immutable expected = wtext("This is a "w, Tint.log, "log"w, Tint.off, " line."w);
+        assert((replaced == expected), replaced.to!string);
+    }
+    {
+        import std.conv : dtext;
+
+        immutable line = "This is a <l>log</> line."d;
+        immutable replaced = line.expandTags;
+        immutable expected = dtext("This is a "d, Tint.log, "log"d, Tint.off, " line."d);
+        assert((replaced == expected), replaced.to!string);
+    }
+    {
+        immutable line = `<i>info</>nothing<c>critical</>nothing\<w>not warning`;
+        immutable replaced = line.expandTags;
+        immutable expected = text(Tint.info, "info", Tint.off, "nothing",
+            Tint.critical, "critical", Tint.off, "nothing<w>not warning");
+        assert((replaced == expected), replaced);
+    }
+}
+
+
 // replaceTokens
 /++
     Apply some common text replacements. Used on part and quit reasons.

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -1283,13 +1283,14 @@ unittest
 // expandTags
 /++
     String-replaces `<tags>` in a string with the results from calls to `Tint`.
+    Also works with `dstring`s and `wstring`s.
 
     `<tags>` are the lowercase first letter of all
-    [std.experimental.logger.LogLevel|LogLevel]s; `<a>`, `<l>`, `<t>`, `<i>`,
-    `<w>`, `<e>`, `<c>` and `<f>`.
+    [std.experimental.logger.LogLevel|LogLevel]s; `<l>`, `<t>`, `<i>`, `<w>`
+    `<e>`, `<c>` and `<f>`. `<a>` is not included.
 
     `</>` equals [std.experimental.logger.LogLevel.off|LogLevel.off] and terminates
-    the colour sequence.
+    any colour sequence.
 
     This should hopefully make highlighted strings more readable.
 
@@ -1307,7 +1308,11 @@ unittest
     ---
 
     Params:
-        line = A line of text.
+        line = A line of text, presumably with `<tags>`.
+
+    Returns:
+        The passsed `line` but with any `<tags>` replaced with ANSI colour sequences.
+        The original string is passed back if there was nothing to replace.
  +/
 T expandTags(T)(/*const*/ T line) @safe
 {

--- a/source/kameloso/common.d
+++ b/source/kameloso/common.d
@@ -1319,6 +1319,8 @@ T expandTags(T)(/*const*/ T line) @safe
     import lu.string : contains;
     import std.array : replace;
 
+    if (!line.length || !line.contains('<')) return line;
+
     bool hasEscapes;
 
     if (line.contains(`\<`))

--- a/source/kameloso/main.d
+++ b/source/kameloso/main.d
@@ -13,7 +13,7 @@ module kameloso.main;
 private:
 
 import kameloso.kameloso : Kameloso, CoreSettings;
-import kameloso.common : Tint, logger;
+import kameloso.common : Tint, expandTags, logger;
 import kameloso.plugins.common.core : IRCPlugin, Replay;
 import dialect.defs;
 import lu.common : Next;
@@ -309,8 +309,8 @@ void messageFiber(ref Kameloso instance)
                 }
                 catch (Exception e)
                 {
-                    enum pattern = "The %s%s%s plugin threw an exception when reloading: %1$s%4$s";
-                    logger.errorf(pattern, Tint.log, plugin.name, Tint.error, e.msg);
+                    enum pattern = "The <l>%s<e> plugin threw an exception when reloading: <l>%s";
+                    logger.errorf(pattern.expandTags, plugin.name, e.msg);
                     version(PrintStacktraces) logger.trace(e);
                 }
             }
@@ -879,8 +879,8 @@ Next mainLoop(ref Kameloso instance)
         }
         catch (Exception e)
         {
-            enum pattern = "Unhandled messenger exception: %s%s%s (at %1$s%4$s%3$s:%1$s%5$d%3$s)";
-            logger.warningf(pattern, Tint.log, e.msg, Tint.warning, e.file, e.line);
+            enum pattern = "Unhandled messenger exception: <l>%s<w> (at <l>%s<w>:<l>%d<w>)";
+            logger.warningf(pattern.expandTags, e.msg, e.file, e.line);
             version(PrintStacktraces) logger.trace(e);
         }
 
@@ -1065,18 +1065,18 @@ Next listenAttemptToNext(ref Kameloso instance, const ListenAttempt attempt)
         version(Posix)
         {
             import kameloso.common : errnoStrings;
-            enum pattern = "Connection error! (%s%s%s) (%1$s%4$s%3$s)";
-            logger.warningf(pattern, Tint.log, attempt.error, Tint.warning, errnoStrings[attempt.errno]);
+            enum pattern = "Connection error! (<l>%s<w>) (<l>%s<w>)";
+            logger.warningf(pattern.expandTags, attempt.error, errnoStrings[attempt.errno]);
         }
         else version(Windows)
         {
-            enum pattern = "Connection error! (%s%s%s) (%1$s%4$d%3$s)";
-            logger.warningf(pattern, Tint.log, attempt.error, Tint.warning, attempt.errno);
+            enum pattern = "Connection error! (<l>%s<w>) (<l>%d<w>)";
+            logger.warningf(pattern.expandTags, attempt.error, attempt.errno);
         }
         else
         {
-            enum pattern = "Connection error! (%s%s%s)";
-            logger.warningf(pattern, Tint.log, attempt.error, Tint.warning);
+            enum pattern = "Connection error! (<l>%s<w>)";
+            logger.warningf(pattern.expandTags, attempt.error);
         }
 
         // Sleep briefly so it won't flood the screen on chains of errors
@@ -1100,18 +1100,18 @@ Next listenAttemptToNext(ref Kameloso instance, const ListenAttempt attempt)
             version(Posix)
             {
                 import kameloso.common : errnoStrings;
-                enum pattern = "Connection error: invalid server response! (%s%s%s) (%1$s%4$s%3$s)";
-                logger.errorf(pattern, Tint.log, attempt.error, Tint.error, errnoStrings[attempt.errno]);
+                enum pattern = "Connection error: invalid server response! (<l>%s<e>) (<l>%s<e>)";
+                logger.errorf(pattern.expandTags, attempt.error, errnoStrings[attempt.errno]);
             }
             else version(Windows)
             {
-                enum pattern = "Connection error: invalid server response! (%s%s%s) (%1$s%4$d%3$s)";
-                logger.errorf(pattern, Tint.log, attempt.error, Tint.error, attempt.errno);
+                enum pattern = "Connection error: invalid server response! (<l>%s<e>) (<l>%d<e>)";
+                logger.errorf(pattern.expandTags, attempt.error, attempt.errno);
             }
             else
             {
-                enum pattern = "Connection error: invalid server response! (%s%s%s)";
-                logger.errorf(pattern, Tint.log, attempt.error, Tint.error);
+                enum pattern = "Connection error: invalid server response! (<l>%s<e>)";
+                logger.errorf(pattern.expandTags, attempt.error);
             }
         }
 
@@ -1229,27 +1229,27 @@ void processLineFromServer(ref Kameloso instance, const string raw, const long n
             }
             catch (NomException e)
             {
-                enum pattern = `Nom Exception %s.postprocess: tried to nom "%s%s%s" with "%2$s%5$s%4$s"`;
-                logger.warningf(pattern, plugin.name, Tint.log, e.haystack, Tint.warning, e.needle);
+                enum pattern = `NomException %s.postprocess: tried to nom "<l>%s<w>" with "<l>%s<w>"`;
+                logger.warningf(pattern.expandTags, plugin.name, e.haystack, e.needle);
                 printEventDebugDetails(event, raw);
                 version(PrintStacktraces) logger.trace(e.info);
             }
             catch (UTFException e)
             {
-                enum pattern = "UTFException %s.postprocess: %s%s";
-                logger.warningf(pattern, plugin.name, Tint.log, e.msg);
+                enum pattern = "UTFException %s.postprocess: <l>%s";
+                logger.warningf(pattern.expandTags, plugin.name, e.msg);
                 version(PrintStacktraces) logger.trace(e.info);
             }
             catch (UnicodeException e)
             {
-                enum pattern = "UnicodeException %s.postprocess: %s%s";
-                logger.warningf(pattern, plugin.name, Tint.log, e.msg);
+                enum pattern = "UnicodeException %s.postprocess: <l>%s";
+                logger.warningf(pattern.expandTags, plugin.name, e.msg);
                 version(PrintStacktraces) logger.trace(e.info);
             }
             catch (Exception e)
             {
-                enum pattern = "Exception %s.postprocess: %s%s";
-                logger.warningf(pattern, plugin.name, Tint.log, e.msg);
+                enum pattern = "Exception %s.postprocess: <l>%s";
+                logger.warningf(pattern.expandTags, plugin.name, e.msg);
                 printEventDebugDetails(event, raw);
                 version(PrintStacktraces) logger.trace(e);
             }
@@ -1278,21 +1278,27 @@ void processLineFromServer(ref Kameloso instance, const string raw, const long n
             }
             catch (NomException e)
             {
-                enum pattern = `Nom Exception %s: tried to nom "%s%s%s" with "%2$s%5$s%4$s"`;
-                logger.warningf(pattern, plugin.name, Tint.log, e.haystack, Tint.warning, e.needle);
+                enum pattern = `NomException %s: tried to nom "<l>%s<w>" with "<l>%s<w>"`;
+                logger.warningf(pattern.expandTags, plugin.name, e.haystack, e.needle);
                 printEventDebugDetails(event, raw);
                 version(PrintStacktraces) logger.trace(e.info);
             }
             catch (UTFException e)
             {
-                enum pattern = "UTFException %s: %s%s";
-                logger.warningf(pattern, plugin.name, Tint.log, e.msg);
+                enum pattern = "UTFException %s: <l>%s";
+                logger.warningf(pattern.expandTags, plugin.name, e.msg);
+                version(PrintStacktraces) logger.trace(e.info);
+            }
+            catch (UnicodeException e)
+            {
+                enum pattern = "UnicodeException %s: <l>%s";
+                logger.warningf(pattern.expandTags, plugin.name, e.msg);
                 version(PrintStacktraces) logger.trace(e.info);
             }
             catch (Exception e)
             {
-                enum pattern = "Exception %s: %s%s";
-                logger.warningf(pattern, plugin.name, Tint.log, e.msg);
+                enum pattern = "Exception %s: <l>%s";
+                logger.warningf(pattern.expandTags, plugin.name, e.msg);
                 printEventDebugDetails(event, raw);
                 version(PrintStacktraces) logger.trace(e);
             }
@@ -1362,15 +1368,15 @@ void processLineFromServer(ref Kameloso instance, const string raw, const long n
     }
     catch (IRCParseException e)
     {
-        enum pattern = "IRC Parse Exception: %s%s%s (at %1$s%4$s%3$s:%1$s%5$d%3$s)";
-        logger.warningf(pattern, Tint.log, e.msg, Tint.warning, e.file, e.line);
+        enum pattern = "IRCParseException: <l>%s<w> (at <l>%s<w>:<l>%d<w>)";
+        logger.warningf(pattern.expandTags, e.msg, e.file, e.line);
         printEventDebugDetails(event, raw);
         version(PrintStacktraces) logger.trace(e.info);
     }
     catch (NomException e)
     {
-        enum pattern = `Nom Exception: tried to nom "%s%s%s" with "%1$s%4$s%3$s"`;
-        logger.warningf(pattern, Tint.log, e.haystack, Tint.warning, e.needle);
+        enum pattern = `NomException: tried to nom "<l>%s<w>" with "<l>%s<w>" (at <l>%s<w>:<l>%d<w>)`;
+        logger.warningf(pattern.expandTags, e.haystack, e.needle, e.file, e.line);
         printEventDebugDetails(event, raw);
         version(PrintStacktraces) logger.trace(e.info);
     }
@@ -1386,8 +1392,8 @@ void processLineFromServer(ref Kameloso instance, const string raw, const long n
     }
     catch (Exception e)
     {
-        enum pattern = "Unhandled exception: %s%s%s (at %1$s%4$s%3$s:%1$s%5$d%3$s)";
-        logger.warningf(pattern, Tint.log, e.msg, Tint.warning, e.file, e.line);
+        enum pattern = "Unhandled exception: <l>%s<w> (at <l>%s<w>:<l>%d<w>)";
+        logger.warningf(pattern.expandTags, e.msg, e.file, e.line);
         printEventDebugDetails(event, raw);
         version(PrintStacktraces) logger.trace(e);
     }
@@ -1425,8 +1431,8 @@ void processAwaitingDelegates(IRCPlugin plugin, const ref IRCEvent event)
             }
             catch (Exception e)
             {
-                enum pattern = "Exception %s.awaitingDelegates[%d]: %s%s";
-                logger.warningf(pattern, plugin.name, i, Tint.log, e.msg);
+                enum pattern = "Exception %s.awaitingDelegates[%d]: <l>%s";
+                logger.warningf(pattern.expandTags, plugin.name, i, e.msg);
                 printEventDebugDetails(event, event.raw);
                 version(PrintStacktraces) logger.trace(e);
             }
@@ -1503,8 +1509,8 @@ void processAwaitingFibers(IRCPlugin plugin, const ref IRCEvent event)
             }
             catch (Exception e)
             {
-                enum pattern = "Exception %s.awaitingFibers[%d]: %s%s";
-                logger.warningf(pattern, plugin.name, i, Tint.log, e.msg);
+                enum pattern = "Exception %s.awaitingFibers[%d]: <l>%s";
+                logger.warningf(pattern.expandTags, plugin.name, i, e.msg);
                 printEventDebugDetails(event, event.raw);
                 version(PrintStacktraces) logger.trace(e);
                 expiredFibers ~= fiber;
@@ -1574,8 +1580,8 @@ in ((nowInHnsecs > 0), "Tried to process queued `ScheduledDelegate`s with an uns
         }
         catch (Exception e)
         {
-            enum pattern = "Exception %s.scheduledDelegates[%d]: %s%s";
-            logger.warningf(pattern, plugin.name, i, Tint.log, e.msg);
+            enum pattern = "Exception %s.scheduledDelegates[%d]: <l>%s";
+            logger.warningf(pattern.expandTags, plugin.name, i, e.msg);
             version(PrintStacktraces) logger.trace(e);
         }
 
@@ -1624,8 +1630,8 @@ in ((nowInHnsecs > 0), "Tried to process queued `ScheduledFiber`s with an unset 
         }
         catch (Exception e)
         {
-            enum pattern = "Exception %s.scheduledFibers[%d]: %s%s";
-            logger.warningf(pattern, plugin.name, i, Tint.log, e.msg);
+            enum pattern = "Exception %s.scheduledFibers[%d]: <l>%s";
+            logger.warningf(pattern.expandTags, plugin.name, i, e.msg);
             version(PrintStacktraces) logger.trace(e);
         }
 
@@ -1679,31 +1685,31 @@ void processReadyReplays(ref Kameloso instance, IRCPlugin plugin)
         }
         catch (NomException e)
         {
-            enum pattern = "Nom Exception postprocessing %s.state.readyReplays[%d]: " ~
-                `tried to nom "%s%s%s" with "%3$s%6$s%5$s"`;
-            logger.warningf(pattern, plugin.name, i, Tint.log, e.haystack, Tint.warning, e.needle);
+            enum pattern = "NomException postprocessing %s.state.readyReplays[%d]: " ~
+                `tried to nom "<l>%s<w>" with "<l>%s<w>"`;
+            logger.warningf(pattern.expandTags, plugin.name, i, e.haystack, e.needle);
             printEventDebugDetails(replay.event, replay.event.raw);
             version(PrintStacktraces) logger.trace(e.info);
             continue;
         }
         catch (UTFException e)
         {
-            enum pattern = "UTFException postprocessing %s.state.readyReplays[%d]: %s%s";
-            logger.warningf(pattern, plugin.name, i, Tint.log, e.msg);
+            enum pattern = "UTFException postprocessing %s.state.readyReplace[%d]: <l>%s";
+            logger.warningf(pattern.expandTags, plugin.name, i, e.msg);
             version(PrintStacktraces) logger.trace(e.info);
             continue;
         }
         catch (UnicodeException e)
         {
-            enum pattern = "UnicodeException postprocessing %s.state.readyReplays[%d]: %s%s";
-            logger.warningf(pattern, plugin.name, i, Tint.log, e.msg);
+            enum pattern = "UnicodeException postprocessing %s.state.readyReplace[%d]: <l>%s";
+            logger.warningf(pattern.expandTags, plugin.name, i, e.msg);
             version(PrintStacktraces) logger.trace(e.info);
             continue;
         }
         catch (Exception e)
         {
-            enum pattern = "Exception postprocessing %s.state.readyReplays[%d]: %s%s";
-            logger.warningf(pattern, plugin.name, i, Tint.log, e.msg);
+            enum pattern = "Exception postprocessing %s.state.readyReplace[%d]: <l>%s";
+            logger.warningf(pattern.expandTags, plugin.name, i, e.msg);
             printEventDebugDetails(replay.event, replay.event.raw);
             version(PrintStacktraces) logger.trace(e);
             continue;
@@ -1717,8 +1723,8 @@ void processReadyReplays(ref Kameloso instance, IRCPlugin plugin)
         }
         catch (Exception e)
         {
-            enum pattern = "Exception %s.state.readyReplays[%d]: %s%s";
-            logger.warningf(pattern, plugin.name, i, Tint.log, e.msg);
+            enum pattern = "Exception %s.state.readyReplays[%d].dg(): <l>%s";
+            logger.warningf(pattern.expandTags, plugin.name, i, e.msg);
             printEventDebugDetails(replay.event, replay.event.raw);
             version(PrintStacktraces) logger.trace(e);
         }
@@ -1880,14 +1886,14 @@ Next tryGetopt(ref Kameloso instance, string[] args, out string[] customSettings
     }
     catch (FileTypeMismatchException e)
     {
-        enum pattern = "Specified configuration file %s%s%s is not a file!";
-        logger.errorf(pattern, Tint.log, e.filename, Tint.error);
+        enum pattern = "Specified configuration file <l>%s<e> is not a file!";
+        logger.errorf(pattern.expandTags, e.filename);
         //version(PrintStacktraces) logger.trace(e.info);
     }
     catch (ConfigurationFileReadFailureException e)
     {
-        enum pattern = "Error reading and decoding configuration file [%s%s%s]: %1$s%4$s";
-        logger.errorf(pattern, Tint.log, e.filename, Tint.error, e.msg);
+        enum pattern = "Error reading and decoding configuration file [<l>%s<e>]: <l>%s";
+        logger.errorf(pattern.expandTags, e.filename, e.msg);
         version(PrintStacktraces) logger.trace(e.info);
     }
     catch (DeserialisationException e)
@@ -1897,8 +1903,8 @@ Next tryGetopt(ref Kameloso instance, string[] args, out string[] customSettings
     }
     catch (ProcessException e)
     {
-        enum pattern = "Failed to open %s%s%s in an editor: %1$s%4$s";
-        logger.errorf(pattern, Tint.log, instance.settings.configFile, Tint.error, e.msg);
+        enum pattern = "Failed to open <l>%s<e> in an editor: <l>%s";
+        logger.errorf(pattern.expandTags, instance.settings.configFile, e.msg);
         version(PrintStacktraces) logger.trace(e.info);
     }
     catch (Exception e)
@@ -1960,8 +1966,8 @@ Next tryConnect(ref Kameloso instance)
 
         void verboselyDelay()
         {
-            enum pattern = "Retrying in %s%d%s seconds...";
-            logger.logf(pattern, Tint.info, incrementedRetryDelay, Tint.log);
+            enum pattern = "Retrying in <i>%d<l> seconds...";
+            logger.logf(pattern.expandTags, incrementedRetryDelay);
             interruptibleSleep(incrementedRetryDelay.seconds, *instance.abort);
 
             import std.algorithm.comparison : min;
@@ -1972,8 +1978,8 @@ Next tryConnect(ref Kameloso instance)
 
         void verboselyDelayToNextIP()
         {
-            enum pattern = "Failed to connect to IP. Trying next IP in %s%d%s seconds.";
-            logger.logf(pattern, Tint.info, Timeout.connectionRetry, Tint.log);
+            enum pattern = "Failed to connect to IP. Trying next IP in <i>%d<l> seconds.";
+            logger.logf(pattern.expandTags, Timeout.connectionRetry);
             incrementedRetryDelay = Timeout.connectionRetry;
             interruptibleSleep(Timeout.connectionRetry.seconds, *instance.abort);
         }
@@ -2009,8 +2015,8 @@ Next tryConnect(ref Kameloso instance)
 
             immutable rtPattern = !resolvedHost.length &&
                 (attempt.ip.addressFamily == AddressFamily.INET6) ?
-                "Connecting to [%s%s%s]:%1$s%4$s%3$s %5$s..." :
-                "Connecting to %s%s%s:%1$s%4$s%3$s %5$s...";
+                    "Connecting to [<i>%s<l>]:<i>%s<l> %s..." :
+                    "Connecting to <i>%s<l>:<i>%s<l> %s...";
 
             immutable ssl = instance.conn.ssl ? "(SSL) " : string.init;
 
@@ -2019,7 +2025,7 @@ Next tryConnect(ref Kameloso instance)
                 (sharedDomains(instance.parser.server.address, resolvedHost) < 2)) ?
                 attempt.ip.toAddrString : resolvedHost;
 
-            logger.logf(rtPattern, Tint.info, address, Tint.log, attempt.ip.toPortString, ssl);
+            logger.logf(rtPattern.expandTags, address, attempt.ip.toPortString, ssl);
             continue;
 
         case connected:
@@ -2051,13 +2057,13 @@ Next tryConnect(ref Kameloso instance)
                 version(Posix)
                 {
                     import kameloso.common : errnoStrings;
-                    enum pattern = "Connection failed with %s%s%s: %1$s%4$s";
-                    logger.warningf(pattern, Tint.log, errnoStrings[attempt.errno], Tint.warning, errorString);
+                    enum pattern = "Connection failed with <l>%s<w>: <l>%s";
+                    logger.warningf(pattern.expandTags, errnoStrings[attempt.errno], errorString);
                 }
                 else version(Windows)
                 {
-                    enum pattern = "Connection failed with error %s%d%s: %1$s%4$s";
-                    logger.warningf(pattern, Tint.log, attempt.errno, Tint.warning, errorString);
+                    enum pattern = "Connection failed with error <l>%d<w>: <l>%s";
+                    logger.warningf(pattern.expandTags, attempt.errno, errorString);
                 }
             }
 
@@ -2080,13 +2086,13 @@ Next tryConnect(ref Kameloso instance)
             version(Posix)
             {
                 import kameloso.common : errnoStrings;
-                enum pattern = "IPv6 connection failed with %s%s%s: %1$s%4$s";
-                logger.warningf(pattern, Tint.log, errnoStrings[attempt.errno], Tint.warning, errorString);
+                enum pattern = "IPv6 connection failed with <l>%s<w>: <l>%s";
+                logger.warningf(pattern.expandTags, errnoStrings[attempt.errno], errorString);
             }
             else version(Windows)
             {
-                enum pattern = "IPv6 connection failed with error %s%d%s: %1$s%4$s";
-                logger.warningf(pattern, Tint.log, attempt.errno, Tint.warning, errorString);
+                enum pattern = "IPv6 connection failed with error <l>%d<w>: <l>%s";
+                logger.warningf(pattern.expandTags, attempt.errno, errorString);
             }
             else
             {
@@ -2110,13 +2116,13 @@ Next tryConnect(ref Kameloso instance)
             version(Posix)
             {
                 import kameloso.common : errnoStrings;
-                enum pattern = "Failed to connect: %s%s%s (%1$s%4$s%3$s)";
-                logger.errorf(pattern, Tint.log, errorString, Tint.error, errnoStrings[attempt.errno]);
+                enum pattern = "Failed to connect: <l>%s<e> <l>%s<e>)";
+                logger.errorf(pattern.expandTags, errorString, errnoStrings[attempt.errno]);
             }
             else version(Windows)
             {
-                enum pattern = "Failed to connect: %s%s%s (%1$s%4$d%3$s)";
-                logger.errorf(pattern, Tint.log, errorString, Tint.error, attempt.errno);
+                enum pattern = "Failed to connect: <l>%s<e> (<l>%d<e>)";
+                logger.errorf(pattern.expandTags, errorString, attempt.errno);
             }
             else
             {
@@ -2175,8 +2181,8 @@ Next tryResolve(ref Kameloso instance, const Flag!"firstConnect" firstConnect)
         import std.algorithm.comparison : min;
         import core.time : seconds;
 
-        enum pattern = "Network down? Retrying in %s%d%s seconds.";
-        logger.logf(pattern, Tint.info, incrementedRetryDelay, Tint.log);
+        enum pattern = "Network down? Retrying in <i>%d<l> seconds.";
+        logger.logf(pattern.expandTags, incrementedRetryDelay);
         interruptibleSleep(incrementedRetryDelay.seconds, *instance.abort);
         if (*instance.abort) return;
 
@@ -2205,29 +2211,29 @@ Next tryResolve(ref Kameloso instance, const Flag!"firstConnect" firstConnect)
 
         case success:
             import lu.string : plurality;
-            enum pattern = "%s%s resolved into %s%s%2$s %5$s.";
-            logger.infof(pattern, instance.parser.server.address, Tint.log,
-                Tint.info, instance.conn.ips.length,
+            enum pattern = "<l>%s<i> resolved into <l>%d<i> %s.";
+            logger.infof(pattern.expandTags, instance.parser.server.address,
+                instance.conn.ips.length,
                 instance.conn.ips.length.plurality("IP", "IPs"));
             return Next.continue_;
 
         case exception:
-            enum pattern = "Could not resolve server address: %s%s%s (%1$s%4$d%3$s)";
-            logger.warningf(pattern, Tint.log, errorString, Tint.warning, attempt.errno);
+            enum pattern = "Could not resolve server address: <l>%s<w> (<l>%d<w>)";
+            logger.warningf(pattern.expandTags, errorString, attempt.errno);
             delayOnNetworkDown();
             if (*instance.abort) return Next.returnFailure;
             continue;
 
         case error:
-            enum pattern = "Could not resolve server address: %s%s%s (%1$s%4$d%3$s)";
-            logger.errorf(pattern, Tint.log, errorString, Tint.error, attempt.errno);
+            enum pattern = "Could not resolve server address: <l>%s<e> (<l>%d<e>)";
+            logger.errorf(pattern, errorString, attempt.errno);
 
             if (firstConnect)
             {
                 // First attempt and a failure; something's wrong, abort
-                enum firstConnectPattern = "Failed to resolve host. Verify that you " ~
-                    "are connected to the Internet and that the server address (%s%s%s) is correct.";
-                logger.logf(firstConnectPattern, Tint.info, instance.parser.server.address, Tint.log);
+                enum firstConnectPattern = "Failed to resolve host. Verify that you are " ~
+                    "connected to the Internet and that the server address (<i>%s<l>) is correct.";
+                logger.logf(firstConnectPattern.expandTags, instance.parser.server.address);
                 return Next.returnFailure;
             }
             else
@@ -2386,8 +2392,8 @@ Next verifySettings(ref Kameloso instance)
 
     if (!addressIsResolvable)
     {
-        enum pattern = "Invalid address! [%s%s%s]";
-        logger.errorf(pattern, Tint.log, instance.parser.server.address, Tint.error);
+        enum pattern = "Invalid address! [<l>%s<e>]";
+        logger.errorf(pattern.expandTags, instance.parser.server.address);
         return Next.returnFailure;
     }
 
@@ -2607,11 +2613,9 @@ void startBot(ref Kameloso instance, ref AttemptState attempt)
         }
         catch (IRCPluginInitialisationException e)
         {
-            import kameloso.terminal : TerminalToken;
-
-            enum pattern = "The %s%s%s plugin failed to load its resources: " ~
-                "%1$s%4$s%3$s (at %1$s%5$s%3$s:%1$s%6$d%3$s)%7$s";
-            logger.warningf(pattern, Tint.log, e.file.baseName[0..$-2], Tint.warning,
+            enum pattern = "The <l>%s<w> plugin failed to load its resources; " ~
+                "<l>%s<w> (at <l>%s<w>:<l>%d<w>)%s";
+            logger.warningf(pattern.expandTags, e.file.baseName[0..$-2],
                 e.msg, e.file.baseName, e.line, bell);
             version(PrintStacktraces) logger.trace(e.info);
             attempt.retval = ShellReturnValue.pluginResourceLoadFailure;
@@ -2619,12 +2623,9 @@ void startBot(ref Kameloso instance, ref AttemptState attempt)
         }
         catch (Exception e)
         {
-            import kameloso.terminal : TerminalToken;
-
-            enum pattern = "An error occurred while initialising the %s%s%s " ~
-                "plugin's resources: %1$s%4$s%3$s " ~
-                "(at %1$s%5$s%3$s:%1$s%6$d%3$s)%7$s";
-            logger.warningf(pattern, Tint.log, e.file.baseName[0..$-2], Tint.warning,
+            enum pattern = "An unexpected error occured while initialising the <l>%s<w> " ~
+                "plugin's resources: <l>%s<w> (at <l>%s<w>:<l>%d<w>)%s";
+            logger.warningf(pattern.expandTags, e.file.baseName[0..$-2],
                 e.msg, e.file, e.line, bell);
             version(PrintStacktraces) logger.trace(e);
             attempt.retval = ShellReturnValue.pluginResourceLoadException;
@@ -2643,11 +2644,9 @@ void startBot(ref Kameloso instance, ref AttemptState attempt)
         }
         catch (IRCPluginInitialisationException e)
         {
-            import kameloso.terminal : TerminalToken;
-
-            enum pattern = "The %s%s%s plugin failed to start up: %1$s%4$s%3$s " ~
-                "(at %1$s%5$s%3$s:%1$s%6$d%3$s)%7$s";
-            logger.warningf(pattern, Tint.log, e.file.baseName[0..$-2], Tint.warning,
+            enum pattern = "The <l>%s<w> plugin failed to start: <l>%s<w> " ~
+                "(at <l>%s<w>:<l>%d<w>)%s";
+            logger.warningf(pattern.expandTags, e.file.baseName[0..$-2],
                 e.msg, e.file.baseName, e.line, bell);
             version(PrintStacktraces) logger.trace(e.info);
             attempt.retval = ShellReturnValue.pluginStartFailure;
@@ -2655,12 +2654,10 @@ void startBot(ref Kameloso instance, ref AttemptState attempt)
         }
         catch (Exception e)
         {
-            import kameloso.terminal : TerminalToken;
-
-            enum pattern = "An error occurred while starting up the %s%s%s plugin: " ~
-                "%1$s%4$s%3$s (at %1$s%5$s%3$s:%1$s%6$d%3$s)%7$s";
-            logger.warningf(pattern, Tint.log, e.file.baseName[0..$-2], Tint.warning,
-                e.msg, e.file.baseName, e.line, bell);
+            enum pattern = "An unexpected error occured while starting the <l>%s<w> plugin: " ~
+                "<l>%s<w> (at <l>%s<w>:<l>%d<w>)%s";
+            logger.warningf(pattern.expandTags, e.file.baseName[0..$-2],
+                e.msg, e.file, e.line, bell);
             version(PrintStacktraces) logger.trace(e);
             attempt.retval = ShellReturnValue.pluginStartException;
             break outerloop;
@@ -2695,8 +2692,8 @@ void printEventDebugDetails(const ref IRCEvent event,
 
     if (!eventWasInitialised || (event == IRCEvent.init))
     {
-        enum pattern = `Offending line: "%s%s%s"`;
-        logger.warningf(pattern, Tint.log, raw, Tint.warning);
+        enum pattern = `Offending line: "<l>%s<w>"`;
+        logger.warningf(pattern.expandTags, raw);
     }
     else
     {
@@ -2771,9 +2768,9 @@ void printSummary(const ref Kameloso instance)
             entry.numEvents, entry.bytesReceived, startString, stopString);
     }
 
-    enum pattern = "Total received: %s%,d%s bytes";
     logger.info("Total time connected: ", Tint.log, totalTime.timeSince!(7, 1));
-    logger.infof(pattern, Tint.log, totalBytesReceived, Tint.info);
+    enum pattern = "Total received: <l>%,d<i> bytes";
+    logger.infof(pattern.expandTags, totalBytesReceived);
 }
 
 
@@ -3101,8 +3098,8 @@ int run(string[] args)
         catch (Exception e)
         {
             enum pattern = "Caught Exception when saving settings: " ~
-                "%s%s%s (at %1$s%4$s%3$s:%1$s%5$d%3$s)";
-            logger.warningf(pattern, Tint.log, e.msg, Tint.warning, e.file, e.line);
+                "<l>%s<w> (at <l>%s<w>:<l>%d<w>)";
+            logger.warningf(pattern.expandTags, e.msg, e.file, e.line);
             version(PrintStacktraces) logger.trace(e);
         }
     }
@@ -3123,12 +3120,12 @@ int run(string[] args)
             static if (__VERSION__ >= 2087L)
             {
                 immutable allocated = stats.allocatedInCurrentThread;
-                enum pattern = "Allocated in current thread: %s%,d%s bytes";
-                logger.infof(pattern, Tint.log, allocated, Tint.info);
+                enum pattern = "Allocated in current thread: <l>%,d<%i> bytes";
+                logger.infof(pattern.expandTags, allocated);
             }
 
-            enum memoryUsedPattern = "Memory used: %s%,d%s bytes, free: %1$s%4$,d%3$s bytes";
-            logger.infof(memoryUsedPattern, Tint.log, stats.usedSize, Tint.info, stats.freeSize);
+            enum memoryUsedPattern = "Memory used: <l>%,d<i> bytes, free <l>%,d<i> bytes";
+            logger.infof(memoryUsedPattern.expandTags, stats.usedSize, stats.freeSize);
         }
 
         if (*instance.abort)

--- a/source/kameloso/plugins/admin/base.d
+++ b/source/kameloso/plugins/admin/base.d
@@ -25,7 +25,7 @@ debug import kameloso.plugins.admin.debugging;
 import kameloso.plugins.common.core;
 import kameloso.plugins.common.misc : applyCustomSettings;
 import kameloso.plugins.common.awareness;
-import kameloso.common : Tint, logger;
+import kameloso.common : expandTags, logger;
 import kameloso.constants : BufferSize;
 import kameloso.irccolours : IRCColour, ircBold, ircColour, ircColourByHash;
 import kameloso.messaging;
@@ -1242,8 +1242,8 @@ void onBusMessage(AdminPlugin plugin, const string header, shared Sendable conte
 
         if (slice.length)
         {
-            enum pattern = "Reloading plugin \"%s%s%s\".";
-            logger.logf(pattern, Tint.info, slice, Tint.log);
+            enum pattern = `Reloading plugins "<i>%s<l>".`;
+            logger.logf(pattern.expandTags, slice);
         }
         else
         {

--- a/source/kameloso/plugins/admin/classifiers.d
+++ b/source/kameloso/plugins/admin/classifiers.d
@@ -18,7 +18,7 @@ private:
 import kameloso.plugins.admin.base;
 
 import kameloso.plugins.common.misc : nameOf;
-import kameloso.common : Tint, logger;
+import kameloso.common : Tint, expandTags, logger;
 import kameloso.irccolours : IRCColour, ircBold, ircColour, ircColourByHash;
 import kameloso.messaging;
 import dialect.defs;
@@ -208,8 +208,8 @@ in (list.among!("whitelist", "blacklist", "operator", "staff"),
             final switch (result)
             {
             case success:
-                enum pattern = "Added %s%s%s as %s in %s.";
-                logger.logf(pattern, Tint.info, id, Tint.log, asWhat, channel);
+                enum pattern = "Added <i>%s<l> as %s in %s.";
+                logger.logf(pattern.expandTags, id, asWhat, channel);
                 break;
 
             case noSuchAccount:
@@ -217,8 +217,8 @@ in (list.among!("whitelist", "blacklist", "operator", "staff"),
                 assert(0, "Invalid enlist-only `AlterationResult` passed to `lookupEnlist.report`");
 
             case alreadyInList:
-                enum pattern = "%s%s%s is already %s in %s.";
-                logger.logf(pattern, Tint.info, id, Tint.log, asWhat, channel);
+                enum pattern = "<i>%s<l> is already %s in %s.";
+                logger.logf(pattern.expandTags, id, asWhat, channel);
                 break;
             }
         }
@@ -439,18 +439,18 @@ in (list.among!("whitelist", "blacklist", "operator", "staff"),
             assert(0, "Invalid enlist-only `AlterationResult` returned to `delist`");
 
         case noSuchAccount:
-            enum pattern = "No such account %s%s%s was found as %s in %s.";
-            logger.logf(pattern, Tint.info, account, Tint.log, asWhat, channel);
+            enum pattern = "No such account <i>%s<l> was found as %s in %s.";
+            logger.logf(pattern.expandTags, account, asWhat, channel);
             break;
 
         case noSuchChannel:
-            enum pattern = "Account %s%s%s isn't %s in %s.";
-            logger.logf(pattern, Tint.info, account, Tint.log, asWhat, channel);
+            enum pattern = "Account <i>%s<l> isn't %s in %s.";
+            logger.logf(pattern.expandTags, account, asWhat, channel);
             break;
 
         case success:
-            enum pattern = "Removed %s%s%s as %s in %s";
-            logger.logf(pattern, Tint.info, account, Tint.log, asWhat, channel);
+            enum pattern = "Removed <i>%s<l> as %s in %s.";
+            logger.logf(pattern.expandTags, account, asWhat, channel);
             break;
         }
     }
@@ -631,9 +631,9 @@ in (mask.length, "Tried to add an empty hostmask definition")
         {
             if (event == IRCEvent.init)
             {
-                enum pattern = `Invalid hostmask: "%s%s%s"; must be in the form ` ~
-                    `"%1$snickname!ident@address%3$s".`;
-                logger.warningf(pattern, Tint.log, mask, Tint.warning);
+                enum pattern = `Invalid hostmask "<l>%s<w>"; must be in the form ` ~
+                    `"<l>nickname!ident@address<w>".`;
+                logger.warningf(pattern.expandTags, mask);
             }
             else
             {
@@ -650,12 +650,11 @@ in (mask.length, "Tried to add an empty hostmask definition")
         // Remove any placeholder example since there should now be at least one true entry
         aa.remove(examplePlaceholderKey);
 
-        immutable colouredAccount = colourByHash(account, brightFlag);
-
         if (event == IRCEvent.init)
         {
-            enum pattern = `Added hostmask "%s%s%s", mapped to account %4$s%3$s.`;
-            logger.infof(pattern, Tint.log, mask, Tint.info, colouredAccount);
+            immutable colouredAccount = colourByHash(account, brightFlag);
+            enum pattern = `Added hostmask "<l>%s<i>", mapped to account <l>%s.`;
+            logger.infof(pattern.expandTags, mask, colouredAccount);
         }
         else
         {
@@ -675,8 +674,8 @@ in (mask.length, "Tried to add an empty hostmask definition")
 
             if (event == IRCEvent.init)
             {
-                enum pattern = `Removed hostmask "%s%s%s".`;
-                logger.infof(pattern, Tint.log, mask, Tint.info);
+                enum pattern = `Removed hostmask "<l>%s<i>".`;
+                logger.infof(pattern.expandTags, mask);
             }
             else
             {
@@ -688,8 +687,8 @@ in (mask.length, "Tried to add an empty hostmask definition")
         {
             if (event == IRCEvent.init)
             {
-                enum pattern = `No such hostmask "%s%s%s" on file.`;
-                logger.warningf(pattern, Tint.log, mask, Tint.warning);
+                enum pattern = `No such hostmask "<l>%s<w>" on file.`;
+                logger.warningf(pattern.expandTags, mask);
             }
             else
             {

--- a/source/kameloso/plugins/automode.d
+++ b/source/kameloso/plugins/automode.d
@@ -16,7 +16,7 @@ private:
 
 import kameloso.plugins.common.core;
 import kameloso.plugins.common.awareness : ChannelAwareness, UserAwareness;
-import kameloso.common : Tint, logger;
+import kameloso.common : expandTags, logger;
 import kameloso.irccolours : IRCColour, ircBold, ircColour, ircColourByHash;
 import kameloso.messaging;
 import dialect.defs;
@@ -231,9 +231,9 @@ in (account.length, "Tried to apply automodes to an empty account")
 
     if (!channel.ops.canFind(plugin.state.client.nickname))
     {
-        enum pattern = "Could not apply %s+%s%s %1$s%4$s%3$s in %1$s%5$s%3$s " ~
+        enum pattern = "Could not apply <i>+%s<l> <i>%s<l> in <i>%s<l> " ~
             "because we are not an operator in the channel.";
-        logger.logf(pattern, Tint.info, missingModes, Tint.log, nickname, channelName);
+        logger.logf(pattern.expandTags, missingModes, nickname, channelName);
         return;
     }
 

--- a/source/kameloso/plugins/common/misc.d
+++ b/source/kameloso/plugins/common/misc.d
@@ -43,7 +43,7 @@ bool applyCustomSettings(IRCPlugin[] plugins,
     const string[] customSettings,
     CoreSettings copyOfSettings)
 {
-    import kameloso.common : Tint, logger;
+    import kameloso.common : Tint, expandTags, logger;
     import lu.string : contains, nom;
     import std.conv : ConvException;
 
@@ -54,8 +54,8 @@ bool applyCustomSettings(IRCPlugin[] plugins,
     {
         if (!line.contains!(Yes.decode)('.'))
         {
-            enum pattern = `Bad %splugin%s.%1$ssetting%2$s=%1$svalue%2$s format. (%1$s%3$s%2$s)`;
-            logger.warningf(pattern, Tint.log, Tint.warning, line);
+            enum pattern = `Bad <l>plugin<w>.<l>setting<w>=<l>value<w> format. (<l>%s<w>)`;
+            logger.warningf(pattern.expandTags, line);
             noErrors = false;
             continue;
         }
@@ -78,8 +78,8 @@ bool applyCustomSettings(IRCPlugin[] plugins,
 
                 if (!success)
                 {
-                    enum pattern = "No such %score%s setting: %1$s%3$s";
-                    logger.warningf(pattern, Tint.log, Tint.warning, setting);
+                    enum pattern = "No such <l>core<w> setting: <l>%s";
+                    logger.warningf(pattern.expandTags, setting);
                     noErrors = false;
                 }
                 else
@@ -101,16 +101,16 @@ bool applyCustomSettings(IRCPlugin[] plugins,
             }
             catch (SetMemberException e)
             {
-                enum pattern = "Failed to set %score%s.%1$s%3$s%2$s: " ~
-                    "it requires a value and none was supplied";
-                logger.warningf(pattern, Tint.log, Tint.warning, setting);
+                enum pattern = "Failed to set <l>core<w>.<l>%s<w>: " ~
+                    "it requires a value and none was supplied.";
+                logger.warningf(pattern.expandTags, setting);
                 version(PrintStacktraces) logger.trace(e.info);
                 noErrors = false;
             }
             catch (ConvException e)
             {
-                enum pattern = `Invalid value for %score%s.%1$s%3$s%2$s: "%1$s%4$s%2$s"`;
-                logger.warningf(pattern, Tint.log, Tint.warning, setting, value);
+                enum pattern = `Invalid value for <l>core<w>.<l>%s<w>: "<l>%s<w>"`;
+                logger.warningf(pattern.expandTags, setting, value);
                 noErrors = false;
             }
 
@@ -131,15 +131,15 @@ bool applyCustomSettings(IRCPlugin[] plugins,
 
                     if (!success)
                     {
-                        enum pattern = "No such %s%s%s plugin setting: %1$s%4$s";
-                        logger.warningf(pattern, Tint.log, pluginstring, Tint.warning, setting);
+                        enum pattern = "No such <l>%s<w> plugin setting: <l>%s";
+                        logger.warningf(pattern.expandTags, pluginstring, setting);
                         noErrors = false;
                     }
                 }
                 catch (ConvException e)
                 {
-                    enum pattern = `Invalid value for %s%s%s.%1$s%4$s%3$s: "%1$s%5$s%3$s"`;
-                    logger.warningf(pattern, Tint.log, pluginstring, Tint.warning, setting, value);
+                    enum pattern = `Invalid value for <l>%s<w>.<l>%s<w>: "<l>%s<w>"`;
+                    logger.warningf(pattern.expandTags, pluginstring, setting, value);
                     noErrors = false;
 
                     //version(PrintStacktraces) logger.trace(e.info);
@@ -340,7 +340,7 @@ in ((fun !is null), "Tried to `enqueue` with a null function pointer")
 
     version(ExplainReplay)
     {
-        import kameloso.common : Tint, logger;
+        import kameloso.common : expandTags, logger;
         import lu.string : beginsWith;
 
         immutable callerSlice = caller.beginsWith("kameloso.plugins.") ?
@@ -360,27 +360,9 @@ in ((fun !is null), "Tried to `enqueue` with a null function pointer")
         {
             version(ExplainReplay)
             {
-                version(Colours)
-                {
-                    enum pattern = "%s%s%s plugin %6$sNOT%3$s queueing an event to be replayed " ~
-                        "on behalf of %1$s%4$s%3$s; delta time %1$s%5$d%3$s is too recent";
-
-                    logger.logf(pattern,
-                        Tint.info, plugin.name, Tint.log,
-                        callerSlice,
-                        delta,
-                        Tint.warning);
-                }
-                else
-                {
-                    enum pattern = "%s plugin NOT queueing an event to be replayed " ~
-                        "on behalf of %s; delta time %d is too recent";
-
-                    logger.logf(pattern,
-                        plugin.name,
-                        callerSlice,
-                        delta);
-                }
+                enum pattern = "<i>%s<l> plugin <w>NOT<l> queueing an event to be replayed " ~
+                    "on behalf of <i>%s<l>; delta time <i>%d<l> is too recent";
+                logger.logf(pattern.expandTags, plugin.name, callerSlice, delta);
             }
             return;
         }
@@ -388,16 +370,8 @@ in ((fun !is null), "Tried to `enqueue` with a null function pointer")
 
     version(ExplainReplay)
     {
-        version(Colours)
-        {
-            enum pattern = "%s%s%s plugin queueing an event to be replayed on behalf of %1$s%4$s%3$s";
-            logger.logf(pattern, Tint.info, plugin.name, Tint.log, callerSlice);
-        }
-        else
-        {
-            enum pattern = "%s plugin queueing an event to be replayed on behalf of %s";
-            logger.logf(pattern, plugin.name, callerSlice);
-        }
+        enum pattern = "<i>%s<l> plugin queueing an event to be replayed on behalf of <i>%s";
+        logger.logf(pattern.expandTags, plugin.name, callerSlice);
     }
 
     plugin.state.pendingReplays[user.nickname] ~=
@@ -435,76 +409,42 @@ Replay replay(Plugin, Fun)(Plugin plugin, const ref IRCEvent event,
         version(ExplainReplay)
         void explainReplay()
         {
-            import kameloso.common : Tint, logger;
+            import kameloso.common : expandTags, logger;
             import lu.string : beginsWith;
 
             immutable caller = replay.caller.beginsWith("kameloso.plugins.") ?
                 replay.caller[17..$] :
                 replay.caller;
 
-            version(Colours)
-            {
-                enum pattern = "%s%s%s replaying %1$s%4$s%3$s-level event (invoking %1$s%5$s%3$s) " ~
-                    "based on WHOIS results: user %1$s%6$s%3$s is %1$s%7$s%3$s class";
-
-                logger.logf(pattern,
-                    Tint.info, plugin.name, Tint.log,
-                    replay.permissionsRequired,
-                    caller,
-                    replay.event.sender.nickname,
-                    replay.event.sender.class_);
-            }
-            else
-            {
-                enum pattern = "%s replaying %s-level event (invoking %s) " ~
-                    "based on WHOIS results: user %s is %s class";
-
-                logger.logf(pattern,
-                    plugin.name,
-                    replay.permissionsRequired,
-                    caller,
-                    replay.event.sender.nickname,
-                    replay.event.sender.class_);
-            }
+            enum pattern = "<i>%s<l> replaying <i>%s<l>-level event (invoking <i>%s<l>) " ~
+                "based on WHOIS results; user <i>%s<l> is <i>%s<l> class";
+            logger.logf(pattern.expandTags,
+                plugin.name,
+                Enum!Permissions.toString(replay.permissionsRequired),
+                caller,
+                replay.event.sender.nickname,
+                Enum!(IRCUser.Class).toString(replay.event.sender.class_));
         }
 
         version(ExplainReplay)
         void explainRefuse()
         {
-            import kameloso.common : Tint, logger;
+            import kameloso.common : expandTags, logger;
             import lu.string : beginsWith;
 
             immutable caller = replay.caller.beginsWith("kameloso.plugins.") ?
                 replay.caller[17..$] :
                 replay.caller;
 
-            version(Colours)
-            {
-                enum pattern = "%s%s%s %8$sNOT%3$s replaying %1$s%4$s%3$s-level event " ~
-                    "(which would have invoked %1$s%5$s%3$s) " ~
-                    "based on WHOIS results: user %1$s%6$s%3$s is insufficient %1$s%7$s%3$s class";
-
-                logger.logf(pattern,
-                    Tint.info, plugin.name, Tint.log,
-                    replay.permissionsRequired,
-                    caller,
-                    replay.event.sender.nickname,
-                    replay.event.sender.class_,
-                    Tint.warning);
-            }
-            else
-            {
-                enum pattern = "%s NOT replaying %s-level event " ~
-                    "(which would have invoked %s) " ~
-                    "based on WHOIS results: user %s is insufficient %s class";
-
-                logger.logf(pattern,
-                    plugin.name,
-                    replay.permissionsRequired,
-                    caller,
-                    replay.event.sender.nickname,
-                    replay.event.sender.class_);
-            }
+            enum pattern = "<i>%s<l> plugin <w>NOT<l> replaying <i>%s<l>-level event " ~
+                "(which would have invoked <i>%s<l>) " ~
+                "based on WHOIS results: user <i>%s<l> is <i>%s<l> class";
+            logger.logf(pattern.expandTags,
+                plugin.name,
+                Enum!Permissions.toString(replay.permissionsRequired),
+                caller,
+                replay.event.sender.nickname,
+                Enum!(IRCUser.Class).toString(replay.event.sender.class_));
         }
 
         with (Permissions)

--- a/source/kameloso/plugins/help.d
+++ b/source/kameloso/plugins/help.d
@@ -90,7 +90,6 @@ void onCommandHelp(HelpPlugin plugin, const /*ref*/ IRCEvent event)
         import kameloso.irccolours : ircBold;
         import lu.string : beginsWith, contains, nom;
         import std.algorithm.sorting : sort;
-        import std.array : array;
         import std.format : format;
         import std.typecons : No, Yes;
 
@@ -184,7 +183,10 @@ void onCommandHelp(HelpPlugin plugin, const /*ref*/ IRCEvent event)
 
                     enum width = 12;
                     enum pattern = "* %-*s %-([%s]%| %)";
-                    const keys = nonhiddenCommands.keys.sort.array;
+                    const keys = nonhiddenCommands
+                        .keys
+                        .sort
+                        .release;
 
                     immutable message = plugin.state.settings.colouredOutgoing ?
                         pattern.format(width, specifiedPlugin.ircBold, keys) :
@@ -228,7 +230,10 @@ void onCommandHelp(HelpPlugin plugin, const /*ref*/ IRCEvent event)
 
                 enum width = 12;
                 enum pattern = "* %-*s %-([%s]%| %)";
-                const keys = nonhiddenCommands.keys.sort.array;
+                const keys = nonhiddenCommands
+                    .keys
+                    .sort
+                    .release;
 
                 immutable message = plugin.state.settings.colouredOutgoing ?
                     pattern.format(width, pluginName.ircBold, keys) :

--- a/source/kameloso/plugins/notes.d
+++ b/source/kameloso/plugins/notes.d
@@ -15,7 +15,7 @@ private:
 
 import kameloso.plugins.common.core;
 import kameloso.plugins.common.awareness : MinimalAuthentication;
-import kameloso.common : Tint, logger;
+import kameloso.common : expandTags, logger;
 import kameloso.irccolours : ircBold, ircColourByHash;
 import kameloso.messaging;
 import dialect.defs;
@@ -106,7 +106,7 @@ void playbackNotes(NotesPlugin plugin,
     const string givenChannel,
     const Flag!"background" background = No.background)
 {
-    import kameloso.common : timeSince;
+    import kameloso.common : Tint, timeSince;
     import dialect.common : toLowerCase;
     import std.datetime.systime : Clock;
     import std.exception : ErrnoException;
@@ -193,8 +193,8 @@ void playbackNotes(NotesPlugin plugin,
             catch (JSONException e)
             {
                 enum pattern = "Failed to fetch, replay and clear notes for " ~
-                    "%s%s%s on %1$s%4$s%3$s: %1$s%5$s";
-                logger.errorf(pattern, Tint.log, id, Tint.error,
+                    "<l>%s<e> on <l>%s<e>: <l>%s";
+                logger.errorf(pattern.expandTags, id,
                     (channelName.length ? channelName : "<no channel>"), e.msg);
 
                 if (e.msg == "JSONValue is not an object")

--- a/source/kameloso/plugins/pipeline.d
+++ b/source/kameloso/plugins/pipeline.d
@@ -22,7 +22,7 @@ version(WithPipelinePlugin):
 private:
 
 import kameloso.plugins.common.core;
-import kameloso.common : Tint, logger;
+import kameloso.common : expandTags, logger;
 import kameloso.messaging;
 import kameloso.thread : ThreadMessage;
 import dialect.defs;
@@ -414,20 +414,20 @@ in (!plugin.workerRunning, "Tried to double-initialise the pipereader")
     }
     catch (ReturnValueException e)
     {
-        enum pattern = "Failed to initialise Pipeline plugin: %s (%s%s%s returned %2$s%5$d%4$s)";
-        logger.warningf(pattern, e.msg, Tint.log, e.command, Tint.warning, e.retval);
+        enum pattern = "Failed to initialise the Pipeline plugin: <l>%s<w> (<l>%s<w> returned <l>%d<w>)";
+        logger.warningf(pattern.expandTags, e.msg, e.command, e.retval);
         //version(PrintStacktraces) logger.trace(e.info);
     }
     catch (FileExistsException e)
     {
-        enum pattern = "Failed to initialise Pipeline plugin: %s [%s%s%s]";
-        logger.warningf(pattern, e.msg, Tint.log, e.filename, Tint.warning);
+        enum pattern = "Failed to initialise the Pipeline plugin: <l>%s<w> [<l>%s<w>]";
+        logger.warningf(pattern.expandTags, e.msg, e.filename);
         //version(PrintStacktraces) logger.trace(e.info);
     }
     catch (FileTypeMismatchException e)
     {
-        enum pattern = "Failed to initialise Pipeline plugin: %s [%s%s%s]";
-        logger.warningf(pattern, e.msg, Tint.log, e.filename, Tint.warning);
+        enum pattern = "Failed to initialise the Pipeline plugin: <l>%s<w> [<l>%s<w>]";
+        logger.warningf(pattern.expandTags, e.msg, e.filename);
         //version(PrintStacktraces) logger.trace(e.info);
     }
 

--- a/source/kameloso/plugins/printer/base.d
+++ b/source/kameloso/plugins/printer/base.d
@@ -487,7 +487,7 @@ void commitAllLogs(PrinterPlugin plugin)
 )
 void onISUPPORT(PrinterPlugin plugin)
 {
-    import kameloso.common : Tint, logger;
+    import kameloso.common : expandTags, logger;
 
     if (plugin.printedISUPPORT || !plugin.state.server.network.length)
     {
@@ -497,11 +497,9 @@ void onISUPPORT(PrinterPlugin plugin)
 
     plugin.printedISUPPORT = true;
 
-    enum pattern = "Detected %s%s%s running daemon %s%s%s (%s)";
-    logger.logf(pattern,
-        Tint.info, plugin.state.server.network, Tint.log,
-        Tint.info, plugin.state.server.daemon,
-        Tint.off, plugin.state.server.daemonstring);
+    enum pattern = "Detected <i>%s<l> running daemon <i>%s<l> (<i>%s<l>)";
+    logger.logf(pattern.expandTags, plugin.state.server.network,
+        plugin.state.server.daemon, plugin.state.server.daemonstring);
 }
 
 

--- a/source/kameloso/plugins/printer/logging.d
+++ b/source/kameloso/plugins/printer/logging.d
@@ -103,7 +103,7 @@ public:
 void onLoggableEventImpl(PrinterPlugin plugin, const ref IRCEvent event)
 {
     import kameloso.plugins.printer.formatting : formatMessageMonochrome;
-    import kameloso.common : Tint, logger;
+    import kameloso.common : Tint, expandTags, logger;
     import std.typecons : Flag, No, Yes;
 
     if (!plugin.printerSettings.logs) return;
@@ -307,15 +307,15 @@ void onLoggableEventImpl(PrinterPlugin plugin, const ref IRCEvent event)
                 import kameloso.common : errnoStrings;
                 import core.stdc.errno : errno;
 
-                enum pattern = "ErrnoException (%s%s%s) caught when writing to log: %1$s%4$s";
-                logger.warningf(pattern, Tint.log, errnoStrings[errno], Tint.warning, e.msg);
+                enum pattern = "ErrnoException (<l>%s<w>) caught when writing to log: <l>%s";
+                logger.warningf(pattern.expandTags, errnoStrings[errno], e.msg);
             }
             else version(Windows)
             {
                 import core.stdc.errno : errno;
 
-                enum pattern = "ErrnoException (%s%ds%s) caught when writing to log: %1$s%4$s";
-                logger.warningf(pattern, Tint.log, errno, Tint.warning, e.msg);
+                enum pattern = "ErrnoException (<l>%d<w>) caught when writing to log: <l>%s";
+                logger.warningf(pattern.expandTags, errno, e.msg);
             }
             else
             {
@@ -462,7 +462,7 @@ void onLoggableEventImpl(PrinterPlugin plugin, const ref IRCEvent event)
  +/
 bool establishLogLocation(PrinterPlugin plugin, const string logLocation)
 {
-    import kameloso.common : Tint, logger;
+    import kameloso.common : Tint, expandTags, logger;
     import std.file : exists, isDir;
 
     if (logLocation.exists)
@@ -471,8 +471,8 @@ bool establishLogLocation(PrinterPlugin plugin, const string logLocation)
 
         if (!plugin.naggedAboutDir)
         {
-            enum pattern = "Specified log directory (%s%s%s) is not a directory.";
-            logger.warningf(pattern, Tint.log, logLocation, Tint.warning);
+            enum pattern = "Specified log directory (<l>%s<w>) is not a directory.";
+            logger.warningf(pattern.expandTags, logLocation);
             plugin.naggedAboutDir = true;
         }
 
@@ -531,7 +531,7 @@ void commitAllLogsImpl(PrinterPlugin plugin)
  +/
 void commitLog(PrinterPlugin plugin, ref LogLineBuffer buffer)
 {
-    import kameloso.common : Tint, logger;
+    import kameloso.common : expandTags, logger;
     import std.exception : ErrnoException;
     import std.file : FileException;
     import std.utf : UTFException;
@@ -572,8 +572,8 @@ void commitLog(PrinterPlugin plugin, ref LogLineBuffer buffer)
     }
     catch (FileException e)
     {
-        enum pattern = "File exception caught when committing log %s%s%s: %1$s%4$s%5$s";
-        logger.warningf(pattern, Tint.log, buffer.file, Tint.warning, e.msg, plugin.bell);
+        enum pattern = "File exception caught when committing log <l>%s<w>: <l>%s%s";
+        logger.warningf(pattern.expandTags, buffer.file, e.msg, plugin.bell);
         version(PrintStacktraces) logger.trace(e.info);
     }
     catch (ErrnoException e)
@@ -581,25 +581,22 @@ void commitLog(PrinterPlugin plugin, ref LogLineBuffer buffer)
         version(Posix)
         {
             import kameloso.common : errnoStrings;
-            enum pattern = "ErrnoException %s%s%s caught when committing " ~
-                "log to %1$s%4$s%3$s: %1$s%5$s%6$s";
-            logger.warningf(pattern, Tint.log, errnoStrings[e.errno], Tint.warning,
+            enum pattern = "ErrnoException <l>%s<w> caught when committing log to <l>%s<w>: <l>%s%s";
+            logger.warningf(pattern.expandTags, errnoStrings[e.errno],
                 buffer.file, e.msg, plugin.bell);
         }
         else
         {
-            enum pattern = "ErrnoException %s%d%s caught when committing " ~
-                "log to %1$s%4$s%3$s: %1$s%5$s%6$s";
-            logger.warningf(pattern, Tint.log, e.errno, Tint.warning,
-                buffer.file, e.msg, plugin.bell);
+            enum pattern = "ErrnoException <l>%d<w> caught when committing log to <l>%s<w>: <l>%s%s";
+            logger.warningf(pattern.expandTags, e.errno, buffer.file, e.msg, plugin.bell);
         }
 
         version(PrintStacktraces) logger.trace(e.info);
     }
     catch (Exception e)
     {
-        enum pattern = "Unexpected exception caught when committing log %s%s%s: %1$s%4$s%5$s";
-        logger.warningf(pattern, Tint.log, buffer.file, Tint.warning, e.msg, plugin.bell);
+        enum pattern = "Unexpected exception caught when committing log <l>%s<w>: <l>%s%s";
+        logger.warningf(pattern.expandTags, buffer.file, e.msg, plugin.bell);
         version(PrintStacktraces) logger.trace(e);
     }
 }

--- a/source/kameloso/plugins/quotes.d
+++ b/source/kameloso/plugins/quotes.d
@@ -18,7 +18,7 @@ private:
 
 import kameloso.plugins.common.core;
 import kameloso.plugins.common.awareness : UserAwareness;
-import kameloso.common : Tint, logger;
+import kameloso.common : expandTags, logger;
 import kameloso.messaging;
 import dialect.defs;
 import lu.json : JSONStorage;
@@ -246,8 +246,8 @@ in (rawLine.length, "Tried to add an empty quote")
     }
     catch (JSONException e)
     {
-        enum pattern = "Could not add quote for %s%s%s: %1$s%4$s";
-        logger.errorf(pattern, Tint.log, id, Tint.error, e.msg);
+        enum pattern = "Could not add quote for <l>%s<e>: <l>%s";
+        logger.errorf(pattern.expandTags, id, e.msg);
         version(PrintStacktraces) logger.trace(e.info);
     }
 }
@@ -333,8 +333,8 @@ void modQuoteAndReport(QuotesPlugin plugin,
     }
     catch (JSONException e)
     {
-        enum pattern = "Could not remove quote for %s%s%s: %1$s%4$s";
-        logger.errorf(pattern, Tint.log, id, Tint.error, e.msg);
+        enum pattern = "Could not remove quote for <l>%s<e>: <l>%s";
+        logger.errorf(pattern.expandTags, id, e.msg);
         version(PrintStacktraces) logger.trace(e.info);
     }
 }
@@ -750,8 +750,8 @@ void manageQuoteImpl(QuotesPlugin plugin,
     }
     catch (JSONException e)
     {
-        enum pattern = "Could not quote %s%s%s: %1$s%4$s";
-        logger.errorf(pattern, Tint.log, specified, Tint.error, e.msg);
+        enum pattern = "Could not quote <l>%s<e>: <l>%s";
+        logger.errorf(pattern.expandTags, specified, e.msg);
         version(PrintStacktraces) logger.trace(e.info);
     }
 }

--- a/source/kameloso/plugins/seen.d
+++ b/source/kameloso/plugins/seen.d
@@ -48,8 +48,8 @@ private import dialect.defs;
 // [kameloso.irccolours] for some IRC colouring and formatting.
 private import kameloso.irccolours : ircBold, ircColourByHash;
 
-// [kameloso.common] for some globals.
-private import kameloso.common : Tint, logger;
+// [kameloso.common] for some globals and helpers.
+private import kameloso.common : expandTags, logger;
 
 // [std.datetime.systime] for the [std.datetime.systime.Clock|Clock], to update times with.
 private import std.datetime.systime : Clock;
@@ -1010,8 +1010,8 @@ long[string] loadSeen(const string filename)
 
     if (!filename.exists || !filename.isFile)
     {
-        enum pattern = "%s%s%s does not exist or is not a file";
-        logger.warningf(pattern, Tint.log, filename, Tint.warning);
+        enum pattern = "<l>%s<w> does not exist or is not a file";
+        logger.warningf(pattern.expandTags, filename);
         return aa;
     }
 
@@ -1027,6 +1027,7 @@ long[string] loadSeen(const string filename)
     }
     catch (JSONException e)
     {
+        import kameloso.common : Tint;
         logger.error("Could not load seen JSON from file: ", Tint.log, e.msg);
         version(PrintStacktraces) logger.trace(e.info);
     }
@@ -1113,8 +1114,8 @@ void onWelcome(SeenPlugin plugin)
 
         // Reports statistics on how many users are registered as having been seen
 
-        enum pattern = "Currently %s%d%s %s seen.";
-        logger.logf(pattern, Tint.info, plugin.seenUsers.length, Tint.log,
+        enum pattern = "Currently <i>%d<l> %s seen.";
+        logger.logf(pattern.expandTags, plugin.seenUsers.length,
             plugin.seenUsers.length.plurality("user", "users"));
     }
 

--- a/source/kameloso/plugins/services/chanqueries.d
+++ b/source/kameloso/plugins/services/chanqueries.d
@@ -311,13 +311,13 @@ void startChannelQueries(ChanQueriesService service)
 
                         if (++consecutiveUnknownCommands >= maxConsecutiveUnknownCommands)
                         {
-                            import kameloso.common : Tint;
+                            import kameloso.common : expandTags;
 
                             // Cannot WHOIS on this server (assume)
                             logger.error("Error: This server does not seem " ~
                                 "to support user accounts?");
-                            enum pattern = "Consider enabling %sCore%s.%1$spreferHostmasks%2$s.";
-                            logger.errorf(pattern, Tint.log, Tint.warning);
+                            enum pattern = "Consider enabling <l>Core<e>.<l>preferHostmasks<e>.";
+                            logger.error(pattern.expandTags);
                             service.serverSupportsWHOIS = false;
                             return;
                         }

--- a/source/kameloso/plugins/services/persistence.d
+++ b/source/kameloso/plugins/services/persistence.d
@@ -592,9 +592,9 @@ void reloadHostmasksFromDisk(PersistenceService service)
         }
         catch (FormatException e)
         {
-            import kameloso.common : Tint, logger;
-            enum pattern = "Malformed hostmask in %s%s%s: %1$s%4$s";
-            logger.warningf(pattern, Tint.log, service.hostmasksFile, Tint.warning, hostmask);
+            import kameloso.common : expandTags, logger;
+            enum pattern =`Malformed hostmask in <l>%s<w>: "<l>%s<w>"`;
+            logger.warningf(pattern.expandTags, service.hostmasksFile, hostmask);
         }
     }
 }

--- a/source/kameloso/plugins/twitchbot/api.d
+++ b/source/kameloso/plugins/twitchbot/api.d
@@ -65,9 +65,9 @@ if (isSomeFunction!dg)
     }
     catch (TwitchQueryException e)
     {
-        import kameloso.common : Tint, curlErrorStrings, logger;
-        enum pattern = "Failed to query Twitch: %s (%s%s%s) (%2$s%5$s%4$s)";
-        logger.errorf(pattern, e.msg, Tint.log, e.error, Tint.error, curlErrorStrings[e.errorCode]);
+        import kameloso.common : curlErrorStrings, expandTags, logger;
+        enum pattern = "Failed to query Twitch: <l>%s<e> (<l>%s<e>) (<l>%s<e>)";
+        logger.errorf(pattern.expandTags, e.msg, e.error, curlErrorStrings[e.errorCode]);
     }
 }
 

--- a/source/kameloso/plugins/twitchbot/base.d
+++ b/source/kameloso/plugins/twitchbot/base.d
@@ -203,11 +203,11 @@ void onUserstate(const ref IRCEvent event)
     if (!event.target.badges.contains("moderator/") &&
         !event.target.badges.contains("broadcaster/"))
     {
-        import kameloso.common : Tint;
+        import kameloso.common : expandTags;
 
-        enum pattern = "The bot is not a moderator of home channel %s%s%s. " ~
+        enum pattern = "The bot is not a moderator of home channel <l>%s<w>. " ~
             "Consider elevating it to such to avoid being as rate-limited.";
-        logger.warningf(pattern, Tint.log, event.channel, Tint.warning);
+        logger.warningf(pattern.expandTags, event.channel);
     }
 }
 
@@ -1019,7 +1019,7 @@ void onEndOfMOTD(TwitchBotPlugin plugin)
 
         void validationDg()
         {
-            import kameloso.common : Tint;
+            import kameloso.common : expandTags;
             import lu.string : plurality;
             import std.conv : to;
             import std.datetime.systime : Clock, SysTime;
@@ -1075,17 +1075,17 @@ void onEndOfMOTD(TwitchBotPlugin plugin)
                 {
                     // More than a week away, just .info
                     enum pattern = "Your Twitch authorisation key will expire " ~
-                        "in %s%d days%s on %1$s%4$02d-%5$02d-%6$02d%3$s.";
-                    logger.infof(pattern, Tint.log, numDays, Tint.info,
+                        "in <l>%d days<i> on <l>%4d-%02d-%02d<i>.";
+                    logger.infof(pattern.expandTags, numDays,
                         expiresWhen.year, expiresWhen.month, expiresWhen.day);
                 }
                 else if (delta > 1.days)
                 {
                     // A week or less, more than a day; warning
                     enum pattern = "Warning: Your Twitch authorisation key will expire " ~
-                        "in %s%d %s%s on %1$s%5$02d-%6$02d-%7$02d %8$02d:%9$02d3$%s.";
-                    logger.warningf(pattern, Tint.log, numDays,
-                        numDays.plurality("day", "days"), Tint.warning,
+                        "in <l>%d %s<w> on <l>%4d-%02d-%02d %02d:%02d<w>.";
+                    logger.warningf(pattern.expandTags,
+                        numDays, numDays.plurality("day", "days"),
                         expiresWhen.year, expiresWhen.month, expiresWhen.day,
                         expiresWhen.hour, expiresWhen.minute);
                 }
@@ -1093,10 +1093,10 @@ void onEndOfMOTD(TwitchBotPlugin plugin)
                 {
                     // Less than a day; warning
                     immutable numHours = delta.total!"hours";
-                    enum pattern = "Warning: Your Twitch authorisation key will expire " ~
-                        "in %s%d %s%s at %5$02d:%6$02d3$%s.";
-                    logger.warningf(pattern, Tint.log, numHours,
-                        numHours.plurality("hour", "hours"), Tint.warning,
+                    enum pattern = "WARNING: Your Twitch authorisation key will expire " ~
+                        "in <l>%d %s<w> at <l>%02d:%02d<w>.";
+                    logger.warningf(pattern.expandTags,
+                        numHours, numHours.plurality("hour", "hours"),
                         expiresWhen.hour, expiresWhen.minute);
                 }
             }
@@ -1106,15 +1106,15 @@ void onEndOfMOTD(TwitchBotPlugin plugin)
                 import etc.c.curl : CurlError;
 
                 // Something is deeply wrong.
-                enum pattern = "Failed to validate Twitch API keys: %s (%s%s%s) (%2$s%5$s%4$s)";
-                logger.errorf(pattern, e.msg, Tint.log, e.error, Tint.error, curlErrorStrings[e.errorCode]);
+                enum pattern = "Failed to validate Twitch API keys: <l>%s<e> (<l>%s<e>) (<l>%s<e>)";
+                logger.errorf(pattern.expandTags, e.msg, e.error, curlErrorStrings[e.errorCode]);
 
                 if (e.errorCode == CurlError.ssl_cacert)
                 {
                     // Peer certificate cannot be authenticated with given CA certificates
                     enum caBundlePattern = "You may need to supply a CA bundle file " ~
-                        "(e.g. %scacert.pem%s) in the configuration file.";
-                    logger.errorf(caBundlePattern, Tint.log, Tint.error);
+                        "(e.g. <l>cacert.pem<e>) in the configuration file.";
+                    logger.error(caBundlePattern.expandTags);
                 }
 
                 logger.error("Disabling API features.");

--- a/source/kameloso/plugins/twitchbot/keygen.d
+++ b/source/kameloso/plugins/twitchbot/keygen.d
@@ -32,7 +32,7 @@ package:
  +/
 void generateKey(TwitchBotPlugin plugin)
 {
-    import kameloso.common : Tint, logger;
+    import kameloso.common : expandTags, logger;
     import kameloso.thread : ThreadMessage;
     import lu.string : contains, nom, stripped;
     import std.process : Pid, ProcessException, wait;
@@ -52,17 +52,17 @@ void generateKey(TwitchBotPlugin plugin)
 Attempting to open a Twitch login page in your default web browser. Follow the
 instructions and log in to authorise the use of this program with your account.
 
-%1$sThen paste the address of the page you are redirected to afterwards here.%2$s
+<l>Then paste the address of the page you are redirected to afterwards here.</>
 
-* The redirected address should start with %3$shttp://localhost%2$s.
-* It will probably say "%1$sthis site can't be reached%2$s".
+* The redirected address should start with <i>http://localhost</>.
+* It will probably say "<l>this site can't be reached</>".
 * If your browser is already logged in on Twitch, it will likely immediately
   lead you to this page without asking for login credentials. If you want to
   generate a key for a different account, first log out and retry.
-* If you are running local web server on port %3$s80%2$s, you may have to
+* If you are running local web server on port <i>80</>, you may have to
   temporarily disable it for this to work.
 `;
-    writefln(attemptToOpenPattern, Tint.log, Tint.off, Tint.info);
+    writeln(attemptToOpenPattern.expandTags);
 
     static immutable scopes =
     [
@@ -126,17 +126,16 @@ instructions and log in to authorise the use of this program with your account.
 
     void printManualURL()
     {
-        enum scissors = "8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8<";
         enum copyPastePattern = `
-%1$sCopy and paste this link manually into your browser, and log in as asked:%2$s
+<l>Copy and paste this link manually into your browser, and log in as asked:
 
-%3$s%4$s%2$s
+<i>8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8<</>
 
-%5$s
+%s
 
-%3$s%4$s%2$s
+<i>8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8<</>
 `;
-        writefln(copyPastePattern, Tint.log, Tint.off, Tint.info, scissors, url);
+        writefln(copyPastePattern.expandTags, url);
     }
 
     if (plugin.state.settings.force)
@@ -219,10 +218,10 @@ instructions and log in to authorise the use of this program with your account.
     {
         import std.stdio : writef;
 
-        enum pattern = "%1$sPaste the addresss of the page you were redirected to here (empty line exits):%2$s
+        enum pattern = "<l>Paste the addresss of the page you were redirected to here (empty line exits):</>
 
 > ";
-        writef(pattern, Tint.log, Tint.off);
+        write(pattern.expandTags);
         stdout.flush();
 
         stdin.flush();
@@ -261,10 +260,10 @@ instructions and log in to authorise the use of this program with your account.
     plugin.state.updates |= typeof(plugin.state.updates).bot;
 
     enum keyPattern = "
-%1$sYour private authorisation key is: %2$s%3$s%4$s
-It should be entered as %2$spass%4$s under %2$s[IRCBot]%4$s.
+<l>Your private authorisation key is: <i>%s</>
+It should be entered as <i>pass</> under <i>[IRCBot]</>.
 ";
-    writefln(keyPattern, Tint.log, Tint.info, key, Tint.off);
+    writefln(keyPattern.expandTags, key);
 
     if (!plugin.state.settings.saveOnExit)
     {
@@ -282,20 +281,20 @@ It should be entered as %2$spass%4$s under %2$s[IRCBot]%4$s.
         }
         else
         {
-            enum keyAddPattern = "\n* Make sure to add it to %s%s%s, then.";
-            writefln(keyAddPattern, Tint.info, plugin.state.settings.configFile, Tint.off);
+            enum keyAddPattern = "\n* Make sure to add it to <i>%s</>, then.";
+            writefln(keyAddPattern.expandTags, plugin.state.settings.configFile);
         }
     }
 
     enum issuePattern = "
 --------------------------------------------------------------------------------
 
-All done! Restart the program (without %1$s--set twitchbot.keygen%2$s) and it should
+All done! Restart the program (without <i>--set twitchbot.keygen</>) and it should
 just work. If it doesn't, please file an issue at:
 
-    %1$shttps://github.com/zorael/kameloso/issues/new%2$s
+    <i>https://github.com/zorael/kameloso/issues/new</>
 
-%3$sNote: keys are valid for 60 days, after which this process needs to be repeated.%2$s
+<l>Note: keys are valid for 60 days, after which this process needs to be repeated.</>
 ";
-    writefln(issuePattern, Tint.info, Tint.off, Tint.log);
+    writeln(issuePattern.expandTags);
 }


### PR DESCRIPTION
This changes colouring from using the the quite frankly unreadable format specifier `Tint`ing to using custom colour `<tags>`.

```d
enum pattern = "IRC Parse Exception: %s%s%s (at %1$s%4$s%3$s:%1$s%5$d%3$s)";
logger.warningf(pattern, Tint.log, e.msg, Tint.warning, e.file, e.line);
```

...becomes...

```d
enum pattern = "IRC Parse Exception: <l>%s<w> (at <l>%s<w>:<l>%d<w>)";
logger.warningf(pattern.expandTags, e.msg, e.file, e.line);
```

Where the lowercase letter in the `<tag>` correlates to a `std.experimental.LogLevel`, the same way we've been using them with `kameloso.common.Tint` so far. `<i>` is `LogLevel.info`, `<w>` is `LogLevel.warning`, `</>` is `LogLevel.off`, etc.

The immediate advantage of this is that things become considerably more legible. Mistakes are easier to spot. The immediate disadvantage is that all our coloured output is now untested overnight and may have things like format specifier/parameter mismatches. It's hard to test.

Compile-time memory use went down slightly at least, so there's at least that.