### PR TITLE
Flattened `ThreadMessage`s

### DIFF
--- a/source/kameloso/main.d
+++ b/source/kameloso/main.d
@@ -631,7 +631,7 @@ void messageFiber(ref Kameloso instance)
 
             if (instance.settings.headless) return;
 
-            with (ThreadMessage.TerminalOutput)
+            with (OutputRequest.Level)
             final switch (request.logLevel)
             {
             case writeln:

--- a/source/kameloso/messaging.d
+++ b/source/kameloso/messaging.d
@@ -1080,7 +1080,7 @@ void askToOutputImpl(string logLevel)(IRCPluginState state, const string line)
     import kameloso.thread : OutputRequest, ThreadMessage;
     import std.concurrency : prioritySend;
 
-    mixin("state.mainThread.prioritySend(OutputRequest(ThreadMessage.TerminalOutput.", logLevel, ", line));");
+    mixin("state.mainThread.prioritySend(OutputRequest(OutputRequest.Level.", logLevel, ", line));");
 }
 
 
@@ -1113,7 +1113,7 @@ unittest
     state.askToWarn("warning");
     state.askToError("error");
 
-    alias T = ThreadMessage.TerminalOutput;
+    alias T = OutputRequest.Level;
 
     static immutable T[6] expectedLevels =
     [

--- a/source/kameloso/plugins/admin/base.d
+++ b/source/kameloso/plugins/admin/base.d
@@ -345,7 +345,6 @@ in (rawChannel.length, "Tried to add a home but the channel string was empty")
 
     if (existingChannelIndex != -1)
     {
-        import kameloso.thread : ThreadMessage, busMessage;
         import std.algorithm.mutation : SwapStrategy, remove;
 
         logger.info("We're already in this channel as a guest. Cycling.");
@@ -812,10 +811,10 @@ void onCommandAuth(AdminPlugin plugin)
         if (plugin.state.server.daemon == IRCServer.Daemon.twitch) return;
     }
 
-    import kameloso.thread : ThreadMessage, busMessage;
+    import kameloso.thread : ThreadMessage, sendable;
     import std.concurrency : send;
 
-    plugin.state.mainThread.send(ThreadMessage.busMessage("connect", busMessage("auth")));
+    plugin.state.mainThread.send(ThreadMessage.busMessage("connect", sendable("auth")));
 }
 
 

--- a/source/kameloso/plugins/admin/base.d
+++ b/source/kameloso/plugins/admin/base.d
@@ -619,7 +619,7 @@ void onCommandReload(AdminPlugin plugin, const ref IRCEvent event)
         "Reloading plugins.";
 
     privmsg(plugin.state, event.channel, event.sender.nickname, message);
-    plugin.state.mainThread.send(ThreadMessage.Reload(), event.content);
+    plugin.state.mainThread.send(ThreadMessage.Reload(event.content));
 }
 
 
@@ -815,7 +815,7 @@ void onCommandAuth(AdminPlugin plugin)
     import kameloso.thread : ThreadMessage, busMessage;
     import std.concurrency : send;
 
-    plugin.state.mainThread.send(ThreadMessage.BusMessage(), "connect", busMessage("auth"));
+    plugin.state.mainThread.send(ThreadMessage.BusMessage("connect", busMessage("auth")));
 }
 
 
@@ -1255,7 +1255,7 @@ void onBusMessage(AdminPlugin plugin, const string header, shared Sendable conte
             logger.log("Reloading plugins.");
         }
 
-        return plugin.state.mainThread.send(ThreadMessage.Reload(), slice);
+        return plugin.state.mainThread.send(ThreadMessage.Reload(slice));
 
     case "whitelist":
     case "operator":

--- a/source/kameloso/plugins/admin/base.d
+++ b/source/kameloso/plugins/admin/base.d
@@ -153,7 +153,7 @@ void onCommandSave(AdminPlugin plugin, const ref IRCEvent event)
     import kameloso.thread : ThreadMessage;
 
     privmsg(plugin.state, event.channel, event.sender.nickname, "Saving configuration to disk.");
-    plugin.state.mainThread.send(ThreadMessage.Save());
+    plugin.state.mainThread.send(ThreadMessage.save());
 }
 
 
@@ -619,7 +619,7 @@ void onCommandReload(AdminPlugin plugin, const ref IRCEvent event)
         "Reloading plugins.";
 
     privmsg(plugin.state, event.channel, event.sender.nickname, message);
-    plugin.state.mainThread.send(ThreadMessage.Reload(event.content));
+    plugin.state.mainThread.send(ThreadMessage.reload(event.content));
 }
 
 
@@ -815,7 +815,7 @@ void onCommandAuth(AdminPlugin plugin)
     import kameloso.thread : ThreadMessage, busMessage;
     import std.concurrency : send;
 
-    plugin.state.mainThread.send(ThreadMessage.BusMessage("connect", busMessage("auth")));
+    plugin.state.mainThread.send(ThreadMessage.busMessage("connect", busMessage("auth")));
 }
 
 
@@ -864,7 +864,7 @@ void onCommandStatus(AdminPlugin plugin)
 void onCommandSummary(AdminPlugin plugin)
 {
     import kameloso.thread : ThreadMessage;
-    plugin.state.mainThread.send(ThreadMessage.WantLiveSummary());
+    plugin.state.mainThread.send(ThreadMessage.wantLiveSummary());
 }
 
 
