### PR TITLE
Windows: download OpenSSL and `cacert.pem` via `.url` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,16 +100,20 @@ The package manager [**dub**](https://code.dlang.org) is used to facilitate comp
 
 **kameloso** uses [**OpenSSL**](https://www.openssl.org) to establish secure connections. It is the de facto standard SSL library in the Posix sphere (Linux, macOS, ...), but not so on Windows. If you run into errors about *failing to set up an SSL context* when attempting to connect on Windows, download and install **Win64/32 OpenSSL v1.1.1n Light** from [here](https://slproweb.com/products/Win32OpenSSL.html), and opt to install to Windows system directories when asked.
 
+> You can open this download page in your web browser by passing `--get-openssl` on the command line.
+
 > An alternative is to use a different shell environment, such as any one of **Git for Windows** (Bash shell), **MinGW64**, **MSYS2**, **Cygwin** and **Windows Subsystem for Linux** (likely among others), all of which either include said libraries or at the very least offer the ability to install them. Or just limit yourself to non-SSL connections and live without some plugin features.
 
-If you get errors about not being able to verify certificates, you may also need to supply a certificate bundle. Download this [`cacert.pem`](http://curl.se/ca/cacert.pem) file from the cURL project, place it somewhere reasonable, and edit your configuration file to point to it; `caBundleFile` under `[Connection]`. If you place it in `%APPDATA%\kameloso` (or in the working directory) you only need to enter its filename, otherwise enter a full path.
+If you get errors about not being able to verify certificates, you may also need to supply a certificate bundle. Download this [`cacert.pem`](http://curl.se/ca/cacert.pem) file extracted from Mozilla Firefox by the cURL project, place it somewhere reasonable, and edit your configuration file to point to it; `caBundleFile` under `[Connection]`. If you place it in `%APPDATA%\kameloso` (or in the working directory) you only need to enter its filename, otherwise enter a full path.
 
 ```ini
 [Connection]
 caBundleFile                cacert.pem
 ```
 
-You can also specify one at the command line with `--cacert`.
+You can also specify one per-session at the command line with `--cacert`.
+
+> You can quickly download this file with your web browser by passing `--get-cacert`.
 
 ## Downloading
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The package manager [**dub**](https://code.dlang.org) is used to facilitate comp
 
 > You can open this download page in your web browser by passing `--get-openssl` on the command line.
 
-If you get errors about not being able to verify certificates, you may also need to supply a certificate bundle file. Download this [`cacert.pem`](http://curl.se/ca/cacert.pem) file extracted from Mozilla Firefox by the cURL project, place it somewhere reasonable, and edit your configuration file to point to it; `caBundleFile` under `[Connection]`. If you place it in `%APPDATA%\kameloso` (or in the working directory) you only need to enter its filename, otherwise enter a full path. You can also specify one per-session at the command line with `--cacert`.
+If you get errors about not being able to verify certificates, you may also need to supply a certificate bundle file. Download this [`cacert.pem`](https://curl.se/ca/cacert.pem) file extracted from Mozilla Firefox by the cURL project, place it somewhere reasonable, and edit your configuration file to point to it; `caBundleFile` under `[Connection]`. If you place it in `%APPDATA%\kameloso` (or in the working directory) you only need to enter its filename, otherwise enter a full path. You can also specify one per-session at the command line with `--cacert`.
 
 ```ini
 [Connection]

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The package manager [**dub**](https://code.dlang.org) is used to facilitate comp
 
 > An alternative is to use a different shell environment, such as any one of **Git for Windows** (Bash shell), **MinGW64**, **MSYS2**, **Cygwin** and **Windows Subsystem for Linux** (likely among others), all of which either include said libraries or at the very least offer the ability to install them. Or just limit yourself to non-SSL connections and live without some plugin features.
 
-If you get errors about not being able to verify certificates, you may also need to supply a certificate bundle. Download this [`cacert.pem`](https://curl.haxx.se/ca/cacert.pem) file from the cURL project, place it somewhere reasonable, and edit your configuration file to point to it; `caBundleFile` under `[Connection]`. If you place it in `%APPDATA%\kameloso` (or in the working directory) you only need to enter its filename, otherwise enter a full path.
+If you get errors about not being able to verify certificates, you may also need to supply a certificate bundle. Download this [`cacert.pem`](http://curl.se/ca/cacert.pem) file from the cURL project, place it somewhere reasonable, and edit your configuration file to point to it; `caBundleFile` under `[Connection]`. If you place it in `%APPDATA%\kameloso` (or in the working directory) you only need to enter its filename, otherwise enter a full path.
 
 ```ini
 [Connection]

--- a/README.md
+++ b/README.md
@@ -98,22 +98,20 @@ The package manager [**dub**](https://code.dlang.org) is used to facilitate comp
 
 ### SSL Libraries on Windows
 
-**kameloso** uses [**OpenSSL**](https://www.openssl.org) to establish secure connections. It is the de facto standard SSL library in the Posix sphere (Linux, macOS, ...), but not so on Windows. If you run into errors about *failing to set up an SSL context* when attempting to connect on Windows, download and install **Win64/32 OpenSSL v1.1.1n Light** from [here](https://slproweb.com/products/Win32OpenSSL.html), and opt to install to Windows system directories when asked.
+**kameloso** uses [**OpenSSL**](https://www.openssl.org) to establish secure connections. It is the de facto standard SSL library in the Posix sphere (Linux, macOS, ...), but not so on Windows. If you run into errors about *failing to set up an SSL context* when attempting to connect on Windows, download and install **Win64/32 OpenSSL v1.1.1 Light** (not **3.0.x**) from [here](https://slproweb.com/products/Win32OpenSSL.html), and opt to install to Windows system directories when asked.
 
 > You can open this download page in your web browser by passing `--get-openssl` on the command line.
 
-> An alternative is to use a different shell environment, such as any one of **Git for Windows** (Bash shell), **MinGW64**, **MSYS2**, **Cygwin** and **Windows Subsystem for Linux** (likely among others), all of which either include said libraries or at the very least offer the ability to install them. Or just limit yourself to non-SSL connections and live without some plugin features.
-
-If you get errors about not being able to verify certificates, you may also need to supply a certificate bundle. Download this [`cacert.pem`](http://curl.se/ca/cacert.pem) file extracted from Mozilla Firefox by the cURL project, place it somewhere reasonable, and edit your configuration file to point to it; `caBundleFile` under `[Connection]`. If you place it in `%APPDATA%\kameloso` (or in the working directory) you only need to enter its filename, otherwise enter a full path.
+If you get errors about not being able to verify certificates, you may also need to supply a certificate bundle file. Download this [`cacert.pem`](http://curl.se/ca/cacert.pem) file extracted from Mozilla Firefox by the cURL project, place it somewhere reasonable, and edit your configuration file to point to it; `caBundleFile` under `[Connection]`. If you place it in `%APPDATA%\kameloso` (or in the working directory) you only need to enter its filename, otherwise enter a full path. You can also specify one per-session at the command line with `--cacert`.
 
 ```ini
 [Connection]
 caBundleFile                cacert.pem
 ```
 
-You can also specify one per-session at the command line with `--cacert`.
-
 > You can quickly download this file with your web browser by passing `--get-cacert`.
+
+An alternative is to use a different shell environment, such as any one of **Git for Windows** (Bash)/**MinGW64**, **MSYS2**, **Cygwin** and **Windows Subsystem for Linux** (likely among others), all of which either include said libraries or at the very least offer the ability to install them. Or just limit yourself to non-SSL connections and live without some plugin features.
 
 ## Downloading
 

--- a/source/kameloso/config.d
+++ b/source/kameloso/config.d
@@ -924,6 +924,11 @@ Next handleGetopt(ref Kameloso instance,
                     cacertBrowser = openURL(url);
                 }
 
+                if (shouldDownloadCacert && shouldDownloadOpenSSL)
+                {
+                    logger.trace("---");
+                }
+
                 if (shouldDownloadOpenSSL)
                 {
                     enum url = "https://slproweb.com/products/Win32OpenSSL.html";

--- a/source/kameloso/config.d
+++ b/source/kameloso/config.d
@@ -566,7 +566,7 @@ Next handleGetopt(ref Kameloso instance,
             version(Windows)
             {
                 enum getOpenSSLString = "Open the download page for OpenSSL for Windows in your web browser";
-                enum getCacertString = "Download a <l>cacert.pem</> certificate " ~
+                enum getCacertString = "Download a <i>cacert.pem</> certificate " ~
                     "file from the cURL project with your browser";
             }
             else
@@ -907,15 +907,19 @@ Next handleGetopt(ref Kameloso instance,
 
                 if (shouldDownloadCacert)
                 {
+                    import std.path : buildNormalizedPath;
+
                     enum url = "http://curl.se/ca/cacert.pem";
                     enum pattern = "<l>cacert.pem</>: Save it anywhere, preferably in <l>%s/</>.";
                     enum pathPattern = "That way you don't have to enter its full path " ~
                         "in the configuration file (<l>cacert.pem</> will be enough).";
                     enum configPattern = "(Open the configuration file by passing <l>--gedit</)";
 
-                    logger.infof(pattern.expandTags, cbd);
-                    logger.info(pathPattern.expandTags);
-                    logger.info(configPattern.expandTags);
+                    immutable kamelosoDir = buildNormalizedPath(cbd, "kameloso");
+
+                    logger.infof(pattern.expandTags(LogLevel.info), kamelosoDir);
+                    logger.info(pathPattern.expandTags(LogLevel.info));
+                    logger.info(configPattern.expandTags(LogLevel.info));
 
                     cacertBrowser = openURL(url);
                 }
@@ -926,8 +930,8 @@ Next handleGetopt(ref Kameloso instance,
                     enum versionPattern = "<l>OpenSSL>/>: You want <l>v1.1.1n Light</> (or later), not <l>v3.0.x</>.";
                     enum installPattern = "Remember to install to <l>Windows system directories</> when asked.";
 
-                    logger.info(versionPattern.expandTags);
-                    logger.info(installPattern.expandTags);
+                    logger.info(versionPattern.expandTags(LogLevel.info));
+                    logger.info(installPattern.expandTags(LogLevel.info));
                     openSSLBrowser = openURL(url);
                 }
 

--- a/source/kameloso/config.d
+++ b/source/kameloso/config.d
@@ -563,6 +563,18 @@ Next handleGetopt(ref Kameloso instance,
                 customSettings ~= setting;
             }
 
+            version(Windows)
+            {
+                enum getOpenSSLString = "Open the download page for OpenSSL for Windows in your web browser";
+                enum getCacertString = "Download a <l>cacert.pem</> certificate " ~
+                    "file from the cURL project with your browser";
+            }
+            else
+            {
+                enum getOpenSSLString = "(Windows-only)";
+                enum getCacertString = "(Windows-only)";
+            }
+
             return getopt(theseArgs,
                 config.caseSensitive,
                 config.bundling,
@@ -696,6 +708,15 @@ Next handleGetopt(ref Kameloso instance,
                         "Path to <i>cacert.pem</> certificate bundle, or equivalent"
                             .expandTags(LogLevel.trace),
                     &connSettings.caBundleFile,
+                "get-openssl",
+                    quiet ? string.init :
+                        getOpenSSLString,
+                    &shouldDownloadOpenSSL,
+                "get-cacert",
+                    quiet ? string.init :
+                        getCacertString
+                            .expandTags(LogLevel.trace),
+                    &shouldDownloadCacert,
                 "numeric",
                     quiet ? string.init :
                         "Use numeric output of addresses",

--- a/source/kameloso/config.d
+++ b/source/kameloso/config.d
@@ -873,73 +873,8 @@ Next handleGetopt(ref Kameloso instance,
         {
             if (shouldDownloadCacert || shouldDownloadOpenSSL)
             {
-                import kameloso.common : logger;
-                import kameloso.platform : cbd = configurationBaseDirectory;
-                import std.process : Pid, wait;
-
-                Pid cacertBrowser;
-                Pid openSSLBrowser;
-
-                scope(exit)
-                {
-                    if (cacertBrowser) wait(cacertBrowser);
-                    if (openSSLBrowser) wait(openSSLBrowser);
-                }
-
-                Pid openURL(const string url)
-                {
-                    import std.file : tempDir;
-                    import std.path : buildNormalizedPath;
-                    import std.process : spawnProcess;
-                    import std.stdio : File;
-
-                    immutable urlFileName = buildNormalizedPath(tempDir, "kameloso", "link.url");
-
-                    {
-                        auto urlFile = File(urlFileName, "w");
-                        urlFile.writeln("[InternetShortcut]\nURL=", url);
-                    }
-
-                    immutable string[2] browserCommand = [ "explorer", urlFileName ];
-                    auto nulFile = File("NUL", "r+");
-                    return spawnProcess(browserCommand[], nulFile, nulFile, nulFile);
-                }
-
-                if (shouldDownloadCacert)
-                {
-                    import std.path : buildNormalizedPath;
-
-                    enum url = "http://curl.se/ca/cacert.pem";
-                    enum pattern = "<l>cacert.pem</>: Save it anywhere, though preferably in <l>%s</>.";
-                    enum pathPattern = "That way you don't have to enter its full path " ~
-                        "in the configuration file (<l>cacert.pem</> will be enough).";
-                    enum configPattern = "Open the configuration file by passing <l>--gedit</>.";
-
-                    immutable kamelosoDir = buildNormalizedPath(cbd, "kameloso");
-
-                    logger.infof(pattern.expandTags(LogLevel.info), kamelosoDir);
-                    logger.info(pathPattern.expandTags(LogLevel.info));
-                    logger.info(configPattern.expandTags(LogLevel.info));
-
-                    cacertBrowser = openURL(url);
-                }
-
-                if (shouldDownloadCacert && shouldDownloadOpenSSL)
-                {
-                    logger.trace("---");
-                }
-
-                if (shouldDownloadOpenSSL)
-                {
-                    enum url = "https://slproweb.com/products/Win32OpenSSL.html";
-                    enum versionPattern = "<l>OpenSSL</>: You want <l>v1.1.1n Light</> (or later), not <l>v3.0.x</>.";
-                    enum installPattern = "Remember to install to <l>Windows system directories</> when asked.";
-
-                    logger.info(versionPattern.expandTags(LogLevel.info));
-                    logger.info(installPattern.expandTags(LogLevel.info));
-                    openSSLBrowser = openURL(url);
-                }
-
+                import kameloso.ssldownloads : downloadWindowsSSL;
+                downloadWindowsSSL(shouldDownloadCacert, shouldDownloadOpenSSL);
                 return Next.returnSuccess;
             }
         }

--- a/source/kameloso/config.d
+++ b/source/kameloso/config.d
@@ -910,10 +910,10 @@ Next handleGetopt(ref Kameloso instance,
                     import std.path : buildNormalizedPath;
 
                     enum url = "http://curl.se/ca/cacert.pem";
-                    enum pattern = "<l>cacert.pem</>: Save it anywhere, preferably in <l>%s</>.";
+                    enum pattern = "<l>cacert.pem</>: Save it anywhere, though preferably in <l>%s</>.";
                     enum pathPattern = "That way you don't have to enter its full path " ~
                         "in the configuration file (<l>cacert.pem</> will be enough).";
-                    enum configPattern = "(Open the configuration file by passing <l>--gedit</>)";
+                    enum configPattern = "Open the configuration file by passing <l>--gedit</>.";
 
                     immutable kamelosoDir = buildNormalizedPath(cbd, "kameloso");
 

--- a/source/kameloso/config.d
+++ b/source/kameloso/config.d
@@ -874,7 +874,9 @@ Next handleGetopt(ref Kameloso instance,
             if (shouldDownloadCacert || shouldDownloadOpenSSL)
             {
                 import kameloso.ssldownloads : downloadWindowsSSL;
-                downloadWindowsSSL(shouldDownloadCacert, shouldDownloadOpenSSL);
+                downloadWindowsSSL(
+                    cast(Flag!"shouldDownloadCacert")shouldDownloadCacert,
+                    cast(Flag!"shouldDownloadOpenSSL")shouldDownloadOpenSSL);
                 return Next.returnSuccess;
             }
         }

--- a/source/kameloso/config.d
+++ b/source/kameloso/config.d
@@ -459,6 +459,10 @@ Next handleGetopt(ref Kameloso instance,
         bool shouldShowSettings;
         bool shouldAppendToArrays;
 
+        // Windows-only but must be declared regardless of platform
+        bool shouldDownloadOpenSSL;
+        bool shouldDownloadCacert;
+
         string[] inputGuestChannels;
         string[] inputHomeChannels;
         string[] inputAdmins;
@@ -842,6 +846,72 @@ Next handleGetopt(ref Kameloso instance,
             // --settings was passed, show all options and quit
             if (!settings.headless) printSettings(instance, customSettings);
             return Next.returnSuccess;
+        }
+
+        version(Windows)
+        {
+            if (shouldDownloadCacert || shouldDownloadOpenSSL)
+            {
+                import kameloso.common : logger;
+                import kameloso.platform : cbd = configurationBaseDirectory;
+                import std.process : Pid, wait;
+
+                Pid cacertBrowser;
+                Pid openSSLBrowser;
+
+                scope(exit)
+                {
+                    if (cacertBrowser) wait(cacertBrowser);
+                    if (openSSLBrowser) wait(openSSLBrowser);
+                }
+
+                Pid openURL(const string url)
+                {
+                    import std.file : tempDir;
+                    import std.path : buildNormalizedPath;
+                    import std.process : spawnProcess;
+                    import std.stdio : File;
+
+                    immutable urlFileName = buildNormalizedPath(tempDir, "kameloso", "link.url");
+
+                    {
+                        auto urlFile = File(urlFileName, "w");
+                        urlFile.writeln("[InternetShortcut]\nURL=", url);
+                    }
+
+                    immutable string[2] browserCommand = [ "explorer", urlFileName ];
+                    auto nulFile = File("NUL", "r+");
+                    return spawnProcess(browserCommand[], nulFile, nulFile, nulFile);
+                }
+
+                if (shouldDownloadCacert)
+                {
+                    enum url = "http://curl.se/ca/cacert.pem";
+                    enum pattern = "<l>cacert.pem</>: Save it anywhere, preferably in <l>%s/</>.";
+                    enum pathPattern = "That way you don't have to enter its full path " ~
+                        "in the configuration file (<l>cacert.pem</> will be enough).";
+                    enum configPattern = "(Open the configuration file by passing <l>--gedit</)";
+
+                    logger.infof(pattern.expandTags, cbd);
+                    logger.info(pathPattern.expandTags);
+                    logger.info(configPattern.expandTags);
+
+                    cacertBrowser = openURL(url);
+                }
+
+                if (shouldDownloadOpenSSL)
+                {
+                    enum url = "https://slproweb.com/products/Win32OpenSSL.html";
+                    enum versionPattern = "<l>OpenSSL>/>: You want <l>v1.1.1n Light</> (or later), not <l>v3.0.x</>.";
+                    enum installPattern = "Remember to install to <l>Windows system directories</> when asked.";
+
+                    logger.info(versionPattern.expandTags);
+                    logger.info(installPattern.expandTags);
+                    openSSLBrowser = openURL(url);
+                }
+
+                return Next.returnSuccess;
+            }
         }
 
         return Next.continue_;

--- a/source/kameloso/config.d
+++ b/source/kameloso/config.d
@@ -913,7 +913,7 @@ Next handleGetopt(ref Kameloso instance,
                     enum pattern = "<l>cacert.pem</>: Save it anywhere, preferably in <l>%s/</>.";
                     enum pathPattern = "That way you don't have to enter its full path " ~
                         "in the configuration file (<l>cacert.pem</> will be enough).";
-                    enum configPattern = "(Open the configuration file by passing <l>--gedit</)";
+                    enum configPattern = "(Open the configuration file by passing <l>--gedit</>)";
 
                     immutable kamelosoDir = buildNormalizedPath(cbd, "kameloso");
 

--- a/source/kameloso/config.d
+++ b/source/kameloso/config.d
@@ -567,7 +567,7 @@ Next handleGetopt(ref Kameloso instance,
             {
                 enum getOpenSSLString = "Open the download page for OpenSSL for Windows in your web browser";
                 enum getCacertString = "Download a <i>cacert.pem</> certificate " ~
-                    "file from the cURL project with your browser";
+                    "bundle from the cURL project with your browser";
             }
             else
             {

--- a/source/kameloso/config.d
+++ b/source/kameloso/config.d
@@ -910,7 +910,7 @@ Next handleGetopt(ref Kameloso instance,
                     import std.path : buildNormalizedPath;
 
                     enum url = "http://curl.se/ca/cacert.pem";
-                    enum pattern = "<l>cacert.pem</>: Save it anywhere, preferably in <l>%s/</>.";
+                    enum pattern = "<l>cacert.pem</>: Save it anywhere, preferably in <l>%s</>.";
                     enum pathPattern = "That way you don't have to enter its full path " ~
                         "in the configuration file (<l>cacert.pem</> will be enough).";
                     enum configPattern = "(Open the configuration file by passing <l>--gedit</>)";
@@ -927,7 +927,7 @@ Next handleGetopt(ref Kameloso instance,
                 if (shouldDownloadOpenSSL)
                 {
                     enum url = "https://slproweb.com/products/Win32OpenSSL.html";
-                    enum versionPattern = "<l>OpenSSL>/>: You want <l>v1.1.1n Light</> (or later), not <l>v3.0.x</>.";
+                    enum versionPattern = "<l>OpenSSL</>: You want <l>v1.1.1n Light</> (or later), not <l>v3.0.x</>.";
                     enum installPattern = "Remember to install to <l>Windows system directories</> when asked.";
 
                     logger.info(versionPattern.expandTags(LogLevel.info));

--- a/source/kameloso/ssldownloads.d
+++ b/source/kameloso/ssldownloads.d
@@ -66,7 +66,7 @@ void downloadWindowsSSL(
         import kameloso.platform : cbd = configurationBaseDirectory;
         import std.path : buildNormalizedPath;
 
-        enum url = "http://curl.se/ca/cacert.pem";
+        enum url = "https://curl.se/ca/cacert.pem";
         enum pattern = "<l>cacert.pem</>: Save it anywhere, though preferably in <l>%s</>.";
         enum pathPattern = "That way you don't have to enter its full path " ~
             "in the configuration file (<l>cacert.pem</> will be enough).";

--- a/source/kameloso/ssldownloads.d
+++ b/source/kameloso/ssldownloads.d
@@ -71,7 +71,7 @@ void downloadWindowsSSL(
 
         enum url = "https://curl.se/ca/cacert.pem";
         enum pattern = "<l>cacert.pem</>: Save it anywhere, though preferably in " ~
-            "<l>%%APPDATA%%\\kameloso</>. [<l>%s</>]";
+            "<l>%%APPDATA%%\\\\kameloso</>. [<l>%s</>]";
         enum pathPattern = "That way you don't have to enter its full path in the configuration file.";
         enum configPattern = "Tip: Open the configuration file by passing <l>--gedit</>.";
 
@@ -98,4 +98,6 @@ void downloadWindowsSSL(
         logger.info(installPattern.expandTags(LogLevel.info));
         openSSLBrowser = openURL(url);
     }
+
+    logger.trace("---");
 }

--- a/source/kameloso/ssldownloads.d
+++ b/source/kameloso/ssldownloads.d
@@ -40,12 +40,16 @@ void downloadWindowsSSL(
 
     static Pid openURL(const string url)
     {
+        import std.array : replace;
         import std.file : tempDir;
         import std.path : buildNormalizedPath;
         import std.process : spawnProcess;
         import std.stdio : File;
 
-        immutable urlFileName = buildNormalizedPath(tempDir, "kameloso", "link.url");
+        // Save the filename as the URL sans "https://"
+        assert(((url.length > 8) && (url[0..8] == "https://")), url);
+        immutable basename = url[8..$].replace('/', '_') ~ ".url";
+        immutable urlFileName = buildNormalizedPath(tempDir, "kameloso", basename);
 
         {
             auto urlFile = File(urlFileName, "w");

--- a/source/kameloso/ssldownloads.d
+++ b/source/kameloso/ssldownloads.d
@@ -7,9 +7,23 @@ version(Windows):
 
 private:
 
+import std.typecons : Flag, No, Yes;
+
 public:
 
-void downloadWindowsSSL(const bool shouldDownloadCacert, const bool shouldDownloadOpenSSL)
+
+// downloadWindowsSSL
+/++
+    Downloads OpenSSL for Windows and/or a `cacert.pem` certificate bundle from
+    the cURL project, extracted from Mozilla Firefox.
+
+    Params:
+        shouldDownloadCacert = Whether or not `cacert.pem` should be downloaded.
+        shouldDownloadOpenSSL = Whether or not OpenSSL for Windows should be downloaded.
+ +/
+void downloadWindowsSSL(
+    const Flag!"shouldDownloadCacert" shouldDownloadCacert,
+    const Flag!"shouldDownloadOpenSSL" shouldDownloadOpenSSL)
 {
     import kameloso.common : expandTags, logger;
     import kameloso.logger : LogLevel;

--- a/source/kameloso/ssldownloads.d
+++ b/source/kameloso/ssldownloads.d
@@ -1,0 +1,80 @@
+/++
+    Bits and bobs that download SSL libraries and related necessities on Windows.
+ +/
+module kameloso.ssldownloads;
+
+version(Windows):
+
+private:
+
+public:
+
+void downloadWindowsSSL(const bool shouldDownloadCacert, const bool shouldDownloadOpenSSL)
+{
+    import kameloso.common : expandTags, logger;
+    import kameloso.logger : LogLevel;
+    import std.process : Pid, wait;
+
+    Pid cacertBrowser;
+    Pid openSSLBrowser;
+
+    scope(exit)
+    {
+        if (cacertBrowser) wait(cacertBrowser);
+        if (openSSLBrowser) wait(openSSLBrowser);
+    }
+
+    static Pid openURL(const string url)
+    {
+        import std.file : tempDir;
+        import std.path : buildNormalizedPath;
+        import std.process : spawnProcess;
+        import std.stdio : File;
+
+        immutable urlFileName = buildNormalizedPath(tempDir, "kameloso", "link.url");
+
+        {
+            auto urlFile = File(urlFileName, "w");
+            urlFile.writeln("[InternetShortcut]\nURL=", url);
+        }
+
+        immutable string[2] browserCommand = [ "explorer", urlFileName ];
+        auto nulFile = File("NUL", "r+");
+        return spawnProcess(browserCommand[], nulFile, nulFile, nulFile);
+    }
+
+    if (shouldDownloadCacert)
+    {
+        import kameloso.platform : cbd = configurationBaseDirectory;
+        import std.path : buildNormalizedPath;
+
+        enum url = "http://curl.se/ca/cacert.pem";
+        enum pattern = "<l>cacert.pem</>: Save it anywhere, though preferably in <l>%s</>.";
+        enum pathPattern = "That way you don't have to enter its full path " ~
+            "in the configuration file (<l>cacert.pem</> will be enough).";
+        enum configPattern = "Open the configuration file by passing <l>--gedit</>.";
+
+        immutable kamelosoDir = buildNormalizedPath(cbd, "kameloso");
+
+        logger.infof(pattern.expandTags(LogLevel.info), kamelosoDir);
+        logger.info(pathPattern.expandTags(LogLevel.info));
+        logger.info(configPattern.expandTags(LogLevel.info));
+        cacertBrowser = openURL(url);
+    }
+
+    if (shouldDownloadCacert && shouldDownloadOpenSSL)
+    {
+        logger.trace("---");
+    }
+
+    if (shouldDownloadOpenSSL)
+    {
+        enum url = "https://slproweb.com/products/Win32OpenSSL.html";
+        enum versionPattern = "<l>OpenSSL</>: You want <l>v1.1.1n Light</> (or later), not <l>v3.0.x</>.";
+        enum installPattern = "Remember to install to <l>Windows system directories</> when asked.";
+
+        logger.info(versionPattern.expandTags(LogLevel.info));
+        logger.info(installPattern.expandTags(LogLevel.info));
+        openSSLBrowser = openURL(url);
+    }
+}

--- a/source/kameloso/ssldownloads.d
+++ b/source/kameloso/ssldownloads.d
@@ -73,7 +73,7 @@ void downloadWindowsSSL(
         enum pattern = "<l>cacert.pem</>: Save it anywhere, ideally in " ~
             "<l>%%APPDATA%%\\\\kameloso</>. [<l>%s</>]";
         enum pathPattern = "That way you don't have to enter its full path in the configuration file.";
-        enum configPattern = "Tip: Open the configuration file by passing <l>--gedit</>.";
+        enum configPattern = "Tip: Open the configuration file in a text editor by passing <l>--gedit</>.";
 
         immutable kamelosoDir = buildNormalizedPath(cbd, "kameloso");
 

--- a/source/kameloso/ssldownloads.d
+++ b/source/kameloso/ssldownloads.d
@@ -61,7 +61,8 @@ void downloadWindowsSSL(
         return spawnProcess(browserCommand[], nulFile, nulFile, nulFile);
     }
 
-    logger.info("Opening your web browser to download given files...");
+    logger.log("Opening your web browser to download given files...");
+    logger.trace("---");
 
     if (shouldDownloadCacert)
     {
@@ -69,7 +70,8 @@ void downloadWindowsSSL(
         import std.path : buildNormalizedPath;
 
         enum url = "https://curl.se/ca/cacert.pem";
-        enum pattern = "<l>cacert.pem</>: Save it anywhere, though preferably in <l>%%APPDATA%%/kameloso</>. [<l>%s</>]";
+        enum pattern = "<l>cacert.pem</>: Save it anywhere, though preferably in " ~
+            "<l>%%APPDATA%%\\kameloso</>. [<l>%s</>]";
         enum pathPattern = "That way you don't have to enter its full path in the configuration file.";
         enum configPattern = "Tip: Open the configuration file by passing <l>--gedit</>.";
 

--- a/source/kameloso/ssldownloads.d
+++ b/source/kameloso/ssldownloads.d
@@ -61,16 +61,17 @@ void downloadWindowsSSL(
         return spawnProcess(browserCommand[], nulFile, nulFile, nulFile);
     }
 
+    logger.info("Opening your web browser to download given files...");
+
     if (shouldDownloadCacert)
     {
         import kameloso.platform : cbd = configurationBaseDirectory;
         import std.path : buildNormalizedPath;
 
         enum url = "https://curl.se/ca/cacert.pem";
-        enum pattern = "<l>cacert.pem</>: Save it anywhere, though preferably in <l>%s</>.";
-        enum pathPattern = "That way you don't have to enter its full path " ~
-            "in the configuration file (<l>cacert.pem</> will be enough).";
-        enum configPattern = "Open the configuration file by passing <l>--gedit</>.";
+        enum pattern = "<l>cacert.pem</>: Save it anywhere, though preferably in <l>%APPDATA%/kameloso</>. [<l>%s</>]";
+        enum pathPattern = "That way you don't have to enter its full path in the configuration file.";
+        enum configPattern = "Tip: Open the configuration file by passing <l>--gedit</>.";
 
         immutable kamelosoDir = buildNormalizedPath(cbd, "kameloso");
 
@@ -88,7 +89,7 @@ void downloadWindowsSSL(
     if (shouldDownloadOpenSSL)
     {
         enum url = "https://slproweb.com/products/Win32OpenSSL.html";
-        enum versionPattern = "<l>OpenSSL</>: You want <l>v1.1.1n Light</> (or later), not <l>v3.0.x</>.";
+        enum versionPattern = "<l>OpenSSL</>: You want <l>v1.1.1 Light</>, not <l>v3.0.x</>.";
         enum installPattern = "Remember to install to <l>Windows system directories</> when asked.";
 
         logger.info(versionPattern.expandTags(LogLevel.info));

--- a/source/kameloso/ssldownloads.d
+++ b/source/kameloso/ssldownloads.d
@@ -70,7 +70,7 @@ void downloadWindowsSSL(
         import std.path : buildNormalizedPath;
 
         enum url = "https://curl.se/ca/cacert.pem";
-        enum pattern = "<l>cacert.pem</>: Save it anywhere, though preferably in " ~
+        enum pattern = "<l>cacert.pem</>: Save it anywhere, ideally in " ~
             "<l>%%APPDATA%%\\\\kameloso</>. [<l>%s</>]";
         enum pathPattern = "That way you don't have to enter its full path in the configuration file.";
         enum configPattern = "Tip: Open the configuration file by passing <l>--gedit</>.";

--- a/source/kameloso/ssldownloads.d
+++ b/source/kameloso/ssldownloads.d
@@ -69,7 +69,7 @@ void downloadWindowsSSL(
         import std.path : buildNormalizedPath;
 
         enum url = "https://curl.se/ca/cacert.pem";
-        enum pattern = "<l>cacert.pem</>: Save it anywhere, though preferably in <l>%APPDATA%/kameloso</>. [<l>%s</>]";
+        enum pattern = "<l>cacert.pem</>: Save it anywhere, though preferably in <l>%%APPDATA%%/kameloso</>. [<l>%s</>]";
         enum pathPattern = "That way you don't have to enter its full path in the configuration file.";
         enum configPattern = "Tip: Open the configuration file by passing <l>--gedit</>.";
 


### PR DESCRIPTION
This is the third workaround to try to automate downloading OpenSSL and a certificate bundle on Windows. Since we can't create a Powershell script and execute it without first having enabled scripts on the host computer, and we can't access the files via non-encrypted `http://`, this is what we're left with; pointing the user's browser to the files we want them to download.

It's better than nothing but a good deal less than ideal.