### PR TITLE
Downloading Windows SSL bits with Powershell

### DIFF
--- a/source/kameloso/config.d
+++ b/source/kameloso/config.d
@@ -915,8 +915,16 @@ Next handleGetopt(ref Kameloso instance,
                     cast(Flag!"shouldDownloadCacert")shouldDownloadCacert,
                     cast(Flag!"shouldDownloadOpenSSL")shouldDownloadOpenSSL);
 
-                shouldWriteConfig |= settingsTouched;
-                if (!shouldWriteConfig) return Next.returnSuccess;
+                if (settingsTouched)
+                {
+                    import std.stdio : writeln;
+                    shouldWriteConfig = true;
+                    writeln();
+                }
+                else
+                {
+                    return Next.returnSuccess;
+                }
             }
         }
 

--- a/source/kameloso/config.d
+++ b/source/kameloso/config.d
@@ -603,9 +603,9 @@ Next handleGetopt(ref Kameloso instance,
 
             version(Windows)
             {
-                enum getOpenSSLString = "Open the download page for OpenSSL for Windows in your web browser";
+                enum getOpenSSLString = "Downloads OpenSSL for Windows";
                 enum getCacertString = "Download a <i>cacert.pem</> certificate " ~
-                    "bundle from the cURL project with your browser";
+                    "bundle (implies <i>--save</>)";
             }
             else
             {
@@ -904,6 +904,20 @@ Next handleGetopt(ref Kameloso instance,
             return Next.returnSuccess;
         }
 
+        version(Windows)
+        {
+            if (shouldDownloadCacert || shouldDownloadOpenSSL)
+            {
+                import kameloso.ssldownloads : downloadWindowsSSL;
+
+                shouldWriteConfig = shouldWriteConfig || downloadWindowsSSL(
+                    instance.connSettings,
+                    cast(Flag!"shouldDownloadCacert")shouldDownloadCacert,
+                    cast(Flag!"shouldDownloadOpenSSL")shouldDownloadOpenSSL);
+                if (!shouldWriteConfig) return Next.returnSuccess;
+            }
+        }
+
         if (shouldWriteConfig || shouldOpenTerminalEditor || shouldOpenGraphicalEditor)
         {
             // --save and/or --edit was passed; defer to manageConfigFile
@@ -922,18 +936,6 @@ Next handleGetopt(ref Kameloso instance,
             // --settings was passed, show all options and quit
             if (!settings.headless) printSettings(instance, customSettings);
             return Next.returnSuccess;
-        }
-
-        version(Windows)
-        {
-            if (shouldDownloadCacert || shouldDownloadOpenSSL)
-            {
-                import kameloso.ssldownloads : downloadWindowsSSL;
-                downloadWindowsSSL(
-                    cast(Flag!"shouldDownloadCacert")shouldDownloadCacert,
-                    cast(Flag!"shouldDownloadOpenSSL")shouldDownloadOpenSSL);
-                return Next.returnSuccess;
-            }
         }
 
         return Next.continue_;

--- a/source/kameloso/config.d
+++ b/source/kameloso/config.d
@@ -910,10 +910,12 @@ Next handleGetopt(ref Kameloso instance,
             {
                 import kameloso.ssldownloads : downloadWindowsSSL;
 
-                shouldWriteConfig = shouldWriteConfig || downloadWindowsSSL(
+                immutable settingsTouched = downloadWindowsSSL(
                     instance,
                     cast(Flag!"shouldDownloadCacert")shouldDownloadCacert,
                     cast(Flag!"shouldDownloadOpenSSL")shouldDownloadOpenSSL);
+
+                shouldWriteConfig |= settingsTouched;
                 if (!shouldWriteConfig) return Next.returnSuccess;
             }
         }

--- a/source/kameloso/config.d
+++ b/source/kameloso/config.d
@@ -911,7 +911,7 @@ Next handleGetopt(ref Kameloso instance,
                 import kameloso.ssldownloads : downloadWindowsSSL;
 
                 shouldWriteConfig = shouldWriteConfig || downloadWindowsSSL(
-                    instance.connSettings,
+                    instance,
                     cast(Flag!"shouldDownloadCacert")shouldDownloadCacert,
                     cast(Flag!"shouldDownloadOpenSSL")shouldDownloadOpenSSL);
                 if (!shouldWriteConfig) return Next.returnSuccess;

--- a/source/kameloso/ssldownloads.d
+++ b/source/kameloso/ssldownloads.d
@@ -77,8 +77,8 @@ bool downloadWindowsSSL(
         {
             if (!instance.settings.force)
             {
-                enum cacertPattern = "<l>cacert.pem</> saved to <l>%s</>; configuration file updated";
-                logger.infof(cacertPattern.expandTags(LogLevel.info), configDir);
+                enum cacertPattern = "File saved as <l>%s</>; configuration updated.";
+                logger.infof(cacertPattern.expandTags(LogLevel.info), cacertFile);
                 instance.connSettings.caBundleFile = "cacert.pem";  // cacertFile
             }
             retval = true;
@@ -127,6 +127,7 @@ bool downloadWindowsSSL(
                     immutable downloadResult = downloadFile(fileEntryJSON["url"].str, exeFile);
                     if (downloadResult != 0) break;
 
+                    logger.info("Launching OpenSSL installer.");
                     cast(void)execute([ exeFile ]);
                     break;
                 }
@@ -144,7 +145,7 @@ bool downloadWindowsSSL(
         }
         catch (ProcessException e)
         {
-            enum pattern = "Error launching process: <l>%s";
+            enum pattern = "Error starting installer: <l>%s";
             logger.errorf(pattern.expandTags(LogLevel.error), e.msg);
         }
     }

--- a/source/kameloso/ssldownloads.d
+++ b/source/kameloso/ssldownloads.d
@@ -104,7 +104,6 @@ bool downloadWindowsSSL(
         try
         {
             const hashesJSON = parseJSON(readText(jsonFile));
-            bool found;
 
             foreach (immutable filename, fileEntryJSON; hashesJSON["files"].object)
             {
@@ -121,22 +120,19 @@ bool downloadWindowsSSL(
                 {
                     import std.process : execute;
 
-                    found = true;
-
                     immutable exeFile = buildNormalizedPath(temporaryDir, filename);
                     immutable downloadResult = downloadFile(fileEntryJSON["url"].str, exeFile);
                     if (downloadResult != 0) break;
 
                     logger.info("Launching OpenSSL installer.");
                     cast(void)execute([ exeFile ]);
-                    break;
+
+                    return retval;
                 }
             }
 
-            if (!found)
-            {
-                logger.error("Could not find OpenSSL .exe to download");
-            }
+            logger.error("Could not find OpenSSL .exe to download");
+            // Drop down and return
         }
         catch (JSONException e)
         {

--- a/source/kameloso/ssldownloads.d
+++ b/source/kameloso/ssldownloads.d
@@ -80,8 +80,13 @@ bool downloadWindowsSSL(
                 enum cacertPattern = "File saved as <l>%s</>; configuration updated.";
                 logger.infof(cacertPattern.expandTags(LogLevel.info), cacertFile);
                 instance.connSettings.caBundleFile = "cacert.pem";  // cacertFile
+                retval = true;
             }
-            retval = true;
+            else
+            {
+                enum cacertPattern = "File saved as <l>%s</>.";
+                logger.infof(cacertPattern.expandTags(LogLevel.info), cacertFile);
+            }
         }
     }
 

--- a/source/kameloso/ssldownloads.d
+++ b/source/kameloso/ssldownloads.d
@@ -7,7 +7,7 @@ version(Windows):
 
 private:
 
-import kameloso.kameloso : ConnectionSettings, CoreSettings;
+import kameloso.kameloso : Kameloso;
 import std.typecons : Flag, No, Yes;
 
 public:
@@ -19,14 +19,12 @@ public:
     the cURL project, extracted from Mozilla Firefox.
 
     Params:
-        connSettings = Reference to our connection settings struct.
-        settings = Copy of our settings struct.
+        instance = Reference to the current [kameloso.kameloso.Kameloso|Kameloso].
         shouldDownloadCacert = Whether or not `cacert.pem` should be downloaded.
         shouldDownloadOpenSSL = Whether or not OpenSSL for Windows should be downloaded.
  +/
 bool downloadWindowsSSL(
-    ref ConnectionSettings connSettings,
-    const CoreSettings settings,
+    ref Kameloso instance,
     const Flag!"shouldDownloadCacert" shouldDownloadCacert,
     const Flag!"shouldDownloadOpenSSL" shouldDownloadOpenSSL)
 {
@@ -69,12 +67,12 @@ bool downloadWindowsSSL(
     if (shouldDownloadCacert)
     {
         enum cacertURL = "http://curl.se/ca/cacert.pem";
-        immutable cacertFile = buildNormalizedPath(settings.configDirectory, "cacert.pem");
+        immutable cacertFile = buildNormalizedPath(instance.settings.configDirectory, "cacert.pem");
         immutable result = downloadFile(cacertURL, cacertFile);
 
         if (result == 0)
         {
-            connSettings.caBundleFile = cacertFile;
+            instance.connSettings.caBundleFile = cacertFile;
             retval = true;
         }
     }

--- a/source/kameloso/ssldownloads.d
+++ b/source/kameloso/ssldownloads.d
@@ -66,8 +66,10 @@ bool downloadWindowsSSL(
 
     if (shouldDownloadCacert)
     {
+        import std.path : dirName;
+
         enum cacertURL = "http://curl.se/ca/cacert.pem";
-        immutable cacertFile = buildNormalizedPath(instance.settings.configDirectory, "cacert.pem");
+        immutable cacertFile = buildNormalizedPath(instance.settings.configFile.dirName, "cacert.pem");
         immutable result = downloadFile(cacertURL, cacertFile);
 
         if (result == 0)

--- a/source/kameloso/ssldownloads.d
+++ b/source/kameloso/ssldownloads.d
@@ -41,7 +41,7 @@ bool downloadWindowsSSL(
         enum pattern = "Downloading <l>%s</>...";
         logger.infof(pattern.expandTags(LogLevel.info), url);
 
-        enum executePattern = `powershell -c "Invoke-Request '%s' -OutFile '%s'"`;
+        enum executePattern = `powershell -c "Invoke-WebRequest '%s' -OutFile '%s'"`;
         immutable result = executeShell(executePattern.format(url, saveAs));
 
         if (result.status != 0)

--- a/source/kameloso/ssldownloads.d
+++ b/source/kameloso/ssldownloads.d
@@ -86,6 +86,8 @@ bool downloadWindowsSSL(
             {
                 enum cacertPattern = "File saved as <l>%s</>.";
                 logger.infof(cacertPattern.expandTags(LogLevel.info), cacertFile);
+                instance.connSettings.caBundleFile = cacertFile;  // absolute path
+                //retval = true;  // let user supply --save
             }
         }
     }

--- a/source/kameloso/ssldownloads.d
+++ b/source/kameloso/ssldownloads.d
@@ -114,7 +114,11 @@ bool downloadWindowsSSL(
                     import std.process : spawnProcess, wait;
 
                     found = true;
+
                     immutable exeFile = buildNormalizedPath(temporaryDir, filename);
+                    immutable downloadResult = downloadFile(fileEntryJSON["url"].str, exeFile);
+                    if (downloadResult != 0) break;
+
                     auto pid = spawnProcess([ exeFile ]);
                     wait(pid);
                     break;

--- a/source/kameloso/ssldownloads.d
+++ b/source/kameloso/ssldownloads.d
@@ -69,12 +69,18 @@ bool downloadWindowsSSL(
         import std.path : dirName;
 
         enum cacertURL = "http://curl.se/ca/cacert.pem";
-        immutable cacertFile = buildNormalizedPath(instance.settings.configFile.dirName, "cacert.pem");
+        immutable configDir = instance.settings.configFile.dirName;
+        immutable cacertFile = buildNormalizedPath(configDir, "cacert.pem");
         immutable result = downloadFile(cacertURL, cacertFile);
 
         if (result == 0)
         {
-            instance.connSettings.caBundleFile = cacertFile;
+            if (!instance.settings.force)
+            {
+                enum cacertPattern = "<l>cacert.pem</> saved to <l>%s</>; configuration file updated";
+                logger.infof(cacertPattern.expandTags(LogLevel.info), configDir);
+                instance.connSettings.caBundleFile = "cacert.pem";  // cacertFile
+            }
             retval = true;
         }
     }

--- a/source/kameloso/ssldownloads.d
+++ b/source/kameloso/ssldownloads.d
@@ -119,7 +119,7 @@ bool downloadWindowsSSL(
 
                 if (filename.beginsWith(head) && filename.endsWith(".exe"))
                 {
-                    import std.process : spawnProcess, wait;
+                    import std.process : execute;
 
                     found = true;
 
@@ -127,8 +127,7 @@ bool downloadWindowsSSL(
                     immutable downloadResult = downloadFile(fileEntryJSON["url"].str, exeFile);
                     if (downloadResult != 0) break;
 
-                    auto pid = spawnProcess([ exeFile ]);
-                    wait(pid);
+                    cast(void)execute([ exeFile ]);
                     break;
                 }
             }

--- a/source/kameloso/ssldownloads.d
+++ b/source/kameloso/ssldownloads.d
@@ -83,6 +83,7 @@ bool downloadWindowsSSL(
         import std.algorithm.searching : endsWith;
         import std.file : readText;
         import std.json : JSONException, parseJSON;
+        import std.process : ProcessException;
 
         immutable temporaryDir = buildNormalizedPath(tempDir, "kameloso");
         mkdirRecurse(temporaryDir);
@@ -128,6 +129,11 @@ bool downloadWindowsSSL(
         catch (JSONException e)
         {
             enum pattern = "Error parsing file containing OpenSSL download links: <l>%s";
+            logger.errorf(pattern.expandTags(LogLevel.error), e.msg);
+        }
+        catch (ProcessException e)
+        {
+            enum pattern = "Error launching process: <l>%s";
             logger.errorf(pattern.expandTags(LogLevel.error), e.msg);
         }
     }


### PR DESCRIPTION
This is the second attempt at downloading OpenSSL and a `cacert.pem` using Powershell on Windows.

This time we don't create a script to download the files, but rather just pass a command to Powershell with `powershell -c "Invoke-WebRequest [...]"`. It works and we can automate downloading the OpenSSL installer (and `cacert.pem` though it's even over non-encrypted `http:///`).