@@ -1240,7 +1240,7 @@ void onBusMessage(AdminPlugin plugin, const string header, shared Sendable conte
         import kameloso.thread : ThreadMessage;
 
         logger.log("Saving configuration to disk.");
-        return plugin.state.mainThread.send(ThreadMessage.Save());
+        return plugin.state.mainThread.send(ThreadMessage.save());
 
     case "reload":
         import kameloso.thread : ThreadMessage;
@@ -1255,7 +1255,7 @@ void onBusMessage(AdminPlugin plugin, const string header, shared Sendable conte
             logger.log("Reloading plugins.");
         }
 
-        return plugin.state.mainThread.send(ThreadMessage.Reload(slice));
+        return plugin.state.mainThread.send(ThreadMessage.reload(slice));
 
     case "whitelist":
     case "operator":

--- a/source/kameloso/plugins/admin/classifiers.d
+++ b/source/kameloso/plugins/admin/classifiers.d
@@ -563,7 +563,7 @@ in (list.among!("whitelist", "blacklist", "operator", "staff"),
     json.save(plugin.userFile);
 
     // Force persistence to reload the file with the new changes
-    plugin.state.mainThread.send(ThreadMessage.Reload());
+    plugin.state.mainThread.send(ThreadMessage.reload());
     return AlterationResult.success;
 }
 
@@ -703,5 +703,5 @@ in (mask.length, "Tried to add an empty hostmask definition")
     json.save!(JSONStorage.KeyOrderStrategy.passthrough)(plugin.hostmasksFile);
 
     // Force persistence to reload the file with the new changes
-    plugin.state.mainThread.send(ThreadMessage.Reload());
+    plugin.state.mainThread.send(ThreadMessage.reload());
 }

--- a/source/kameloso/plugins/admin/debugging.d
+++ b/source/kameloso/plugins/admin/debugging.d
@@ -201,7 +201,7 @@ void onCommandStatusImpl(AdminPlugin plugin)
 void onCommandBusImpl(AdminPlugin plugin, const string input)
 {
     import kameloso.common : logger;
-    import kameloso.thread : ThreadMessage, busMessage;
+    import kameloso.thread : ThreadMessage, sendable;
     import lu.string : contains, nom;
     import std.concurrency : send;
     import std.stdio : writeln;
@@ -231,6 +231,6 @@ void onCommandBusImpl(AdminPlugin plugin, const string input)
             writeln("Content: ", slice);
         }
 
-        plugin.state.mainThread.send(ThreadMessage.busMessage(header, busMessage(slice)));
+        plugin.state.mainThread.send(ThreadMessage.busMessage(header, sendable(slice)));
     }
 }

--- a/source/kameloso/plugins/admin/debugging.d
+++ b/source/kameloso/plugins/admin/debugging.d
@@ -217,7 +217,7 @@ void onCommandBusImpl(AdminPlugin plugin, const string input)
             writeln("Content: (empty)");
         }
 
-        plugin.state.mainThread.send(ThreadMessage.BusMessage(input));
+        plugin.state.mainThread.send(ThreadMessage.busMessage(input));
     }
     else
     {
@@ -231,6 +231,6 @@ void onCommandBusImpl(AdminPlugin plugin, const string input)
             writeln("Content: ", slice);
         }
 
-        plugin.state.mainThread.send(ThreadMessage.BusMessage(header, busMessage(slice)));
+        plugin.state.mainThread.send(ThreadMessage.busMessage(header, busMessage(slice)));
     }
 }

--- a/source/kameloso/plugins/admin/debugging.d
+++ b/source/kameloso/plugins/admin/debugging.d
@@ -217,7 +217,7 @@ void onCommandBusImpl(AdminPlugin plugin, const string input)
             writeln("Content: (empty)");
         }
 
-        plugin.state.mainThread.send(ThreadMessage.BusMessage(), input);
+        plugin.state.mainThread.send(ThreadMessage.BusMessage(input));
     }
     else
     {
@@ -231,7 +231,6 @@ void onCommandBusImpl(AdminPlugin plugin, const string input)
             writeln("Content: ", slice);
         }
 
-        plugin.state.mainThread.send(ThreadMessage.BusMessage(),
-            header, busMessage(slice));
+        plugin.state.mainThread.send(ThreadMessage.BusMessage(header, busMessage(slice)));
     }
 }

--- a/source/kameloso/plugins/chatbot.d
+++ b/source/kameloso/plugins/chatbot.d
@@ -165,7 +165,7 @@ void onCommandBash(ChatbotPlugin plugin, const ref IRCEvent event)
 
     if (!plugin.chatbotSettings.bashDotOrgQuotes) return;
 
-    plugin.state.mainThread.prioritySend(ThreadMessage.ShortenReceiveTimeout());
+    plugin.state.mainThread.prioritySend(ThreadMessage.shortenReceiveTimeout());
 
     // Defer all work to the worker thread
     cast(void)spawn(&worker, cast(shared)plugin.state, event);

--- a/source/kameloso/plugins/common/mixins.d
+++ b/source/kameloso/plugins/common/mixins.d
@@ -459,7 +459,7 @@ if (isSomeFunction!onSuccess && (is(typeof(onFailure) == typeof(null)) || isSome
             import kameloso.thread : ThreadMessage, busMessage;
             import std.concurrency : send;
 
-            plugin.state.mainThread.send(ThreadMessage.BusMessage("printer", busMessage("squelch " ~ nicknamePart)));
+            plugin.state.mainThread.send(ThreadMessage.busMessage("printer", busMessage("squelch " ~ nicknamePart)));
         }
 
         if (issueWhois)

--- a/source/kameloso/plugins/common/mixins.d
+++ b/source/kameloso/plugins/common/mixins.d
@@ -456,10 +456,10 @@ if (isSomeFunction!onSuccess && (is(typeof(onFailure) == typeof(null)) || isSome
 
         version(WithPrinterPlugin)
         {
-            import kameloso.thread : ThreadMessage, busMessage;
+            import kameloso.thread : ThreadMessage, sendable;
             import std.concurrency : send;
 
-            plugin.state.mainThread.send(ThreadMessage.busMessage("printer", busMessage("squelch " ~ nicknamePart)));
+            plugin.state.mainThread.send(ThreadMessage.busMessage("printer", sendable("squelch " ~ nicknamePart)));
         }
 
         if (issueWhois)

--- a/source/kameloso/plugins/common/mixins.d
+++ b/source/kameloso/plugins/common/mixins.d
@@ -459,8 +459,7 @@ if (isSomeFunction!onSuccess && (is(typeof(onFailure) == typeof(null)) || isSome
             import kameloso.thread : ThreadMessage, busMessage;
             import std.concurrency : send;
 
-            plugin.state.mainThread.send(ThreadMessage.BusMessage(),
-                "printer", busMessage("squelch " ~ nicknamePart));
+            plugin.state.mainThread.send(ThreadMessage.BusMessage("printer", busMessage("squelch " ~ nicknamePart)));
         }
 
         if (issueWhois)

--- a/source/kameloso/plugins/counter.d
+++ b/source/kameloso/plugins/counter.d
@@ -133,7 +133,7 @@ void onCommandCounter(CounterPlugin plugin, const ref IRCEvent event)
                 cast(shared)&channelSpecificDg, event.channel);
         }
 
-        plugin.state.mainThread.send(ThreadMessage.PeekCommands(), cast(shared)&dg);
+        plugin.state.mainThread.send(ThreadMessage.PeekCommands(), cast(shared)&dg, string.init);
         break;
 
     case "remove":

--- a/source/kameloso/plugins/help.d
+++ b/source/kameloso/plugins/help.d
@@ -222,7 +222,7 @@ void onCommandHelp(HelpPlugin plugin, const /*ref*/ IRCEvent event)
         }
     }
 
-    plugin.state.mainThread.send(ThreadMessage.PeekCommands(), cast(shared)&dg);
+    plugin.state.mainThread.send(ThreadMessage.PeekCommands(), cast(shared)&dg, string.init);
 }
 
 // sendCommandHelp

--- a/source/kameloso/plugins/oneliners.d
+++ b/source/kameloso/plugins/oneliners.d
@@ -184,7 +184,7 @@ void onCommandModifyOneliner(OnelinersPlugin plugin, const ref IRCEvent event)
                 cast(shared)&channelSpecificDg, event.channel);
         }
 
-        plugin.state.mainThread.send(ThreadMessage.PeekCommands(), cast(shared)&dg);
+        plugin.state.mainThread.send(ThreadMessage.PeekCommands(), cast(shared)&dg, string.init);
         break;
 
     case "del":

--- a/source/kameloso/plugins/pipeline.d
+++ b/source/kameloso/plugins/pipeline.d
@@ -131,11 +131,11 @@ in (filename.length, "Tried to set up a pipereader with an empty filename")
                 {
                     string slice = line[1..$];
                     immutable header = slice.nom(' ');
-                    state.mainThread.send(ThreadMessage.BusMessage(header, busMessage(slice)));
+                    state.mainThread.send(ThreadMessage.busMessage(header, busMessage(slice)));
                 }
                 else
                 {
-                    state.mainThread.send(ThreadMessage.BusMessage(line[1..$]));
+                    state.mainThread.send(ThreadMessage.busMessage(line[1..$]));
                 }
                 break;
             }
@@ -181,7 +181,7 @@ in (filename.length, "Tried to set up a pipereader with an empty filename")
             {
                 enum variantPattern = "Pipeline plugin received Variant: <l>%s";
                 state.askToError(variantPattern.format(v.toString));
-                state.mainThread.send(ThreadMessage.BusMessage("pipeline", busMessage("halted")));
+                state.mainThread.send(ThreadMessage.busMessage("pipeline", busMessage("halted")));
                 halt = true;
             }
         );
@@ -199,7 +199,7 @@ in (filename.length, "Tried to set up a pipereader with an empty filename")
             enum fifoPattern = "Pipeline plugin failed to reopen FIFO: <l>%s";
             state.askToError(fifoPattern.format(e.msg));
             version(PrintStacktraces) state.askToTrace(e.info.toString);
-            state.mainThread.send(ThreadMessage.BusMessage("pipeline", busMessage("halted")));
+            state.mainThread.send(ThreadMessage.busMessage("pipeline", busMessage("halted")));
             break toploop;
         }
         catch (Exception e)
@@ -405,7 +405,7 @@ void teardown(PipelinePlugin plugin)
 
     if (!plugin.workerRunning) return;
 
-    plugin.fifoThread.send(ThreadMessage.Teardown());
+    plugin.fifoThread.send(ThreadMessage.teardown());
 
     if (plugin.fifoFilename.exists && !plugin.fifoFilename.isDir)
     {

--- a/source/kameloso/plugins/pipeline.d
+++ b/source/kameloso/plugins/pipeline.d
@@ -124,14 +124,14 @@ in (filename.length, "Tried to set up a pipereader with an empty filename")
 
             if (line[0] == ':')
             {
-                import kameloso.thread : busMessage;
+                import kameloso.thread : sendable;
                 import lu.string : contains, nom;
 
                 if (line.contains(' '))
                 {
                     string slice = line[1..$];
                     immutable header = slice.nom(' ');
-                    state.mainThread.send(ThreadMessage.busMessage(header, busMessage(slice)));
+                    state.mainThread.send(ThreadMessage.busMessage(header, sendable(slice)));
                 }
                 else
                 {
@@ -159,7 +159,7 @@ in (filename.length, "Tried to set up a pipereader with an empty filename")
             break;
         }
 
-        import kameloso.thread : busMessage;
+        import kameloso.thread : sendable;
         import core.time : Duration;
 
         static immutable instant = Duration.zero;
@@ -181,7 +181,7 @@ in (filename.length, "Tried to set up a pipereader with an empty filename")
             {
                 enum variantPattern = "Pipeline plugin received Variant: <l>%s";
                 state.askToError(variantPattern.format(v.toString));
-                state.mainThread.send(ThreadMessage.busMessage("pipeline", busMessage("halted")));
+                state.mainThread.send(ThreadMessage.busMessage("pipeline", sendable("halted")));
                 halt = true;
             }
         );
@@ -199,7 +199,7 @@ in (filename.length, "Tried to set up a pipereader with an empty filename")
             enum fifoPattern = "Pipeline plugin failed to reopen FIFO: <l>%s";
             state.askToError(fifoPattern.format(e.msg));
             version(PrintStacktraces) state.askToTrace(e.info.toString);
-            state.mainThread.send(ThreadMessage.busMessage("pipeline", busMessage("halted")));
+            state.mainThread.send(ThreadMessage.busMessage("pipeline", sendable("halted")));
             break toploop;
         }
         catch (Exception e)

--- a/source/kameloso/plugins/services/chanqueries.d
+++ b/source/kameloso/plugins/services/chanqueries.d
@@ -141,7 +141,7 @@ void startChannelQueries(ChanQueriesService service)
                 version(WithPrinterPlugin)
                 {
                     service.state.mainThread.send(
-                        ThreadMessage.BusMessage("printer", busMessage(squelchMessage)));
+                        ThreadMessage.busMessage("printer", busMessage(squelchMessage)));
                 }
 
                 raw(service.state, text(command, ' ', channelName), Yes.quiet, Yes.background);
@@ -186,7 +186,7 @@ void startChannelQueries(ChanQueriesService service)
                     // [chanoprivsneeded] [#d] sinisalo.freenode.net: "You're not a channel operator" (#482)
                     // Ask the Printer to squelch those messages too.
                     service.state.mainThread.send(
-                        ThreadMessage.BusMessage("printer", busMessage(squelchMessage)));
+                        ThreadMessage.busMessage("printer", busMessage(squelchMessage)));
                 }
 
                 import kameloso.messaging : mode;
@@ -245,7 +245,7 @@ void startChannelQueries(ChanQueriesService service)
             version(WithPrinterPlugin)
             {
                 service.state.mainThread.send(
-                    ThreadMessage.BusMessage("printer", busMessage("unsquelch")));
+                    ThreadMessage.busMessage("printer", busMessage("unsquelch")));
             }
         }
 
@@ -277,7 +277,7 @@ void startChannelQueries(ChanQueriesService service)
             version(WithPrinterPlugin)
             {
                 service.state.mainThread.send(
-                    ThreadMessage.BusMessage("printer", busMessage("squelch " ~ nickname)));
+                    ThreadMessage.busMessage("printer", busMessage("squelch " ~ nickname)));
             }
 
             whois(service.state, nickname, No.force, Yes.quiet, Yes.background);

--- a/source/kameloso/plugins/services/chanqueries.d
+++ b/source/kameloso/plugins/services/chanqueries.d
@@ -93,7 +93,7 @@ void startChannelQueries(ChanQueriesService service)
 
     void dg()
     {
-        import kameloso.thread : CarryingFiber, ThreadMessage, busMessage;
+        import kameloso.thread : CarryingFiber, ThreadMessage, sendable;
         import std.concurrency : send;
         import std.datetime.systime : Clock;
         import std.string : representation;
@@ -141,7 +141,7 @@ void startChannelQueries(ChanQueriesService service)
                 version(WithPrinterPlugin)
                 {
                     service.state.mainThread.send(
-                        ThreadMessage.busMessage("printer", busMessage(squelchMessage)));
+                        ThreadMessage.busMessage("printer", sendable(squelchMessage)));
                 }
 
                 raw(service.state, text(command, ' ', channelName), Yes.quiet, Yes.background);
@@ -186,7 +186,7 @@ void startChannelQueries(ChanQueriesService service)
                     // [chanoprivsneeded] [#d] sinisalo.freenode.net: "You're not a channel operator" (#482)
                     // Ask the Printer to squelch those messages too.
                     service.state.mainThread.send(
-                        ThreadMessage.busMessage("printer", busMessage(squelchMessage)));
+                        ThreadMessage.busMessage("printer", sendable(squelchMessage)));
                 }
 
                 import kameloso.messaging : mode;
@@ -245,7 +245,7 @@ void startChannelQueries(ChanQueriesService service)
             version(WithPrinterPlugin)
             {
                 service.state.mainThread.send(
-                    ThreadMessage.busMessage("printer", busMessage("unsquelch")));
+                    ThreadMessage.busMessage("printer", sendable("unsquelch")));
             }
         }
 
@@ -277,7 +277,7 @@ void startChannelQueries(ChanQueriesService service)
             version(WithPrinterPlugin)
             {
                 service.state.mainThread.send(
-                    ThreadMessage.busMessage("printer", busMessage("squelch " ~ nickname)));
+                    ThreadMessage.busMessage("printer", sendable("squelch " ~ nickname)));
             }
 
             whois(service.state, nickname, No.force, Yes.quiet, Yes.background);

--- a/source/kameloso/plugins/services/chanqueries.d
+++ b/source/kameloso/plugins/services/chanqueries.d
@@ -140,8 +140,8 @@ void startChannelQueries(ChanQueriesService service)
 
                 version(WithPrinterPlugin)
                 {
-                    service.state.mainThread.send(ThreadMessage.BusMessage(),
-                        "printer", busMessage(squelchMessage));
+                    service.state.mainThread.send(
+                        ThreadMessage.BusMessage("printer", busMessage(squelchMessage)));
                 }
 
                 raw(service.state, text(command, ' ', channelName), Yes.quiet, Yes.background);
@@ -185,8 +185,8 @@ void startChannelQueries(ChanQueriesService service)
                     // channels for specific modes.
                     // [chanoprivsneeded] [#d] sinisalo.freenode.net: "You're not a channel operator" (#482)
                     // Ask the Printer to squelch those messages too.
-                    service.state.mainThread.send(ThreadMessage.BusMessage(),
-                        "printer", busMessage(squelchMessage));
+                    service.state.mainThread.send(
+                        ThreadMessage.BusMessage("printer", busMessage(squelchMessage)));
                 }
 
                 import kameloso.messaging : mode;
@@ -244,8 +244,8 @@ void startChannelQueries(ChanQueriesService service)
 
             version(WithPrinterPlugin)
             {
-                service.state.mainThread.send(ThreadMessage.BusMessage(),
-                    "printer", busMessage("unsquelch"));
+                service.state.mainThread.send(
+                    ThreadMessage.BusMessage("printer", busMessage("unsquelch")));
             }
         }
 
@@ -276,8 +276,8 @@ void startChannelQueries(ChanQueriesService service)
 
             version(WithPrinterPlugin)
             {
-                service.state.mainThread.send(ThreadMessage.BusMessage(),
-                    "printer", busMessage("squelch " ~ nickname));
+                service.state.mainThread.send(
+                    ThreadMessage.BusMessage("printer", busMessage("squelch " ~ nickname)));
             }
 
             whois(service.state, nickname, No.force, Yes.quiet, Yes.background);

--- a/source/kameloso/plugins/services/connect.d
+++ b/source/kameloso/plugins/services/connect.d
@@ -218,7 +218,7 @@ void onPing(ConnectService service, const ref IRCEvent event)
     import std.concurrency : prioritySend;
 
     immutable target = event.content.length ? event.content : event.sender.address;
-    service.state.mainThread.prioritySend(ThreadMessage.Pong(), target);
+    service.state.mainThread.prioritySend(ThreadMessage.Pong(target));
 }
 
 
@@ -1113,8 +1113,8 @@ void onWelcome(ConnectService service, const ref IRCEvent event)
                     {
                         import kameloso.thread : ThreadMessage, busMessage;
                         import std.concurrency : send;
-                        service.state.mainThread.send(ThreadMessage.BusMessage(),
-                            "printer", busMessage(squelchVerb));
+                        service.state.mainThread.send(
+                            ThreadMessage.BusMessage("printer", busMessage(squelchVerb)));
                     }
 
                     raw(service.state, "NICK " ~ service.state.client.origNickname,
@@ -1144,8 +1144,8 @@ void onSelfnickSuccessOrFailure(ConnectService service)
 {
     import kameloso.thread : ThreadMessage, busMessage;
     import std.concurrency : send;
-    service.state.mainThread.send(ThreadMessage.BusMessage(),
-        "printer", busMessage("unsquelch " ~ service.state.client.origNickname));
+    service.state.mainThread.send(
+        ThreadMessage.BusMessage("printer", busMessage("unsquelch " ~ service.state.client.origNickname)));
 }
 
 

--- a/source/kameloso/plugins/services/connect.d
+++ b/source/kameloso/plugins/services/connect.d
@@ -218,7 +218,7 @@ void onPing(ConnectService service, const ref IRCEvent event)
     import std.concurrency : prioritySend;
 
     immutable target = event.content.length ? event.content : event.sender.address;
-    service.state.mainThread.prioritySend(ThreadMessage.Pong(target));
+    service.state.mainThread.prioritySend(ThreadMessage.pong(target));
 }
 
 
@@ -1114,7 +1114,7 @@ void onWelcome(ConnectService service, const ref IRCEvent event)
                         import kameloso.thread : ThreadMessage, busMessage;
                         import std.concurrency : send;
                         service.state.mainThread.send(
-                            ThreadMessage.BusMessage("printer", busMessage(squelchVerb)));
+                            ThreadMessage.busMessage("printer", busMessage(squelchVerb)));
                     }
 
                     raw(service.state, "NICK " ~ service.state.client.origNickname,
@@ -1145,7 +1145,7 @@ void onSelfnickSuccessOrFailure(ConnectService service)
     import kameloso.thread : ThreadMessage, busMessage;
     import std.concurrency : send;
     service.state.mainThread.send(
-        ThreadMessage.BusMessage("printer", busMessage("unsquelch " ~ service.state.client.origNickname)));
+        ThreadMessage.busMessage("printer", busMessage("unsquelch " ~ service.state.client.origNickname)));
 }
 
 
@@ -1275,7 +1275,7 @@ void onReconnect(ConnectService service)
     import std.concurrency : send;
 
     logger.info("Reconnecting upon server request.");
-    service.state.mainThread.send(ThreadMessage.Reconnect());
+    service.state.mainThread.send(ThreadMessage.reconnect());
 }
 
 

--- a/source/kameloso/plugins/services/connect.d
+++ b/source/kameloso/plugins/services/connect.d
@@ -1111,10 +1111,10 @@ void onWelcome(ConnectService service, const ref IRCEvent event)
 
                     version(WithPrinterPlugin)
                     {
-                        import kameloso.thread : ThreadMessage, busMessage;
+                        import kameloso.thread : ThreadMessage, sendable;
                         import std.concurrency : send;
                         service.state.mainThread.send(
-                            ThreadMessage.busMessage("printer", busMessage(squelchVerb)));
+                            ThreadMessage.busMessage("printer", sendable(squelchVerb)));
                     }
 
                     raw(service.state, "NICK " ~ service.state.client.origNickname,
@@ -1142,10 +1142,10 @@ version(WithPrinterPlugin)
 )
 void onSelfnickSuccessOrFailure(ConnectService service)
 {
-    import kameloso.thread : ThreadMessage, busMessage;
+    import kameloso.thread : ThreadMessage, sendable;
     import std.concurrency : send;
     service.state.mainThread.send(
-        ThreadMessage.busMessage("printer", busMessage("unsquelch " ~ service.state.client.origNickname)));
+        ThreadMessage.busMessage("printer", sendable("unsquelch " ~ service.state.client.origNickname)));
 }
 
 

--- a/source/kameloso/plugins/twitchbot/api.d
+++ b/source/kameloso/plugins/twitchbot/api.d
@@ -178,7 +178,7 @@ in (Fiber.getThis, "Tried to call `queryTwitch` from outside a Fiber")
 
     SysTime pre;
 
-    plugin.state.mainThread.prioritySend(ThreadMessage.ShortenReceiveTimeout());
+    plugin.state.mainThread.prioritySend(ThreadMessage.shortenReceiveTimeout());
 
     if (plugin.state.settings.trace)
     {

--- a/source/kameloso/plugins/twitchbot/api.d
+++ b/source/kameloso/plugins/twitchbot/api.d
@@ -115,9 +115,12 @@ void persistentQuerier(shared QueryResponse[string] bucket,
             {
                 queryTwitchImpl(url, authToken, timeout, bucket, caBundleFile);
             },
-            (ThreadMessage.Teardown) scope
+            (ThreadMessage message) scope
             {
-                halt = true;
+                if (message.type == ThreadMessage.Type.teardown)
+                {
+                    halt = true;
+                }
             },
             (OwnerTerminated _) scope
             {

--- a/source/kameloso/plugins/twitchbot/base.d
+++ b/source/kameloso/plugins/twitchbot/base.d
@@ -1365,7 +1365,7 @@ void teardown(TwitchBotPlugin plugin)
         (plugin.persistentWorkerTid != Tid.init))
     {
         // It may not have been started if we're aborting very early.
-        plugin.persistentWorkerTid.send(ThreadMessage.Teardown());
+        plugin.persistentWorkerTid.send(ThreadMessage.teardown());
     }
 }
 

--- a/source/kameloso/plugins/twitchbot/keygen.d
+++ b/source/kameloso/plugins/twitchbot/keygen.d
@@ -316,7 +316,7 @@ It should be entered as <i>pass</> under <i>[IRCBot]</>.
         if (!input.length || (input == "y") || (input == "Y"))
         {
             import std.concurrency : prioritySend;
-            plugin.state.mainThread.prioritySend(ThreadMessage.Save());
+            plugin.state.mainThread.prioritySend(ThreadMessage.save());
         }
         else
         {

--- a/source/kameloso/plugins/webtitles.d
+++ b/source/kameloso/plugins/webtitles.d
@@ -202,7 +202,7 @@ void lookupURLs(WebtitlesPlugin plugin, const ref IRCEvent event, string[] urls)
     import kameloso.thread : ThreadMessage;
     import std.concurrency : prioritySend;
 
-    plugin.state.mainThread.prioritySend(ThreadMessage.ShortenReceiveTimeout());
+    plugin.state.mainThread.prioritySend(ThreadMessage.shortenReceiveTimeout());
 }
 
 

--- a/source/kameloso/thread.d
+++ b/source/kameloso/thread.d
@@ -203,17 +203,6 @@ struct ThreadMessage
         shortenReceiveTimeout,
     }
 
-    /// Concurrency message for writing text to the terminal.
-    enum TerminalOutput
-    {
-        writeln,
-        trace,
-        log,
-        info,
-        warning,
-        error,
-    }
-
     /++
         The [Type] of this thread message.
      +/
@@ -266,21 +255,31 @@ struct ThreadMessage
 /++
     Embodies the notion of a request to output something to the local terminal.
 
-    Merely bundles a [ThreadMessage.TerminalOutput|TerminalOutput] log level and
+    Merely bundles a [OutputRequest.Level|Level] log level and
     a `string` message line. What log level is picked decides what log level is
     passed to the [kameloso.logger.KamelosoLogger|KamelosoLogger] instance, and
     dictates things like what colour to tint the message with (if any).
  +/
 struct OutputRequest
 {
+    /// Output log levels.
+    enum Level
+    {
+        writeln,
+        trace,
+        log,
+        info,
+        warning,
+        error,
+    }
+
     /++
         Log level of the message.
 
         See_Also:
-            [ThreadMessage.TerminalOutput]
             [kameloso.logger.LogLevel]
      +/
-    ThreadMessage.TerminalOutput logLevel;
+    Level logLevel;
 
     /++
         String line to request to be output to the local terminal.

--- a/source/kameloso/thread.d
+++ b/source/kameloso/thread.d
@@ -131,10 +131,6 @@ version(Posix)
  +/
 struct ThreadMessage
 {
-private:
-    import std.uni : toUpper;
-
-public:
     /++
         Different thread message types.
      +/
@@ -255,7 +251,7 @@ public:
     static foreach (immutable memberstring; __traits(allMembers, Type))
     {
         mixin(`
-            static auto ` ~ memberstring[0..1].toUpper ~ memberstring[1..$] ~ `
+            static auto ` ~ memberstring ~ `
                 (const string content = string.init,
                 shared Sendable payload = null,
                 const bool quiet = false)

--- a/source/kameloso/thread.d
+++ b/source/kameloso/thread.d
@@ -131,26 +131,150 @@ version(Posix)
  +/
 struct ThreadMessage
 {
+    /++
+        Different thread message types.
+     +/
+    enum Type
+    {
+        /++
+            Request to send a server [dialect.defs.IRCEvent.Type.PONG|PONG] response.
+         +/
+        pong,
+
+        /++
+            Request to send an outgoing normal line.
+         +/
+        sendline,
+
+        /++
+            Request to send a quiet normal line.
+         +/
+        quietline,
+
+        /++
+            Request to send a line immediately, bypassing queues.
+         +/
+        immediateline,
+
+        /++
+            Request to quit the program.
+         +/
+        quit,
+
+        /++
+            Request to teardown (destroy) a plugin.
+         +/
+        teardown,
+
+        /++
+            Request to save configuration to file.
+         +/
+        save,
+
+        /++
+            Request to reload resources from disk.
+         +/
+        reload,
+
+        /++
+            Request to disconnect and reconect to the server.
+         +/
+        reconnect,
+
+        /++
+            A bus message.
+         +/
+        busMessage,
+
+        /++
+            Request to print a connection summary to the local terminal.
+         +/
+        wantLiveSummary,
+
+        /++
+            Request to abort and exit the program.
+         +/
+        abort,
+
+        /++
+            Request to lower receive timeout briefly and improve
+            responsiveness/precision during that time.
+         +/
+        shortenReceiveTimeout,
+    }
+
+    /// Concurrency message for writing text to the terminal.
+    enum TerminalOutput
+    {
+        writeln,
+        trace,
+        log,
+        info,
+        warning,
+        error,
+    }
+
+    /++
+        The [Type] of this thread message.
+     +/
+    Type type;
+
+    /++
+        String content body of message, where applicable.
+     +/
+    string content;
+
+    /++
+        Bundled `shared` [Sendable] payload, where applicable.
+     +/
+    shared Sendable payload;
+
+    /++
+        Whether or not the action requested should be done quietly.
+     +/
+    bool quiet;
+
     /// Concurrency message type asking for a to-server [dialect.defs.IRCEvent.Type.PONG|PONG] event.
-    static struct Pong {}
+    static auto Pong(const string content)
+    {
+        return ThreadMessage(Type.pong, content);
+    }
 
     /// Concurrency message type asking to verbosely send a line to the server.
-    static struct Sendline {}
+    static auto Sendline(const string content)
+    {
+        return ThreadMessage(Type.sendline, content);
+    }
 
     /// Concurrency message type asking to quietly send a line to the server.
-    static struct Quietline {}
+    static auto Quietline(const string content)
+    {
+        return ThreadMessage(Type.quietline, content);
+    }
 
     /// Concurrency message type asking to immediately send a line to the server.
-    static struct Immediateline {}
+    static auto Immediateline(const string content)
+    {
+        return ThreadMessage(Type.immediateline, content);
+    }
 
     /// Concurrency message type asking to quit the server and exit the program.
-    static struct Quit {}
+    static auto Quit(const string content = string.init)
+    {
+        return ThreadMessage(Type.quit, content);
+    }
 
     /// Concurrency message type asking for a plugin's worker thread to shut down cleanly.
-    static struct Teardown {}
+    static auto Teardown()
+    {
+        return ThreadMessage(Type.teardown);
+    }
 
     /// Concurrency message type asking to have plugins' configuration saved.
-    static struct Save {}
+    static auto Save()
+    {
+        return ThreadMessage(Type.save);
+    }
 
     /++
         Concurrency message asking for an associative array of a description of
@@ -164,36 +288,43 @@ struct ThreadMessage
     static struct ChangeSetting {}
 
     /// Concurrency message asking plugins to "reload".
-    static struct Reload {}
+    static auto Reload(const string content = string.init)
+    {
+        return ThreadMessage(Type.reload, content);
+    }
 
     /// Concurrency message asking to disconnect and reconnect to the server.
-    static struct Reconnect {}
+    static auto Reconnect()
+    {
+        return ThreadMessage(Type.reconnect);
+    }
 
     /// Concurrency message meant to be sent between plugins.
-    static struct BusMessage {}
-
-    /// Concurrency message for writing text to the terminal.
-    enum TerminalOutput
+    static auto BusMessage(const string content = string.init, shared Sendable payload = null)
     {
-        writeln,
-        trace,
-        log,
-        info,
-        warning,
-        error,
+        return ThreadMessage(Type.busMessage, content, payload);
     }
 
     /// Concurrency message asking the main thread to print a connection summary.
-    static struct WantLiveSummary {}
+    static auto WantLiveSummary()
+    {
+        return ThreadMessage(Type.wantLiveSummary);
+    }
 
     /// Concurrency message asking the main thread to set the `abort` flag.
-    static struct Abort {}
+    static auto Abort()
+    {
+        return ThreadMessage(Type.abort);
+    }
 
     /++
         Concurrency message asking for the Socket receive timeout to be lowered
         temporarily, for increased responsiveness.
      +/
-    static struct ShortenReceiveTimeout {}
+    static auto ShortenReceiveTimeout()
+    {
+        return ThreadMessage(Type.shortenReceiveTimeout);
+    }
 }
 
 

--- a/source/kameloso/thread.d
+++ b/source/kameloso/thread.d
@@ -6,10 +6,10 @@
     ---
     import std.concurrency;
 
-    mainThread.send(ThreadMessage.Sendline(), "Message to send to server");
-    mainThread.send(ThreadMessage.Pong(), "irc.libera.chat");
-    mainThread.send(ThreadMessage.TerminalOutput.writeln, "writeln this for me please");
-    mainThread.send(ThreadMessage.BusMessage(), "header", busMessage("payload"));
+    mainThread.send(ThreadMessage.sendline("Message to send to server"));
+    mainThread.send(ThreadMessage.pong("irc.libera.chat"));
+    mainThread.send(OutputRequest(ThreadMessage.TerminalOutput.writeln, "writeln this for me please"));
+    mainThread.send(ThreadMessage.busMessage("header", busMessage("payload")));
 
     auto fiber = new CarryingFiber!string(&someDelegate, BufferSize.fiberStack);
     fiber.payload = "This string is carried by the Fiber and can be accessed from within it";
@@ -327,9 +327,9 @@ final class BusMessage(T) : Sendable
     Example:
     ---
     IRCEvent event;  // ...
-    mainThread.send(ThreadMessage.BusMessage(), "header", busMessage(event));
-    mainThread.send(ThreadMessage.BusMessage(), "other header", busMessage("text payload"));
-    mainThread.send(ThreadMessage.BusMessage(), "ladida", busMessage(42));
+    mainThread.send(ThreadMessage.busMessage("header", busMessage(event)));
+    mainThread.send(ThreadMessage.busMessage("other header", busMessage("text payload")));
+    mainThread.send(ThreadMessage.busMessage("ladida", busMessage(42)));
     ---
 
     Params:

--- a/source/kameloso/thread.d
+++ b/source/kameloso/thread.d
@@ -319,7 +319,7 @@ final class BusMessage(T) : Sendable
 }
 
 
-// busMessage
+// sendable
 /++
     Constructor function to create a `shared` [BusMessage] with an unqualified
     template type.
@@ -339,7 +339,7 @@ final class BusMessage(T) : Sendable
     Returns:
         A `shared` `BusMessage!T` where `T` is the unqualified type of the payload.
  +/
-shared(Sendable) busMessage(T)(T payload)
+shared(Sendable) sendable(T)(T payload)
 {
     import std.traits : Unqual;
     return new shared BusMessage!(Unqual!T)(payload);
@@ -349,20 +349,20 @@ shared(Sendable) busMessage(T)(T payload)
 unittest
 {
     {
-        auto msg = busMessage("asdf");
+        auto msg = sendable("asdf");
         auto asCast = cast(BusMessage!string)msg;
         assert((msg !is null), "Incorrectly cast message: " ~ typeof(asCast).stringof);
         asCast = null;  // silence dscanner
     }
     {
-        auto msg = busMessage(123_456);
+        auto msg = sendable(123_456);
         auto asCast = cast(BusMessage!int)msg;
         assert((msg !is null), "Incorrectly cast message: " ~ typeof(asCast).stringof);
         asCast = null;  // silence dscanner
     }
     {
         struct Foo {}
-        auto msg = busMessage(Foo());
+        auto msg = sendable(Foo());
         auto asCast = cast(BusMessage!Foo)msg;
         assert((msg !is null), "Incorrectly cast message: " ~ typeof(asCast).stringof);
         asCast = null;  // silence dscanner

--- a/source/kameloso/thread.d
+++ b/source/kameloso/thread.d
@@ -122,12 +122,13 @@ version(Posix)
 
 // ThreadMessage
 /++
-    Aggregate of thread message types.
+    Collection of static functions used to construct thread messages, for passing
+    information of different kinds yet still as one type, to stop [std.concurrency.send]
+    from requiring so much compilation memory.
 
-    This is a way to make concurrency message passing easier. You could use
-    string literals to differentiate between messages and then have big
-    switches inside the catching function, but with these you can actually
-    have separate concurrency-receiving delegates for each.
+    The type of the message is defined as a [ThreadMessage.Type|Type] in
+    [ThreadMessage.type]. Recipients will have to do a (final) switch over that
+    enum to deal with messages accordingly.
  +/
 struct ThreadMessage
 {
@@ -262,22 +263,24 @@ struct ThreadMessage
  +/
 struct OutputRequest
 {
-    /// Output log levels.
+    /++
+        Output log levels.
+
+        See_Also:
+            [kameloso.logger.LogLevel]
+     +/
     enum Level
     {
-        writeln,
-        trace,
-        log,
-        info,
-        warning,
-        error,
+        writeln,    /// writeln the line.
+        trace,      /// Log at [kameloso.logger.LogLevel.trace].
+        log,        /// Log at [kameloso.logger.LogLevel.all] (log).
+        info,       /// Log at [kameloso.logger.LogLevel.info].
+        warning,    /// Log at [kameloso.logger.LogLevel.warning].
+        error,      /// Log at [kameloso.logger.LogLevel.error].
     }
 
     /++
         Log level of the message.
-
-        See_Also:
-            [kameloso.logger.LogLevel]
      +/
     Level logLevel;
 


### PR DESCRIPTION
This refactors `ThreadMessage`s from being uniquely typed (and thus instantiating an extra overload of `std.concurrency.send` each) to instead share a common type runtime-distinguished by a `Type` enum member. It cuts compilation memory requirements considerably.

```d
mainThread.send(ThreadMessage.Pong(), service.state.server.address);
mainThread.send(ThreadMessage.Save());
mainThread.send(ThreadMessage.BusMessage, "admin", busMessage("reload"));

// ...becomes...

mainThread.send(ThreadMessage.pong(service.state.server.address));
mainThread.send(ThreadMessage.save());
mainThread.send(ThreadMessage.busMessage("admin", sendable("reload")));
```

Thus they share one `std.concurrency.send!ThreadMessage` instantiation, instead of one for each static struct nested in `ThreadMessage`. (`Pong`, `Save`, `BusMessage`, `Sendline`, `Quit`, `Reload`, `PeekCommands`, etc.)