### PR TITLE
Song requests (YouTube and Spotify)

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ Assuming a prefix of `!`, commands to test are:
 * `!ecount`
 * `!watchtime`
 * `!nuke`
+* `!songrequest`
 
 ...alongside `!oneliner`, `!counter`, `!timer`, `!poll`, `!stopwatch`, and other non-Twitch-specific commands. Try `!help` or [the wiki](https://github.com/zorael/kameloso/wiki/Current-plugins).
 
@@ -440,7 +441,7 @@ If you still can't find what you're looking for, or if you have suggestions on h
 
 * pipedream zero: **no compiler segfaults** ([#18026](https://issues.dlang.org/show_bug.cgi?id=18026), [#20562](https://issues.dlang.org/show_bug.cgi?id=20562))
 * please send help: Windows Secure Channel SSL
-* Twitch `settitle`, `setgame`? difficult
+* Twitch `settitle`, `setgame`? plausible
 * **more pairs of eyes**
 
 # Built with

--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ To connect to Twitch servers you must first build a configuration that includes 
 
 You must also supply an [OAuth API key](https://en.wikipedia.org/wiki/OAuth). Assuming you have a configuration file set up to connect to Twitch, run the bot with `--set twitch.keygen` to start the captive process of generating one. It will open a browser window, in which you are asked to log onto Twitch *on Twitch's own servers*. Verify this by checking the page address; it should end with `.twitch.tv`, with the little lock symbol showing the connection is secure.
 
-> Note: At no point is the bot privy to your Twitch login credentials! The logging-in is wholly done on Twitch's own servers, and no information is sent to any third parties. The code that deals with this is open for audit; [`generateKey` in `twitchbot/keygen.d`](source/kameloso/plugins/twitchbot/keygen.d).
+> Note: At no point is the bot privy to your Twitch login credentials! The logging-in is wholly done on Twitch's own servers, and no information is sent to any third parties. The code that deals with this is open for audit; [`requestTwitchKey` in `twitchbot/keygen.d`](source/kameloso/plugins/twitchbot/keygen.d).
 
 After entering your login and password and clicking **Authorize**, you will be redirected to an empty "`this site can't be reached`" or "`unable to connect`" page. **Copy the URL address of it** and paste it into the terminal, when asked. It will parse the address, extract your authorisation token, and offer to save it to your configuration file.
 

--- a/source/kameloso/main.d
+++ b/source/kameloso/main.d
@@ -332,10 +332,8 @@ void messageFiber(ref Kameloso instance)
                 break;
 
             default:
-                import std.stdio;
                 enum pattern = "onMessage received unexpected message type: <l>%s";
                 logger.errorf(pattern.expandTags(LogLevel.error), message.type);
-                writeln(message);
                 if (instance.settings.flush) stdout.flush();
                 break;
             }

--- a/source/kameloso/plugins/oneliners.d
+++ b/source/kameloso/plugins/oneliners.d
@@ -171,6 +171,7 @@ public:
         json["trigger"] = JSONValue(this.trigger);
         json["type"] = JSONValue(cast(int)this.type);
         json["responses"] = JSONValue(this.responses);
+
         return json;
     }
 
@@ -184,7 +185,7 @@ public:
         Returns:
             A new [Oneliner] with values loaded from the passed JSON.
      +/
-    static Oneliner fromJSON(const JSONValue json)
+    static auto fromJSON(const JSONValue json)
     {
         Oneliner oneliner;
         oneliner.trigger = json["trigger"].str;

--- a/source/kameloso/plugins/services/connect.d
+++ b/source/kameloso/plugins/services/connect.d
@@ -474,7 +474,7 @@ void onTwitchAuthFailure(ConnectService service, const ref IRCEvent event)
             if (!service.state.bot.pass.length)
             {
                 logger.error("You *need* a pass to join this server.");
-                enum pattern = "Run the program with <i>--set twitchbot.keygen</> to generate a new one.";
+                enum pattern = "Run the program with <i>--set twitch.keygen</> to generate a new one.";
                 logger.log(pattern.expandTags(LogLevel.all));
             }
             else
@@ -486,7 +486,7 @@ void onTwitchAuthFailure(ConnectService service, const ref IRCEvent event)
 
         case "Login authentication failed":
             logger.error("Incorrect client pass. Please make sure it is valid and has not expired.");
-            enum pattern = "Run the program with <i>--set twitchbot.keygen</> to generate a new one.";
+            enum pattern = "Run the program with <i>--set twitch.keygen</> to generate a new one.";
             logger.log(pattern.expandTags(LogLevel.all));
             break;
 

--- a/source/kameloso/plugins/timer.d
+++ b/source/kameloso/plugins/timer.d
@@ -231,7 +231,7 @@ public:
         Returns:
             A new [TimerDefinition] with values loaded from the passed JSON.
      +/
-    static TimerDefinition fromJSON(const JSONValue json)
+    static auto fromJSON(const JSONValue json)
     {
         TimerDefinition def;
         def.name = json["name"].str;

--- a/source/kameloso/plugins/twitchbot/api.d
+++ b/source/kameloso/plugins/twitchbot/api.d
@@ -85,7 +85,7 @@ if (isSomeFunction!dg)
             // Copy/paste kameloso.messaging.quit, since we don't have access to plugin.state
 
             enum apiPattern = "Your Twitch API key has expired. " ~
-                "Run the program with <l>--set twitchbot.keygen</> to generate a new one.";
+                "Run the program with <l>--set twitch.keygen</> to generate a new one.";
             logger.error(apiPattern.expandTags(LogLevel.error));
 
             Message m;

--- a/source/kameloso/plugins/twitchbot/base.d
+++ b/source/kameloso/plugins/twitchbot/base.d
@@ -47,7 +47,7 @@ public:
     /++
         What kind of song requests to accept, if any.
      +/
-    SongRequestMode songRequestMode = SongRequestMode.youtube;
+    SongRequestMode songrequestMode = SongRequestMode.youtube;
 
     /++
         What level of user permissions are needed to issue song requests.
@@ -1355,7 +1355,7 @@ void onCommandSongRequest(TwitchBotPlugin plugin, const ref IRCEvent event)
     import std.format : format;
     import core.time : seconds;
 
-    if (plugin.twitchBotSettings.songRequestMode == SongRequestMode.disabled) return;
+    if (plugin.twitchBotSettings.songrequestMode == SongRequestMode.disabled) return;
     else if (event.sender.class_ < plugin.twitchBotSettings.songrequestPermsNeeded)
     {
         // Issue an error?
@@ -1363,7 +1363,7 @@ void onCommandSongRequest(TwitchBotPlugin plugin, const ref IRCEvent event)
         return;
     }
 
-    if (plugin.twitchBotSettings.songRequestMode == SongRequestMode.youtube)
+    if (plugin.twitchBotSettings.songrequestMode == SongRequestMode.youtube)
     {
         immutable url = event.content.stripped;
 
@@ -1438,7 +1438,7 @@ void onCommandSongRequest(TwitchBotPlugin plugin, const ref IRCEvent event)
             chan(plugin.state, event.channel, e.msg);
         }
     }
-    else if (plugin.twitchBotSettings.songRequestMode == SongRequestMode.spotify)
+    else if (plugin.twitchBotSettings.songrequestMode == SongRequestMode.spotify)
     {
         immutable url = event.content.stripped;
 

--- a/source/kameloso/plugins/twitchbot/base.d
+++ b/source/kameloso/plugins/twitchbot/base.d
@@ -1493,7 +1493,7 @@ void onCommandSongRequest(TwitchBotPlugin plugin, const ref IRCEvent event)
 
             immutable json = addTrackToSpotifyPlaylist(plugin, *creds, trackID);
 
-            if ((json.type != JSONType.object)  || "snapshot" !in json)
+            if ((json.type != JSONType.object)  || "snapshot_id" !in json)
             {
                 logger.error("An error occured.");
                 return;

--- a/source/kameloso/plugins/twitchbot/base.d
+++ b/source/kameloso/plugins/twitchbot/base.d
@@ -85,6 +85,12 @@ public:
             authorisation key. Should not be permanently set in the configuration file!
          +/
         bool keygen = false;
+
+        /++
+            Whether or not to start a captive session for generating Google
+            authorisation codes and tokens. The value should be a channel name.
+         +/
+        string googleKeygen;
     }
 }
 

--- a/source/kameloso/plugins/twitchbot/base.d
+++ b/source/kameloso/plugins/twitchbot/base.d
@@ -206,6 +206,7 @@ package struct Credentials
         json["googleAccessToken"] = this.googleAccessToken;
         json["googleRefreshToken"] = this.googleRefreshToken;
         json["youtubePlaylistID"] = this.youtubePlaylistID;
+        json["spotifyClientID"] = this.spotifyClientID;
         json["spotifyAccessToken"] = this.spotifyAccessToken;
         json["spotifyRefreshToken"] = this.spotifyRefreshToken;
         json["spotifyPlaylistID"] = this.spotifyPlaylistID;
@@ -227,6 +228,7 @@ package struct Credentials
         creds.googleAccessToken = json["googleAccessToken"].str;
         creds.googleRefreshToken = json["googleRefreshToken"].str;
         creds.youtubePlaylistID = json["youtubePlaylistID"].str;
+        creds.spotifyClientID = json["spotifyClientID"].str;
         creds.spotifyAccessToken = json["spotifyAccessToken"].str;
         creds.spotifyRefreshToken = json["spotifyRefreshToken"].str;
         creds.spotifyPlaylistID = json["spotifyPlaylistID"].str;

--- a/source/kameloso/plugins/twitchbot/base.d
+++ b/source/kameloso/plugins/twitchbot/base.d
@@ -90,7 +90,7 @@ public:
             Whether or not to start a captive session for generating Google
             authorisation codes and tokens. The value should be a channel name.
          +/
-        string googleKeygen;
+        bool googleKeygen = false;
     }
 }
 
@@ -1755,16 +1755,9 @@ void onCAP(TwitchBotPlugin plugin)
 
         if (*plugin.state.abort) return;
 
-        if (plugin.twitchBotSettings.googleKeygen.length)
+        if (plugin.twitchBotSettings.googleKeygen)
         {
-            if (plugin.twitchBotSettings.googleKeygen[0] != '#')
-            {
-                enum message = "You must pass a channel as value to <l>--set twitch.googleKeygen</>.";
-                logger.error(message.expandTags(LogLevel.error));
-                return;
-            }
-
-            plugin.generateGoogleCode(plugin.twitchBotSettings.googleKeygen);
+            plugin.generateGoogleCode();
         }
     }
 }

--- a/source/kameloso/plugins/twitchbot/base.d
+++ b/source/kameloso/plugins/twitchbot/base.d
@@ -290,7 +290,7 @@ void onCommandStart(TwitchBotPlugin plugin, const /*ref*/ IRCEvent event)
     import core.thread : Fiber;
 
     auto room = event.channel in plugin.rooms;
-    assert(room, "Tried to start a broadcast on a nonexistent room");
+    assert(room, "Tried to start a broadcast in a nonexistent room");
 
     void sendUsage()
     {
@@ -530,7 +530,7 @@ void onCommandStart(TwitchBotPlugin plugin, const /*ref*/ IRCEvent event)
 void onCommandStop(TwitchBotPlugin plugin, const ref IRCEvent event)
 {
     auto room = event.channel in plugin.rooms;
-    assert(room, "Tried to stop a broadcast on a nonexistent room");
+    assert(room, "Tried to stop a broadcast in a nonexistent room");
 
     if (!room.broadcast.active)
     {

--- a/source/kameloso/plugins/twitchbot/base.d
+++ b/source/kameloso/plugins/twitchbot/base.d
@@ -44,6 +44,16 @@ public:
     bool watchtime = true;
 
     /++
+        Whether or not to enable taking song requests.
+     +/
+    bool songRequests = true;
+
+    /++
+        What level of user permissions are needed to issue song requests.
+     +/
+    IRCUser.Class songrequestPermsNeeded = IRCUser.Class.whitelist;
+
+    /++
         Whether or not broadcasters are always implicitly class
         [dialect.defs.IRCUser.Class.staff|IRCUser.Class.staff].
      +/
@@ -1268,7 +1278,12 @@ void onCommandSongRequest(TwitchBotPlugin plugin, const ref IRCEvent event)
     import std.stdio;
     import core.time : seconds;
 
-    // FIXME: insert soft permissions check
+    if (!plugin.twitchBotSettings.songRequests) return;
+    else if (event.sender.class_ < plugin.twitchBotSettings.songrequestPermsNeeded)
+    {
+        // Issue an error?
+        return;
+    }
 
     if (!event.content.length ||
         event.content.contains(' ') ||

--- a/source/kameloso/plugins/twitchbot/base.d
+++ b/source/kameloso/plugins/twitchbot/base.d
@@ -25,6 +25,7 @@ module kameloso.plugins.twitchbot.base;
 package @Settings struct TwitchBotSettings
 {
 private:
+    import dialect.defs : IRCUser;
     import lu.uda : Unserialisable;
 
 public:
@@ -115,6 +116,30 @@ public:
         bool broadcasterKeygen = false;
     }
 }
+
+
+// SongRequestMode
+/++
+    Song requests may be either disabled, or either in YouTube or Spotify mode.
+ +/
+private enum SongRequestMode
+{
+    /++
+        Song requests are disabled.
+     +/
+    disabled,
+
+    /++
+        Song requests relate to a YouTube playlist.
+     +/
+    youtube,
+
+    /++
+        Song requests relatet to a Spotify playlist.
+     +/
+    spotify,
+}
+
 
 private import kameloso.plugins.common.core;
 
@@ -249,29 +274,6 @@ package struct Credentials
         creds.spotifyPlaylistID = json["spotifyPlaylistID"].str;
         return creds;
     }
-}
-
-
-// SongRequestMode
-/++
-    Song requests may be either disabled, or either in YouTube or Spotify mode.
- +/
-enum SongRequestMode
-{
-    /++
-        Song requests are disabled.
-     +/
-    disabled,
-
-    /++
-        Song requests relate to a YouTube playlist.
-     +/
-    youtube,
-
-    /++
-        Song requests relatet to a Spotify playlist.
-     +/
-    spotify,
 }
 
 

--- a/source/kameloso/plugins/twitchbot/base.d
+++ b/source/kameloso/plugins/twitchbot/base.d
@@ -1331,7 +1331,7 @@ void onCommandNuke(TwitchBotPlugin plugin, const ref IRCEvent event)
  +/
 @(IRCEventHandler()
     .onEvent(IRCEvent.Type.CHAN)
-    .permissionsRequired(Permissions.whitelist)
+    .permissionsRequired(Permissions.anyone)
     .channelPolicy(ChannelPolicy.home)
     .addCommand(
         IRCEventHandler.Command()

--- a/source/kameloso/plugins/twitchbot/base.d
+++ b/source/kameloso/plugins/twitchbot/base.d
@@ -219,6 +219,7 @@ package struct Credentials
         json["googleRefreshToken"] = this.googleRefreshToken;
         json["youtubePlaylistID"] = this.youtubePlaylistID;
         json["spotifyClientID"] = this.spotifyClientID;
+        json["spotifyClientSecret"] = this.spotifyClientSecret;
         json["spotifyAccessToken"] = this.spotifyAccessToken;
         json["spotifyRefreshToken"] = this.spotifyRefreshToken;
         json["spotifyPlaylistID"] = this.spotifyPlaylistID;
@@ -242,6 +243,7 @@ package struct Credentials
         creds.googleRefreshToken = json["googleRefreshToken"].str;
         creds.youtubePlaylistID = json["youtubePlaylistID"].str;
         creds.spotifyClientID = json["spotifyClientID"].str;
+        creds.spotifyClientSecret = json["spotifyClientSecret"].str;
         creds.spotifyAccessToken = json["spotifyAccessToken"].str;
         creds.spotifyRefreshToken = json["spotifyRefreshToken"].str;
         creds.spotifyPlaylistID = json["spotifyPlaylistID"].str;

--- a/source/kameloso/plugins/twitchbot/base.d
+++ b/source/kameloso/plugins/twitchbot/base.d
@@ -1402,7 +1402,11 @@ void onCommandSongRequest(TwitchBotPlugin plugin, const ref IRCEvent event)
         string slice = url;  // mutable
         string videoID;
 
-        if (slice.contains("youtube.com/watch?v="))
+        if (slice.length == 11)
+        {
+            videoID = slice;
+        }
+        else if (slice.contains("youtube.com/watch?v="))
         {
             slice.nom("youtube.com/watch?v=");
             videoID = slice.nom!(Yes.inherit)('&');
@@ -1411,10 +1415,6 @@ void onCommandSongRequest(TwitchBotPlugin plugin, const ref IRCEvent event)
         {
             slice.nom("youtu.be/");
             videoID = slice.nom!(Yes.inherit)('?');
-        }
-        else if (slice.length == 11)
-        {
-            videoID = slice;
         }
         else
         {
@@ -1474,14 +1474,14 @@ void onCommandSongRequest(TwitchBotPlugin plugin, const ref IRCEvent event)
         string slice = url;  // mutable
         string trackID;
 
-        if (slice.contains("spotify.com/track/"))
+        if (slice.length == 22)
+        {
+            trackID = slice;
+        }
+        else if (slice.contains("spotify.com/track/"))
         {
             slice.nom("spotify.com/track/");
             trackID = slice.nom!(Yes.inherit)('?');
-        }
-        else if (slice.length == 22)
-        {
-            trackID = slice;
         }
         else
         {

--- a/source/kameloso/plugins/twitchbot/base.d
+++ b/source/kameloso/plugins/twitchbot/base.d
@@ -91,22 +91,28 @@ public:
         bool bellOnImportant = false;
 
         /++
-            Whether or not to start a captive session for generating a Twitch
-            authorisation key.
+            Whether or not to start a captive session for requesting a Twitch
+            access token with normal chat privileges.
          +/
         bool keygen = false;
 
         /++
-            Whether or not to start a captive session for generating Google
-            authorisation codes and tokens.
+            Whether or not to start a captive session for requesting Google
+            access tokens.
          +/
         bool googleKeygen = false;
 
         /++
-            Whether or not to start a captive session for generating Spotify
-            authorisation codes and tokens.
+            Whether or not to start a captive session for requesting Spotify
+            access tokens.
          +/
         bool spotifyKeygen = false;
+
+        /++
+            Whether or not to start a acptive session for requesting a Twitch
+            authorisation token with higher broadcaster privileges.
+         +/
+        bool broadcasterKeygen = false;
     }
 }
 
@@ -139,6 +145,11 @@ import core.thread : Fiber;
  +/
 package struct Credentials
 {
+    /++
+        Broadcaster-level Twitch key.
+     +/
+    string broadcasterKey;
+
     /++
         Google client ID.
      +/
@@ -201,6 +212,7 @@ package struct Credentials
         json = null;
         json.object = null;
 
+        json["broadcasterKey"] = this.broadcasterKey;
         json["googleClientID"] = this.googleClientID;
         json["googleClientSecret"] = this.googleClientSecret;
         json["googleAccessToken"] = this.googleAccessToken;
@@ -223,6 +235,7 @@ package struct Credentials
     static auto fromJSON(const JSONValue json)
     {
         typeof(this) creds;
+        creds.broadcasterKey = json["broadcasterKey"].str;
         creds.googleClientID = json["googleClientID"].str;
         creds.googleClientSecret = json["googleClientSecret"].str;
         creds.googleAccessToken = json["googleAccessToken"].str;

--- a/source/kameloso/plugins/twitchbot/base.d
+++ b/source/kameloso/plugins/twitchbot/base.d
@@ -1179,6 +1179,12 @@ void onAnyMessage(TwitchBotPlugin plugin, const ref IRCEvent event)
         stdout.flush();
     }
 
+    if (event.type == IRCEvent.Type.QUERY)
+    {
+        // Ignore queries for the rest of this function
+        return;
+    }
+
     // ecount!
     if (plugin.twitchBotSettings.ecount && event.emotes.length)
     {

--- a/source/kameloso/plugins/twitchbot/base.d
+++ b/source/kameloso/plugins/twitchbot/base.d
@@ -375,7 +375,7 @@ void onCommandStart(TwitchBotPlugin plugin, const /*ref*/ IRCEvent event)
     {
         uint addedSinceLastRehash;
 
-        while (room.broadcast.active)
+        while (room.broadcast.active && plugin.useAPIFeatures)
         {
             import kameloso.plugins.common.delayawait : delay;
             import std.json : JSONType;
@@ -920,6 +920,8 @@ void onCommandShoutout(TwitchBotPlugin plugin, const /*ref*/ IRCEvent event)
     import lu.string : SplitResults, beginsWith, splitInto, stripped;
     import std.format : format;
     import std.json : JSONType, parseJSON;
+
+    if (!plugin.useAPIFeatures) return;
 
     void sendUsage()
     {
@@ -1515,7 +1517,8 @@ void onCommandWatchtime(TwitchBotPlugin plugin, const /*ref*/ IRCEvent event)
     import core.thread : Fiber;
     import core.time : Duration, seconds;
 
-    if (!plugin.twitchBotSettings.watchtime) return;
+    if (!plugin.useAPIFeatures) return;
+    else if (!plugin.twitchBotSettings.watchtime) return;
 
     void watchtimeDg()
     {
@@ -1667,7 +1670,7 @@ void onMyInfo(TwitchBotPlugin plugin)
         {
             immutable now = Clock.currTime;
 
-            if (plugin.isEnabled)
+            if (plugin.isEnabled && plugin.useAPIFeatures)
             {
                 foreach (immutable channelName, room; plugin.rooms)
                 {

--- a/source/kameloso/plugins/twitchbot/base.d
+++ b/source/kameloso/plugins/twitchbot/base.d
@@ -1351,7 +1351,6 @@ void onCommandSongRequest(TwitchBotPlugin plugin, const ref IRCEvent event)
     import arsd.http2 : HttpClient, HttpVerb, Uri;
     import lu.string : contains, nom, stripped;
     import std.format : format;
-    import std.stdio;
     import core.time : seconds;
 
     if (plugin.twitchBotSettings.songRequestMode == SongRequestMode.disabled) return;

--- a/source/kameloso/plugins/twitchbot/base.d
+++ b/source/kameloso/plugins/twitchbot/base.d
@@ -1745,11 +1745,27 @@ void onCAP(TwitchBotPlugin plugin)
     import kameloso.plugins.twitchbot.keygen : generateKey;
     import std.algorithm.searching : endsWith;
 
-    if (plugin.twitchBotSettings.keygen &&
-        (plugin.state.server.daemon == IRCServer.Daemon.unset) &&
+    if ((plugin.state.server.daemon == IRCServer.Daemon.unset) &&
         plugin.state.server.address.endsWith(".twitch.tv"))
     {
-        return plugin.generateKey();
+        if (plugin.twitchBotSettings.keygen)
+        {
+            plugin.generateKey();
+        }
+
+        if (*plugin.state.abort) return;
+
+        if (plugin.twitchBotSettings.googleKeygen.length)
+        {
+            if (plugin.twitchBotSettings.googleKeygen[0] != '#')
+            {
+                enum message = "You must pass a channel as value to <l>--set twitch.googleKeygen</>.";
+                logger.error(message.expandTags(LogLevel.error));
+                return;
+            }
+
+            plugin.generateGoogleCode(plugin.twitchBotSettings.googleKeygen);
+        }
     }
 }
 

--- a/source/kameloso/plugins/twitchbot/base.d
+++ b/source/kameloso/plugins/twitchbot/base.d
@@ -1816,7 +1816,7 @@ void onCommandWatchtime(TwitchBotPlugin plugin, const /*ref*/ IRCEvent event)
 )
 void onCAP(TwitchBotPlugin plugin)
 {
-    import kameloso.plugins.twitchbot.keygen : generateKey;
+    import kameloso.plugins.twitchbot.keygen : requestTwitchKey;
     import std.algorithm.searching : endsWith;
 
     if ((plugin.state.server.daemon == IRCServer.Daemon.unset) &&
@@ -1824,14 +1824,14 @@ void onCAP(TwitchBotPlugin plugin)
     {
         if (plugin.twitchBotSettings.keygen)
         {
-            plugin.generateKey();
+            plugin.requestTwitchKey();
         }
 
         if (*plugin.state.abort) return;
 
         if (plugin.twitchBotSettings.googleKeygen)
         {
-            plugin.generateGoogleCode();
+            plugin.requestGoogleKeys();
         }
     }
 }

--- a/source/kameloso/plugins/twitchbot/base.d
+++ b/source/kameloso/plugins/twitchbot/base.d
@@ -1972,6 +1972,14 @@ void onCAP(TwitchBotPlugin plugin)
     if ((plugin.state.server.daemon == IRCServer.Daemon.unset) &&
         plugin.state.server.address.endsWith(".twitch.tv"))
     {
+        if (plugin.twitchBotSettings.keygen ||
+            plugin.twitchBotSettings.googleKeygen ||
+            plugin.twitchBotSettings.spotifyKeygen)
+        {
+            // Some keygen, reload to load secrets so existing ones are read
+            plugin.reload();
+        }
+
         if (plugin.twitchBotSettings.keygen)
         {
             plugin.requestTwitchKey();

--- a/source/kameloso/plugins/twitchbot/base.d
+++ b/source/kameloso/plugins/twitchbot/base.d
@@ -1121,19 +1121,17 @@ void onCommandNuke(TwitchBotPlugin plugin, const ref IRCEvent event)
     import std.conv : text;
     import std.uni : toLower;
 
-    auto room = event.channel in plugin.rooms;
-    assert(room, "Tried to nuke a word in a nonexistent room");
-
     if (!event.content.length)
     {
         import std.format : format;
-
         enum pattern = "Usage: %s%s [word or phrase]";
         immutable message = pattern.format(plugin.state.settings.prefix, event.aux);
         chan(plugin.state, event.channel, message);
         return;
     }
 
+    auto room = event.channel in plugin.rooms;
+    assert(room, "Tried to nuke a word in a nonexistent room");
     immutable phraseToLower = event.content.toLower;
 
     foreach (immutable storedEvent; room.lastNMessages)
@@ -1141,8 +1139,8 @@ void onCommandNuke(TwitchBotPlugin plugin, const ref IRCEvent event)
         import std.algorithm.searching : canFind;
         import std.uni : asLowerCase;
 
-        if (!storedEvent.content.length) continue;
-        else if (storedEvent.sender.class_ >= IRCUser.Class.operator) continue;
+        if (storedEvent.sender.class_ >= IRCUser.Class.operator) continue;
+        else if (!storedEvent.content.length) continue;
 
         if (storedEvent.content.asLowerCase.canFind(phraseToLower))
         {

--- a/source/kameloso/plugins/twitchbot/base.d
+++ b/source/kameloso/plugins/twitchbot/base.d
@@ -44,9 +44,9 @@ public:
     bool watchtime = true;
 
     /++
-        Whether or not to enable taking song requests.
+        What kind of song requests to accept, if any.
      +/
-    bool songRequests = true;
+    SongRequestMode songRequestMode = SongRequestMode.youtube;
 
     /++
         What level of user permissions are needed to issue song requests.
@@ -160,6 +160,16 @@ package struct Credentials
     string youtubePlaylistID;
 
     /++
+        Spotify API OAuth access token.
+     +/
+    string spotifyAccessToken;
+
+    /++
+        Spotify API OAuth refresh token.
+     +/
+    string spotifyRefreshToken;
+
+    /++
         Serialises these [Credentials] into JSON.
 
         Returns:
@@ -176,6 +186,8 @@ package struct Credentials
         json["googleAccessToken"] = this.googleAccessToken;
         json["googleRefreshToken"] = this.googleRefreshToken;
         json["youtubePlaylistID"] = this.youtubePlaylistID;
+        json["spotifyAccessToken"] = this.spotifyAccessToken;
+        json["spotifyRefreshToken"] = this.spotifyRefreshToken;
 
         return json;
     }
@@ -194,8 +206,33 @@ package struct Credentials
         creds.googleAccessToken = json["googleAccessToken"].str;
         creds.googleRefreshToken = json["googleRefreshToken"].str;
         creds.youtubePlaylistID = json["youtubePlaylistID"].str;
+        creds.spotifyAccessToken = json["spotifyAccessToken"].str;
+        creds.spotifyRefreshToken = json["spotifyRefreshToken"].str;
         return creds;
     }
+}
+
+
+// SongRequestMode
+/++
+    Song requests may be either disabled, or either in YouTube or Spotify mode.
+ +/
+enum SongRequestMode
+{
+    /++
+        Song requests are disabled.
+     +/
+    disabled,
+
+    /++
+        Song requests relate to a YouTube playlist.
+     +/
+    youtube,
+
+    /++
+        Song requests relatet to a Spotify playlist.
+     +/
+    spotify,
 }
 
 

--- a/source/kameloso/plugins/twitchbot/base.d
+++ b/source/kameloso/plugins/twitchbot/base.d
@@ -82,7 +82,7 @@ public:
 
         /++
             Whether or not to start a captive session for generating a Twitch
-            authorisation key. Should not be permanently set in the configuration file!
+            authorisation key.
          +/
         bool keygen = false;
 

--- a/source/kameloso/plugins/twitchbot/base.d
+++ b/source/kameloso/plugins/twitchbot/base.d
@@ -1639,121 +1639,131 @@ void onEndOfMOTD(TwitchBotPlugin plugin)
             import std.datetime.systime : Clock, SysTime;
             import core.time : days, hours, weeks;
 
-            try
+            enum retriesInCaseOfConnectionErrors = 5;
+
+            while (true)
             {
-                /*
+                try
                 {
-                    "client_id": "tjyryd2ojnqr8a51ml19kn1yi2n0v1",
-                    "expires_in": 5036421,
-                    "login": "zorael",
-                    "scopes": [
-                        "bits:read",
-                        "channel:moderate",
-                        "channel:read:subscriptions",
-                        "channel_editor",
-                        "chat:edit",
-                        "chat:read",
-                        "user:edit:broadcast",
-                        "whispers:edit",
-                        "whispers:read"
-                    ],
-                    "user_id": "22216721"
-                }
-                */
-
-                immutable validationJSON = getValidation(plugin);
-                plugin.userID = validationJSON["user_id"].str;
-                immutable expiresIn = validationJSON["expires_in"].integer;
-
-                /+
-                    The below can probably never happen, as we never get to
-                    connect if the key has expired.
-                 +/
-                /*if (expiresIn == 0L)
-                {
-                    import kameloso.messaging : quit;
-                    import std.typecons : Flag, No, Yes;
-
-                    // Expired.
-                    logger.error("Error: Your Twitch authorisation key has expired.");
-                    quit!(Yes.priority)(plugin.state, string.init, Yes.quiet);
-                    return;
-                }*/
-
-                immutable expiresWhen = SysTime.fromUnixTime(Clock.currTime.toUnixTime + expiresIn);
-                immutable now = Clock.currTime;
-                immutable delta = (expiresWhen - now);
-                immutable numDays = delta.total!"days";
-
-                if (delta > 1.weeks)
-                {
-                    // More than a week away, just .info
-                    enum pattern = "Your Twitch authorisation key will expire " ~
-                        "in <l>%d days</> on <l>%4d-%02d-%02d</>.";
-                    logger.infof(pattern.expandTags(LogLevel.info), numDays,
-                        expiresWhen.year, expiresWhen.month, expiresWhen.day);
-                }
-                else if (delta > 1.days)
-                {
-                    // A week or less, more than a day; warning
-                    enum pattern = "Warning: Your Twitch authorisation key will expire " ~
-                        "in <l>%d %s</> on <l>%4d-%02d-%02d %02d:%02d</>.";
-                    logger.warningf(pattern.expandTags(LogLevel.warning),
-                        numDays, numDays.plurality("day", "days"),
-                        expiresWhen.year, expiresWhen.month, expiresWhen.day,
-                        expiresWhen.hour, expiresWhen.minute);
-                }
-                else
-                {
-                    // Less than a day; warning
-                    immutable numHours = delta.total!"hours";
-                    enum pattern = "WARNING: Your Twitch authorisation key will expire " ~
-                        "in <l>%d %s</> at <l>%02d:%02d</>.";
-                    logger.warningf(pattern.expandTags(LogLevel.warning),
-                        numHours, numHours.plurality("hour", "hours"),
-                        expiresWhen.hour, expiresWhen.minute);
-                }
-            }
-            catch (TwitchQueryException e)
-            {
-                // Something is deeply wrong.
-
-                if (e.code == 2)
-                {
-                    import kameloso.constants : MagicErrorStrings;
-
-                    enum wikiPattern = cast(string)MagicErrorStrings.visitWikiOneliner;
-
-                    if (e.error == MagicErrorStrings.sslLibraryNotFound)
+                    /*
                     {
-                        enum pattern = "Failed to validate Twitch API keys: <l>%s</> " ~
-                            "<t>(is OpenSSL installed?)";
-                        logger.errorf(pattern.expandTags(LogLevel.error),
-                            cast(string)MagicErrorStrings.sslLibraryNotFoundRewritten);
-                        logger.error(wikiPattern.expandTags(LogLevel.error));
+                        "client_id": "tjyryd2ojnqr8a51ml19kn1yi2n0v1",
+                        "expires_in": 5036421,
+                        "login": "zorael",
+                        "scopes": [
+                            "bits:read",
+                            "channel:moderate",
+                            "channel:read:subscriptions",
+                            "channel_editor",
+                            "chat:edit",
+                            "chat:read",
+                            "user:edit:broadcast",
+                            "whispers:edit",
+                            "whispers:read"
+                        ],
+                        "user_id": "22216721"
+                    }
+                    */
 
-                        version(Windows)
+                    immutable validationJSON = getValidation(plugin);
+                    plugin.userID = validationJSON["user_id"].str;
+                    immutable expiresIn = validationJSON["expires_in"].integer;
+
+                    /+
+                        The below can probably never happen, as we never get to
+                        connect if the key has expired.
+                    +/
+                    /*if (expiresIn == 0L)
+                    {
+                        import kameloso.messaging : quit;
+                        import std.typecons : Flag, No, Yes;
+
+                        // Expired.
+                        logger.error("Error: Your Twitch authorisation key has expired.");
+                        quit!(Yes.priority)(plugin.state, string.init, Yes.quiet);
+                        return;
+                    }*/
+
+                    immutable expiresWhen = SysTime.fromUnixTime(Clock.currTime.toUnixTime + expiresIn);
+                    immutable now = Clock.currTime;
+                    immutable delta = (expiresWhen - now);
+                    immutable numDays = delta.total!"days";
+
+                    if (delta > 1.weeks)
+                    {
+                        // More than a week away, just .info
+                        enum pattern = "Your Twitch authorisation key will expire " ~
+                            "in <l>%d days</> on <l>%4d-%02d-%02d</>.";
+                        logger.infof(pattern.expandTags(LogLevel.info), numDays,
+                            expiresWhen.year, expiresWhen.month, expiresWhen.day);
+                    }
+                    else if (delta > 1.days)
+                    {
+                        // A week or less, more than a day; warning
+                        enum pattern = "Warning: Your Twitch authorisation key will expire " ~
+                            "in <l>%d %s</> on <l>%4d-%02d-%02d %02d:%02d</>.";
+                        logger.warningf(pattern.expandTags(LogLevel.warning),
+                            numDays, numDays.plurality("day", "days"),
+                            expiresWhen.year, expiresWhen.month, expiresWhen.day,
+                            expiresWhen.hour, expiresWhen.minute);
+                    }
+                    else
+                    {
+                        // Less than a day; warning
+                        immutable numHours = delta.total!"hours";
+                        enum pattern = "WARNING: Your Twitch authorisation key will expire " ~
+                            "in <l>%d %s</> at <l>%02d:%02d</>.";
+                        logger.warningf(pattern.expandTags(LogLevel.warning),
+                            numHours, numHours.plurality("hour", "hours"),
+                            expiresWhen.hour, expiresWhen.minute);
+                    }
+                }
+                catch (TwitchQueryException e)
+                {
+                    // Something is deeply wrong.
+
+                    if (e.code == 2)
+                    {
+                        import kameloso.constants : MagicErrorStrings;
+
+                        enum wikiPattern = cast(string)MagicErrorStrings.visitWikiOneliner;
+
+                        if (e.error == MagicErrorStrings.sslLibraryNotFound)
                         {
-                            enum getoptPattern = cast(string)MagicErrorStrings.getOpenSSLSuggestion;
-                            logger.error(getoptPattern.expandTags(LogLevel.error));
+                            enum pattern = "Failed to validate Twitch API keys: <l>%s</> " ~
+                                "<t>(is OpenSSL installed?)";
+                            logger.errorf(pattern.expandTags(LogLevel.error),
+                                cast(string)MagicErrorStrings.sslLibraryNotFoundRewritten);
+                            logger.error(wikiPattern.expandTags(LogLevel.error));
+
+                            version(Windows)
+                            {
+                                enum getoptPattern = cast(string)MagicErrorStrings.getOpenSSLSuggestion;
+                                logger.error(getoptPattern.expandTags(LogLevel.error));
+                            }
+                        }
+                        else
+                        {
+                            static int retries;
+                            if (retries++ < retriesInCaseOfConnectionErrors) continue;
+
+                            enum pattern = "Failed to validate Twitch API keys: <l>%s</> (<l>%s</>) (<t>%d</>)";
+                            logger.errorf(pattern.expandTags(LogLevel.error), e.msg, e.error, e.code);
+                            logger.error(wikiPattern.expandTags(LogLevel.error));
                         }
                     }
                     else
                     {
                         enum pattern = "Failed to validate Twitch API keys: <l>%s</> (<l>%s</>) (<t>%d</>)";
                         logger.errorf(pattern.expandTags(LogLevel.error), e.msg, e.error, e.code);
-                        logger.error(wikiPattern.expandTags(LogLevel.error));
                     }
-                }
-                else
-                {
-                    enum pattern = "Failed to validate Twitch API keys: <l>%s</> (<l>%s</>) (<t>%d</>)";
-                    logger.errorf(pattern.expandTags(LogLevel.error), e.msg, e.error, e.code);
+
+                    logger.warning("Disabling API features. Expect breakage.");
+                    //version(PrintStacktraces) logger.trace(e);
+                    plugin.useAPIFeatures = false;
                 }
 
-                logger.warning("Disabling API features. Expect breakage.");
-                //version(PrintStacktraces) logger.trace(e);
-                plugin.useAPIFeatures = false;
+                return;
             }
         }
 

--- a/source/kameloso/plugins/twitchbot/base.d
+++ b/source/kameloso/plugins/twitchbot/base.d
@@ -1386,8 +1386,9 @@ void onCommandSongRequest(TwitchBotPlugin plugin, const ref IRCEvent event)
 
         if (!creds || !creds.googleAccessToken.length)
         {
-            enum message = "Missing Google API credentials.";
-            chan(plugin.state, event.channel, message);
+            enum message = "Missing Google API credentials. " ~
+                "Run the program with <l>--set twitch.googleKeygen</> to set up.";
+            logger.error(message.expandTags(LogLevel.error));
             return;
         }
 
@@ -1435,7 +1436,8 @@ void onCommandSongRequest(TwitchBotPlugin plugin, const ref IRCEvent event)
         }
         catch (Exception e)
         {
-            chan(plugin.state, event.channel, e.msg);
+            logger.error(e.msg);
+            version(PrintStacktraces) logger.trace(e);
         }
     }
     else if (plugin.twitchBotSettings.songrequestMode == SongRequestMode.spotify)
@@ -1460,8 +1462,9 @@ void onCommandSongRequest(TwitchBotPlugin plugin, const ref IRCEvent event)
 
         if (!creds || !creds.spotifyAccessToken.length)
         {
-            enum message = "Missing Spotify API credentials.";
-            chan(plugin.state, event.channel, message);
+            enum message = "Missing Spotify API credentials. " ~
+                "Run the program with <l>--set twitch.spotifyKeygen</> to set up.";
+            logger.error(message.expandTags(LogLevel.error));
             return;
         }
 
@@ -1495,7 +1498,7 @@ void onCommandSongRequest(TwitchBotPlugin plugin, const ref IRCEvent event)
 
             if ((json.type != JSONType.object)  || "snapshot_id" !in json)
             {
-                logger.error("An error occured.");
+                logger.error("An error occurred.\n", json.toPrettyString);
                 return;
             }
 
@@ -1504,7 +1507,8 @@ void onCommandSongRequest(TwitchBotPlugin plugin, const ref IRCEvent event)
         }
         catch (Exception e)
         {
-            chan(plugin.state, event.channel, e.msg);
+            logger.error(e.msg);
+            version(PrintStacktraces) logger.trace(e);
         }
     }
 }

--- a/source/kameloso/plugins/twitchbot/base.d
+++ b/source/kameloso/plugins/twitchbot/base.d
@@ -1488,9 +1488,16 @@ void onCommandSongRequest(TwitchBotPlugin plugin, const ref IRCEvent event)
         try
         {
             import kameloso.plugins.twitchbot.spotify : addTrackToSpotifyPlaylist;
+            import std.json : JSONType;
 
             immutable json = addTrackToSpotifyPlaylist(plugin, *creds, trackID);
-            // FIXME: lookup title, handle errors
+
+            if ((json.type != JSONType.object)  || "snapshot" !in json)
+            {
+                logger.error("An error occured.");
+                return;
+            }
+
             enum message = `Track added to playlist.`;
             chan(plugin.state, event.channel, message);
         }

--- a/source/kameloso/plugins/twitchbot/base.d
+++ b/source/kameloso/plugins/twitchbot/base.d
@@ -135,11 +135,6 @@ package struct Credentials
     string googleClientSecret;
 
     /++
-        Google API authorisation code.
-     +/
-    string googleCode;
-
-    /++
         Google API OAuth access token.
      +/
     string googleAccessToken;
@@ -168,7 +163,6 @@ package struct Credentials
 
         json["googleClientID"] = this.googleClientID;
         json["googleClientSecret"] = this.googleClientSecret;
-        json["googleCode"] = this.googleCode;
         json["googleAccessToken"] = this.googleAccessToken;
         json["googleRefreshToken"] = this.googleRefreshToken;
         json["youtubePlaylistID"] = this.youtubePlaylistID;
@@ -187,7 +181,6 @@ package struct Credentials
         typeof(this) creds;
         creds.googleClientID = json["googleClientID"].str;
         creds.googleClientSecret = json["googleClientSecret"].str;
-        creds.googleCode = json["googleCode"].str;
         creds.googleAccessToken = json["googleAccessToken"].str;
         creds.googleRefreshToken = json["googleRefreshToken"].str;
         creds.youtubePlaylistID = json["youtubePlaylistID"].str;

--- a/source/kameloso/plugins/twitchbot/google.d
+++ b/source/kameloso/plugins/twitchbot/google.d
@@ -1,0 +1,503 @@
+/++
+ +/
+module kameloso.plugins.twitchbot.google;
+
+version(TwitchSupport):
+version(WithTwitchBotPlugin):
+
+private:
+
+import kameloso.plugins.twitchbot.base;
+
+import kameloso.common : logger;
+
+import arsd.http2 : HttpClient;
+import std.json : JSONValue;
+import std.typecons : Flag, No, Yes;
+
+package:
+
+
+// GoogleCredentials
+/++
+    FIXME
+ +/
+struct GoogleCredentials
+{
+    enum clientID = "842883452112-rohcu5k9u7htstmfevknanvjf5lur4pc.apps.googleusercontent.com";
+    string secret;
+    string code;
+    string accessToken;
+    string refreshToken;
+    string playlistID;
+
+    JSONValue toJSON() const
+    {
+        JSONValue json;
+
+        json["secret"] = this.secret;
+        json["code"] = this.code;
+        json["accessToken"] = this.accessToken;
+        json["refreshToken"] = this.refreshToken;
+        json["playlistID"] = this.playlistID;
+
+        return json;
+    }
+
+    static auto fromJSON(const JSONValue json)
+    {
+        GoogleCredentials creds;
+
+        creds.secret = json["secret"].str;
+        creds.code = json["code"].str;
+        creds.accessToken = json["accessToken"].str;
+        creds.refreshToken = json["refreshToken"].str;
+        creds.playlistID = json["playlistID"].str;
+
+        return creds;
+    }
+
+    string toString() const
+    {
+        import std.format : format;
+
+        enum pattern =
+            "client ID:%s\n" ~
+            "client secret:%s\n" ~
+            "authorisation code:%s\n" ~
+            "access token:%s\n" ~
+            "refresh token:%s";
+        immutable asString = pattern
+            .format(clientID, secret, code, accessToken, refreshToken);
+
+        return asString;
+    }
+}
+
+
+void generateGoogleCode(TwitchBotPlugin plugin, const string channel)
+{
+    import kameloso.common : expandTags, logger;
+    import kameloso.logger : LogLevel;
+    import kameloso.thread : ThreadMessage;
+    import lu.string : contains, nom, stripped;
+    import std.process : Pid, ProcessException, wait;
+    import std.stdio : File, readln, stdin, stdout, write, writefln, writeln;
+
+    scope(exit)
+    {
+        import kameloso.messaging : quit;
+        import std.typecons : Flag, No, Yes;
+
+        quit!(Yes.priority)(plugin.state, string.init, Yes.quiet);
+    }
+
+    logger.trace();
+    logger.info("-- Google authorization code generation mode --");
+    enum attemptToOpenPattern = `
+Attempting to open a Google login page in your default web browser. Follow the
+instructions and log in to authorise the use of this program with your account.
+
+<l>Then paste the address of the page you are redirected to afterwards here.</>
+
+* The redirected address should start with <i>http://localhost</>.
+* It will probably say "<l>this site can't be reached</>" or "<l>unable to connect</>".
+* If you are running local web server on port <i>80</>, you may have to temporarily
+  disable it for this to work.
+`;
+    writeln(attemptToOpenPattern.expandTags(LogLevel.off));
+    if (plugin.state.settings.flush) stdout.flush();
+
+    enum authNode = "https://accounts.google.com/o/oauth2/v2/auth";
+    enum url = authNode ~
+        "?client_id=" ~ GoogleCredentials.clientID ~
+        "&redirect_uri=http://localhost" ~
+        "&response_type=code" ~
+        "&scope=https://www.googleapis.com/auth/youtube";
+
+    Pid browser;
+
+    scope(exit) if (browser !is null) wait(browser);
+
+    void printManualURL()
+    {
+        enum copyPastePattern = `
+<l>Copy and paste this link manually into your browser, and log in as asked:
+
+<i>8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8<</>
+
+%s
+
+<i>8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8< -- 8<</>
+`;
+        writefln(copyPastePattern.expandTags(LogLevel.off), url);
+        if (plugin.state.settings.flush) stdout.flush();
+    }
+
+    if (plugin.state.settings.force)
+    {
+        logger.warning("Forcing; not automatically opening browser.");
+        printManualURL();
+    }
+    else
+    {
+        try
+        {
+            version(Posix)
+            {
+                import std.process : environment, spawnProcess;
+
+                version(OSX)
+                {
+                    enum open = "open";
+                }
+                else
+                {
+                    // Assume XDG
+                    enum open = "xdg-open";
+                }
+
+                immutable browserExecutable = environment.get("BROWSER", open);
+                string[2] browserCommand = [ browserExecutable, url ];  // mutable
+                auto devNull = File("/dev/null", "r+");
+
+                try
+                {
+                    browser = spawnProcess(browserCommand[], devNull, devNull, devNull);
+                }
+                catch (ProcessException e)
+                {
+                    if (browserExecutable == open) throw e;
+
+                    browserCommand[0] = open;
+                    browser = spawnProcess(browserCommand[], devNull, devNull, devNull);
+                }
+            }
+            else version(Windows)
+            {
+                import std.file : tempDir;
+                import std.format : format;
+                import std.path : buildPath;
+                import std.process : spawnProcess;
+
+                enum pattern = "kameloso-google-%s.url";
+                immutable urlBasename = pattern.format(plugin.state.client.nickname);
+                immutable urlFileName = buildPath(tempDir, urlBasename);
+
+                {
+                    auto urlFile = File(urlFileName, "w");
+                    urlFile.writeln("[InternetShortcut]\nURL=", url);
+                }
+
+                immutable string[2] browserCommand = [ "explorer", urlFileName ];
+                auto nulFile = File("NUL", "r+");
+                browser = spawnProcess(browserCommand[], nulFile, nulFile, nulFile);
+            }
+            else
+            {
+                static assert(0, "Unsupported platform, please file a bug.");
+            }
+        }
+        catch (ProcessException e)
+        {
+            // Probably we got some platform wrong and command was not found
+            logger.warning("Error: could not automatically open browser.");
+            printManualURL();
+        }
+    }
+
+    string key;
+
+    while (!key.length)
+    {
+        import std.stdio : writef;
+
+        scope(exit)
+        {
+            if (plugin.state.settings.flush) stdout.flush();
+        }
+
+        enum pattern = "<l>Paste the address of the page you were redirected to here (empty line exits):</>
+
+> ";
+        write(pattern.expandTags(LogLevel.off));
+        stdout.flush();
+
+        stdin.flush();
+        immutable readURL = readln().stripped;
+
+        if (!readURL.length || *plugin.state.abort)
+        {
+            writeln();
+            logger.warning("Aborting key generation.");
+            logger.trace();
+            return;
+        }
+
+        if (!readURL.contains("code="))
+        {
+            import lu.string : beginsWith;
+
+            writeln();
+
+            if (readURL.beginsWith(authNode))
+            {
+                enum wrongPagePattern = "Not that page; the one you're lead to after clicking <l>Authorize</>.";
+                logger.error(wrongPagePattern.expandTags(LogLevel.error));
+            }
+            else
+            {
+                logger.error("Could not make sense of URL. Try again or file a bug.");
+            }
+
+            writeln();
+            continue;
+        }
+
+        string slice = readURL;  // mutable
+        slice.nom("code=");
+        key = slice.nom!(Yes.inherit)('&');
+
+        if (key.length != 73L)
+        {
+            writeln();
+            logger.error("Invalid key length!");
+            writeln();
+            key = string.init;  // reset it so the while loop repeats
+        }
+    }
+
+    GoogleCredentials creds;
+    creds.code = key;
+
+    auto client = getHTTPClient();
+    getGoogleToken(client, creds);
+    writeln(creds);
+
+    plugin.googleSecretsByChannel[channel] = creds;
+    saveSecretsToDisk(plugin.googleSecretsByChannel, plugin.secretsFile);
+
+    enum issuePattern = "
+--------------------------------------------------------------------------------
+
+All done! Restart the program (without <i>--set twitchbot.googleKeygen</>) and
+it should just work. If it doesn't, please file an issue at:
+
+    <i>https://github.com/zorael/kameloso/issues/new</>
+";
+    writeln(issuePattern.expandTags(LogLevel.off));
+    if (plugin.state.settings.flush) stdout.flush();
+}
+
+
+auto getHTTPClient()
+{
+    import kameloso.constants : KamelosoInfo, Timeout;
+    import arsd.http2 : HttpClient, Uri;
+    import core.time : seconds;
+
+    static HttpClient client;
+
+    if (!client)
+    {
+        client = new HttpClient;
+        client.useHttp11 = true;
+        client.keepAlive = true;
+        client.acceptGzip = false;
+        client.defaultTimeout = Timeout.httpGET.seconds;
+        client.userAgent = "kameloso/" ~ cast(string)KamelosoInfo.version_;
+    }
+
+    return client;
+}
+
+
+JSONValue addVideoToYouTubePlaylist(
+    ref GoogleCredentials creds,
+    const string videoID,
+    const Flag!"recursing" recursing = No.recursing)
+{
+    import arsd.http2 : HttpVerb, Uri;
+    import std.format : format;
+    import std.json : JSONValue, JSONType, parseJSON;
+    import std.stdio : writeln;
+
+    enum url = "https://www.googleapis.com/youtube/v3/playlistItems?part=snippet";
+    auto client = getHTTPClient();
+
+    if (!creds.accessToken.length)
+    {
+        logger.info("Requesting Google authorisation code.");
+        getGoogleToken(client, creds);
+    }
+
+    client.authorization = "Bearer " ~ creds.accessToken;
+
+    //"position": 999,
+    enum pattern =
+`{
+  "snippet": {
+    "playlistId": "%s",
+    "resourceId": {
+      "kind": "youtube#video",
+      "videoId": "%s"
+    }
+  }
+}`;
+
+    ubyte[] data = cast(ubyte[])(pattern.format(creds.playlistID, videoID));
+    auto req = client.request(Uri(url), HttpVerb.POST, data, "application/json");
+    auto res = req.waitForCompletion();
+
+    /*
+    {
+        "kind": "youtube#playlistItem",
+        "etag": "QG1leAsBIlxoG2Y4MxMsV_zIaD8",
+        "id": "UExNNnd5dmt2ME9GTVVfc0IwRUZyWDdUd0pZUHdkMUYwRi4xMkVGQjNCMUM1N0RFNEUx",
+        "snippet": {
+            "publishedAt": "2022-05-24T22:03:44Z",
+            "channelId": "UC_iiOE42xes48ZXeQ4FkKAw",
+            "title": "How Do Sinkholes Form?",
+            "description": "CAN CONTAIN NEWLINES",
+            "thumbnails": {
+                "default": {
+                    "url": "https://i.ytimg.com/vi/e-DVIQPqS8E/default.jpg",
+                    "width": 120,
+                    "height": 90
+                },
+            },
+            "channelTitle": "zorael",
+            "playlistId": "PLM6wyvkv0OFMU_sB0EFrX7TwJYPwd1F0F",
+            "position": 5,
+            "resourceId": {
+                "kind": "youtube#video",
+                "videoId": "e-DVIQPqS8E"
+            },
+            "videoOwnerChannelTitle": "Practical Engineering",
+            "videoOwnerChannelId": "UCMOqf8ab-42UUQIdVoKwjlQ"
+        }
+    }
+    */
+
+    writeln(res.contentText);
+    const json = parseJSON(res.contentText);
+    if (json.type != JSONType.object) throw new Exception("unexpected token json");
+
+    if (auto errorJSON = "error" in json)
+    {
+        if (recursing)
+        {
+            throw new Exception(errorJSON.object["message"].str);
+        }
+        else if (auto statusJSON = "status" in errorJSON.object)
+        {
+            if (statusJSON.str == "UNAUTHENTICATED")
+            {
+                refreshGoogleToken(client, creds);
+                return addVideoToYouTubePlaylist(creds, videoID, Yes.recursing);
+            }
+        }
+
+        throw new Exception(errorJSON.object["message"].str);
+    }
+
+    return json;
+}
+
+
+void getGoogleCode(ref GoogleCredentials creds)
+{
+    import std.process;
+    import std.stdio : readln, stdin, stdout, writeln;
+    import std.string : indexOf;
+
+    enum authNode = "https://accounts.google.com/o/oauth2/v2/auth";
+    enum url = authNode ~
+        "?client_id=" ~ GoogleCredentials.clientID ~
+        "&redirect_uri=http://localhost" ~
+        "&response_type=code" ~
+        "&scope=https://www.googleapis.com/auth/youtube";
+
+    immutable results = execute([ "xdg-open", url ]);
+    if (results.status != 0) throw new Exception("failed to open browser");
+
+    writeln("paste address:");
+    stdout.flush();
+    stdin.flush();
+    immutable address = readln();
+
+    // http://localhost/?code=4/0AX4XfWi4kizlMyLEBfHL68j3GypWXyCV_znImdOgEuSoGAI4_4YaMa30Xw6-0K2COiGgGA&scope=https://www.googleapis.com/auth/youtube
+    immutable codePos = address.indexOf("?code=");
+    immutable scopePos = address.indexOf("&scope=");
+    if ((codePos == -1) || (scopePos == -1)) throw new Exception("unexpected address");
+    creds.code = address[codePos+6..scopePos];
+}
+
+
+void getGoogleToken(HttpClient client, ref GoogleCredentials creds)
+{
+    import arsd.http2 : HttpVerb, Uri;
+    import std.format : format;
+    import std.json : JSONType, parseJSON;
+    import std.stdio : writeln;
+    import std.string : indexOf;
+
+    //https://oauth2.googleapis.com/token?client_id=842883452112-rohcu5k9u7htstmfevknanvjf5lur4pc.apps.googleusercontent.com&client_secret=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&code=4/0AX4XfWi4kizlMyLEBfHL68j3GypWXyCV_znImdOgEuSoGAI4_4YaMa30Xw6-0K2COiGgGA&grant_type=authorization_code&redirect_uri=http://localhost
+    enum pattern = "https://oauth2.googleapis.com/token" ~
+        "?client_id=%s" ~
+        "&client_secret=%s" ~
+        "&code=%s" ~
+        "&grant_type=authorization_code" ~
+        "&redirect_uri=http://localhost";
+    immutable url = pattern.format(GoogleCredentials.clientID, creds.secret, creds.code);
+    writeln("getToken: ", url);
+    enum data = cast(ubyte[])"{}";
+    auto req = client.request(Uri(url), HttpVerb.POST, data);
+    //req.requestParameters.headers = [ "Content-Length: 0" ];
+    auto res = req.waitForCompletion();
+    writeln(res.contentText);
+
+    /*
+    {
+        "access_token": "ya29.a0ARrdaM8rcRE8T4h_Zb8Qlroz24qyUtp87_hX07SnOalJvbsDcAGXO7V7sGlj4uyzgS-jX9kwBNrveBCPice1qI9G_gI5DfteQuRzhzY1He3aS9Yh0QuSORQ0N2pFNmGzIkAS1ZqR4WzBPtECzWGXNxl3Splb",
+        "expires_in": 3599,
+        "refresh_token": "1//0ckT2PuOfZLRNCgYIARAAGAwSNwF-L9IrXAZYJnqcJAE9SzADkBgGfhOxicawIGdNwvHPB8KlWzV1Cf7_XZx2x2RdDbIFLhsXxSY",
+        "scope": "https://www.googleapis.com/auth/youtube",
+        "token_type": "Bearer"
+    }
+    */
+
+    const json = parseJSON(res.contentText);
+    if (json.type != JSONType.object) throw new Exception("unexpected token json");
+    if (auto errorJSON = "error" in json) throw new Exception(errorJSON.str);
+
+    creds.accessToken = json["access_token"].str;
+    creds.refreshToken = json["refresh_token"].str;
+}
+
+
+void refreshGoogleToken(HttpClient client, ref GoogleCredentials creds)
+{
+    import arsd.http2 : HttpVerb, Uri;
+    import std.format : format;
+    import std.json : JSONType, parseJSON;
+    import std.stdio : writeln;
+
+    enum pattern = "https://oauth2.googleapis.com/token" ~
+        "?client_id=%s" ~
+        "&client_secret=%s" ~
+        "&refresh_token=%s" ~
+        "&grant_type=refresh_token";
+    immutable url = pattern.format(GoogleCredentials.clientID, creds.secret, creds.refreshToken);
+    writeln("refrsehToken: ", url);
+
+    enum data = cast(ubyte[])"{}";
+    auto req = client.request(Uri(url), HttpVerb.POST, data);
+    auto res = req.waitForCompletion();
+    writeln(res.contentText);
+
+    const json = parseJSON(res.contentText);
+    if (json.type != JSONType.object) throw new Exception("unexpected refresh json");
+
+    creds.accessToken = json["access_token"].str;
+}

--- a/source/kameloso/plugins/twitchbot/google.d
+++ b/source/kameloso/plugins/twitchbot/google.d
@@ -200,6 +200,7 @@ Follow the instructions and log in to authorise the use of this program with you
             writeln();
             logger.warning("Aborting.");
             logger.trace();
+            *plugin.state.abort = true;
             return;
         }
 

--- a/source/kameloso/plugins/twitchbot/google.d
+++ b/source/kameloso/plugins/twitchbot/google.d
@@ -111,9 +111,8 @@ struct GoogleCredentials
 
     Params:
         plugin = The current [TwitchBotPlugin].
-        channel = String name of the channel this code relates to.
  +/
-void generateGoogleCode(TwitchBotPlugin plugin, const string channel)
+void generateGoogleCode(TwitchBotPlugin plugin)
 {
     import kameloso.logger : LogLevel;
     import kameloso.thread : ThreadMessage;

--- a/source/kameloso/plugins/twitchbot/google.d
+++ b/source/kameloso/plugins/twitchbot/google.d
@@ -60,12 +60,12 @@ package void requestGoogleKeys(TwitchBotPlugin plugin)
 <i>*</> <l>Scopes:</> <i>https://www.googleapis.com/auth/youtube</>
 <i>*</> <l>Test users:</> (your Google account)
 
-Then pick <i>+ <l>Create Credentials</> -> <l>OAuth client ID</>:
+Then pick <i>+ Create Credentials</> -> <i>OAuth client ID</>:
 <i>*</> <l>Application type:</> <i>Desktop app</>
 
 Now you should have a newly-generated client ID and client secret.
 
-<l>Enabled APIs and Services</> tab -> <i>+ <l>Enable APIs and Services</>
+<l>Enabled APIs and Services</> tab -> <i>+ Enable APIs and Services</>
 <i>--></> enter "<i>YouTube Data API v3</>", hit <i>Enable</>
 
 You also need to supply a channel for which it all relates.

--- a/source/kameloso/plugins/twitchbot/google.d
+++ b/source/kameloso/plugins/twitchbot/google.d
@@ -1,5 +1,9 @@
 /++
     Bits and bobs to get Google API credentials for YouTube playlist management.
+
+    See_Also:
+        [kameloso.plugins.twitchbot.base|twitchbot.base]
+        [kameloso.plugins.twitchbot.api|twitchbot.api]
  +/
 module kameloso.plugins.twitchbot.google;
 
@@ -24,6 +28,9 @@ package:
 /++
     Credentials needed to access the Google Cloud API; specifically, to manage a
     YouTube playlist.
+
+    See_Also:
+        https://console.cloud.google.com/apis/credentials
  +/
 struct GoogleCredentials
 {
@@ -58,7 +65,7 @@ struct GoogleCredentials
     string playlistID;
 
     /++
-        Serialises a [GoogleCredentials] into JSON.
+        Serialises these [GoogleCredentials] into JSON.
 
         Returns:
             `this` represented in JSON.
@@ -66,6 +73,8 @@ struct GoogleCredentials
     JSONValue toJSON() const
     {
         JSONValue json;
+        json = null;
+        json.object = null;
 
         json["secret"] = this.secret;
         json["code"] = this.code;
@@ -85,7 +94,6 @@ struct GoogleCredentials
     static auto fromJSON(const JSONValue json)
     {
         GoogleCredentials creds;
-
         creds.secret = json["secret"].str;
         creds.code = json["code"].str;
         creds.accessToken = json["accessToken"].str;
@@ -119,11 +127,12 @@ void generateGoogleCode(TwitchBotPlugin plugin, const string channel)
         import kameloso.messaging : quit;
         import std.typecons : Flag, No, Yes;
 
+        if (plugin.state.settings.flush) stdout.flush();
         quit!(Yes.priority)(plugin.state, string.init, Yes.quiet);
     }
 
     logger.trace();
-    logger.info("-- Google authorization code generation mode --");
+    logger.info("-- Google authorisation code generation mode --");
     enum message =
 "To access the Google API you need a <i>client ID</> and a <i>client secret</>.
 
@@ -178,7 +187,7 @@ A normal URL to any playlist you can modify will work fine.
 
 Follow the instructions and log in to authorise the use of this program with your account.
 
-<l>Then paste the address of the page you are redirected to afterwards here.</>
+<l>Then paste the address of the empty page you are redirected to afterwards here.</>
 
 * The redirected address should start with <i>http://localhost</>.
 * It will probably say "<l>this site can't be reached</>" or "<l>unable to connect</>".

--- a/source/kameloso/plugins/twitchbot/google.d
+++ b/source/kameloso/plugins/twitchbot/google.d
@@ -293,11 +293,6 @@ package JSONValue addVideoToYouTubePlaylist(
         throw new SongRequestPlaylistException("Missing YouTube playlist ID");
     }
 
-    if (!creds.googleAccessToken.length)
-    {
-        throw new SongRequestTokenException("Missing Google access token");
-    }
-
     enum url = "https://www.googleapis.com/youtube/v3/playlistItems?part=snippet";
     auto client = getHTTPClient();
 

--- a/source/kameloso/plugins/twitchbot/google.d
+++ b/source/kameloso/plugins/twitchbot/google.d
@@ -50,18 +50,30 @@ package void requestGoogleKeys(TwitchBotPlugin plugin)
     logger.trace();
     logger.info("-- Google authorisation key generation mode --");
     enum message =
-"To access the Google API you need a <i>client ID</> and a <i>client secret</>.
+`To access the Google API you need a <i>client ID</> and a <i>client secret</>.
 
-<l>Go here to create a project and generate said credentials:</>
+<l>Go here to create a project:</>
 
     <i>https://console.cloud.google.com/apis/credentials</>
+
+<l>OAuth consent screen</> tab (choose <i>External</>), follow instructions.
+<i>*</> <l>Scopes:</> <i>https://www.googleapis.com/auth/youtube</>
+<i>*</> <l>Test users:</> (your Google account)
+
+Then pick <i>+ <l>Create Credentials</> -> <l>OAuth client ID</>:
+<i>*</> <l>Application type:</> <i>Desktop app</>
+
+Now you should have a newly-generated client ID and client secret.
+
+<l>Enabled APIs and Services</> tab -> <i>+ <l>Enable APIs and Services</>
+<i>--></> enter "<i>YouTube Data API v3</>", hit <i>Enable</>
 
 You also need to supply a channel for which it all relates.
 (Channels are Twitch lowercase account names, prepended with a '<i>#</>' sign.)
 
 Lastly you need a <i>YouTube playlist ID</> for song requests to work.
 A normal URL to any playlist you can modify will work fine.
-";
+`;
     writeln(message.expandTags(LogLevel.off));
 
     Credentials creds;

--- a/source/kameloso/plugins/twitchbot/google.d
+++ b/source/kameloso/plugins/twitchbot/google.d
@@ -289,11 +289,13 @@ auto getHTTPClient()
     Adds a video to the YouTube playlist whose ID is stored in the passed [Credentials].
 
     Params:
+        plugin = The current `TwitchBotPlugin`.
         creds = Credentials aggregate.
         videoID = YouTube video ID of the video to add.
         recursing = Whether or not the function is recursing into iself.
  +/
 package JSONValue addVideoToYouTubePlaylist(
+    TwitchBotPlugin plugin,
     ref Credentials creds,
     const string videoID,
     const Flag!"recursing" recursing = No.recursing)
@@ -382,7 +384,8 @@ package JSONValue addVideoToYouTubePlaylist(
             if (statusJSON.str == "UNAUTHENTICATED")
             {
                 refreshGoogleToken(client, creds);
-                return addVideoToYouTubePlaylist(creds, videoID, Yes.recursing);
+                saveSecretsToDisk(plugin.secretsByChannel, plugin.secretsFile);
+                return addVideoToYouTubePlaylist(plugin, creds, videoID, Yes.recursing);
             }
         }
 

--- a/source/kameloso/plugins/twitchbot/google.d
+++ b/source/kameloso/plugins/twitchbot/google.d
@@ -299,6 +299,7 @@ package JSONValue addVideoToYouTubePlaylist(
     const Flag!"recursing" recursing = No.recursing)
 {
     import arsd.http2 : HttpVerb, Uri;
+    import std.algorithm.searching : endsWith;
     import std.format : format;
     import std.json : JSONValue, JSONType, parseJSON;
     import std.stdio : writeln;
@@ -316,7 +317,10 @@ package JSONValue addVideoToYouTubePlaylist(
         throw new Exception("Missing Google access token");
     }
 
-    if (!client.authorization.length) client.authorization = "Bearer " ~ creds.googleAccessToken;
+    if (!client.authorization.length || !client.authorization.endsWith(creds.googleAccessToken))
+    {
+        client.authorization = "Bearer " ~ creds.googleAccessToken;
+    }
 
     //"position": 999,
     enum pattern =

--- a/source/kameloso/plugins/twitchbot/google.d
+++ b/source/kameloso/plugins/twitchbot/google.d
@@ -308,13 +308,12 @@ package JSONValue addVideoToYouTubePlaylist(
 
     if (!creds.youtubePlaylistID.length)
     {
-        throw new Exception("Missing YouTube playlist ID.");
+        throw new Exception("Missing YouTube playlist ID");
     }
 
     if (!creds.googleAccessToken.length)
     {
-        logger.info("Requesting Google authorisation code.");
-        getGoogleToken(client, creds);
+        throw new Exception("Missing Google access token");
     }
 
     if (!client.authorization.length) client.authorization = "Bearer " ~ creds.googleAccessToken;

--- a/source/kameloso/plugins/twitchbot/google.d
+++ b/source/kameloso/plugins/twitchbot/google.d
@@ -13,7 +13,7 @@ version(WithTwitchBotPlugin):
 private:
 
 import kameloso.plugins.twitchbot.base;
-import kameloso.plugins.twitchbot.keygenhelpers;
+import kameloso.plugins.twitchbot.songrequesthelpers;
 
 import kameloso.common : expandTags, logger;
 import kameloso.logger : LogLevel;

--- a/source/kameloso/plugins/twitchbot/google.d
+++ b/source/kameloso/plugins/twitchbot/google.d
@@ -22,14 +22,15 @@ import std.json : JSONValue;
 import std.typecons : Flag, No, Yes;
 
 
-// generateGoogleCode
+// requestGoogleKeys
 /++
-    Requests a Google API authorisation code from Google servers.
+    Requests a Google API authorisation code from Google servers, then uses it
+    to obtain an access key and a refresh OAuth key.
 
     Params:
         plugin = The current [TwitchBotPlugin].
  +/
-package void generateGoogleCode(TwitchBotPlugin plugin)
+package void requestGoogleKeys(TwitchBotPlugin plugin)
 {
     import kameloso.logger : LogLevel;
     import kameloso.thread : ThreadMessage;
@@ -48,7 +49,7 @@ package void generateGoogleCode(TwitchBotPlugin plugin)
     }
 
     logger.trace();
-    logger.info("-- Google authorisation code generation mode --");
+    logger.info("-- Google authorisation key generation mode --");
     enum message =
 "To access the Google API you need a <i>client ID</> and a <i>client secret</>.
 

--- a/source/kameloso/plugins/twitchbot/keygen.d
+++ b/source/kameloso/plugins/twitchbot/keygen.d
@@ -140,8 +140,9 @@ instructions and log in to authorise the use of this program with your account.
 
     import std.array : join;
 
-    enum authNode = "https://id.twitch.tv/oauth2/authorize?response_type=token";
+    enum authNode = "https://id.twitch.tv/oauth2/authorize";
     enum ctBaseURL = authNode ~
+        "?response_type=token" ~
         "&client_id=" ~ TwitchBotPlugin.clientID ~
         "&redirect_uri=http://localhost" ~
         "&scope=" ~ scopes.join('+') ~

--- a/source/kameloso/plugins/twitchbot/keygen.d
+++ b/source/kameloso/plugins/twitchbot/keygen.d
@@ -217,7 +217,12 @@ instructions and log in to authorise the use of this program with your account.
             return;
         }
 
-        if (!readURL.contains("access_token="))
+        if (readURL.length == 30)
+        {
+            // As is
+            key = readURL;
+        }
+        else if (!readURL.contains("access_token="))
         {
             import lu.string : beginsWith;
 

--- a/source/kameloso/plugins/twitchbot/keygen.d
+++ b/source/kameloso/plugins/twitchbot/keygen.d
@@ -178,60 +178,8 @@ instructions and log in to authorise the use of this program with your account.
     {
         try
         {
-            version(Posix)
-            {
-                import std.process : environment, spawnProcess;
-
-                version(OSX)
-                {
-                    enum open = "open";
-                }
-                else
-                {
-                    // Assume XDG
-                    enum open = "xdg-open";
-                }
-
-                immutable browserExecutable = environment.get("BROWSER", open);
-                string[2] browserCommand = [ browserExecutable, url ];  // mutable
-                auto devNull = File("/dev/null", "r+");
-
-                try
-                {
-                    browser = spawnProcess(browserCommand[], devNull, devNull, devNull);
-                }
-                catch (ProcessException e)
-                {
-                    if (browserExecutable == open) throw e;
-
-                    browserCommand[0] = open;
-                    browser = spawnProcess(browserCommand[], devNull, devNull, devNull);
-                }
-            }
-            else version(Windows)
-            {
-                import std.file : tempDir;
-                import std.format : format;
-                import std.path : buildPath;
-                import std.process : spawnProcess;
-
-                enum pattern = "kameloso-twitch-%s.url";
-                immutable urlBasename = pattern.format(plugin.state.client.nickname);
-                immutable urlFileName = buildPath(tempDir, urlBasename);
-
-                {
-                    auto urlFile = File(urlFileName, "w");
-                    urlFile.writeln("[InternetShortcut]\nURL=", url);
-                }
-
-                immutable string[2] browserCommand = [ "explorer", urlFileName ];
-                auto nulFile = File("NUL", "r+");
-                browser = spawnProcess(browserCommand[], nulFile, nulFile, nulFile);
-            }
-            else
-            {
-                static assert(0, "Unsupported platform, please file a bug.");
-            }
+            import kameloso.platform : openInBrowser;
+            openInBrowser(url);
         }
         catch (ProcessException e)
         {

--- a/source/kameloso/plugins/twitchbot/keygen.d
+++ b/source/kameloso/plugins/twitchbot/keygen.d
@@ -43,6 +43,7 @@ void generateKey(TwitchBotPlugin plugin)
         import kameloso.messaging : quit;
         import std.typecons : Flag, No, Yes;
 
+        if (plugin.state.settings.flush) stdout.flush();
         quit!(Yes.priority)(plugin.state, string.init, Yes.quiet);
     }
 
@@ -149,9 +150,9 @@ instructions and log in to authorise the use of this program with your account.
         "&force_verify=true" ~
         "&state=kameloso-";
 
-    Pid browser;
     immutable url = ctBaseURL ~ plugin.state.client.nickname;
 
+    Pid browser;
     scope(exit) if (browser !is null) wait(browser);
 
     void printManualURL()
@@ -193,14 +194,12 @@ instructions and log in to authorise the use of this program with your account.
 
     while (!key.length)
     {
-        import std.stdio : writef;
-
         scope(exit)
         {
             if (plugin.state.settings.flush) stdout.flush();
         }
 
-        enum pattern = "<l>Paste the address of the page you were redirected to here (empty line exits):</>
+        enum pattern = "<l>Paste the address of empty the page you were redirected to here (empty line exits):</>
 
 > ";
         write(pattern.expandTags(LogLevel.off));
@@ -212,7 +211,7 @@ instructions and log in to authorise the use of this program with your account.
         if (!readURL.length || *plugin.state.abort)
         {
             writeln();
-            logger.warning("Aborting key generation.");
+            logger.warning("Aborting.");
             logger.trace();
             return;
         }
@@ -230,12 +229,13 @@ instructions and log in to authorise the use of this program with your account.
 
             if (readURL.beginsWith(authNode))
             {
-                enum wrongPagePattern = "Not that page; the one you're lead to after clicking <l>Authorize</>.";
+                enum wrongPagePattern = "Not that page; the empty page you're " ~
+                    "lead to after clicking <l>Authorize</>.";
                 logger.error(wrongPagePattern.expandTags(LogLevel.error));
             }
             else
             {
-                logger.error("Could not make sense of URL. Try again or file a bug.");
+                logger.error("Could not make sense of URL. Try copying again or file a bug.");
             }
 
             writeln();
@@ -264,7 +264,7 @@ instructions and log in to authorise the use of this program with your account.
     enum issuePattern = "
 --------------------------------------------------------------------------------
 
-All done! Restart the program (without <i>--set twitchbot.keygen</>) and it should
+All done! Restart the program (without <i>--set twitch.keygen</>) and it should
 just work. If it doesn't, please file an issue at:
 
     <i>https://github.com/zorael/kameloso/issues/new</>
@@ -272,5 +272,4 @@ just work. If it doesn't, please file an issue at:
 <l>Note: keys are valid for 60 days, after which this process needs to be repeated.</>
 ";
     writeln(issuePattern.expandTags(LogLevel.off));
-    if (plugin.state.settings.flush) stdout.flush();
 }

--- a/source/kameloso/plugins/twitchbot/keygen.d
+++ b/source/kameloso/plugins/twitchbot/keygen.d
@@ -17,7 +17,7 @@ import kameloso.plugins.twitchbot.base;
 package:
 
 
-// generateKey
+// requestTwitchKey
 /++
     Start the captive key generation routine at the earliest possible moment,
     which are the [dialect.defs.IRCEvent.Type.CAP|CAP] events.
@@ -29,7 +29,7 @@ package:
     It would then immediately fail to read if too much time has passed,
     and nothing would be saved.
  +/
-void generateKey(TwitchBotPlugin plugin)
+void requestTwitchKey(TwitchBotPlugin plugin)
 {
     import kameloso.common : expandTags, logger;
     import kameloso.logger : LogLevel;

--- a/source/kameloso/plugins/twitchbot/keygen.d
+++ b/source/kameloso/plugins/twitchbot/keygen.d
@@ -213,6 +213,7 @@ instructions and log in to authorise the use of this program with your account.
             writeln();
             logger.warning("Aborting.");
             logger.trace();
+            *plugin.state.abort = true;
             return;
         }
 

--- a/source/kameloso/plugins/twitchbot/keygen.d
+++ b/source/kameloso/plugins/twitchbot/keygen.d
@@ -255,36 +255,11 @@ instructions and log in to authorise the use of this program with your account.
         }
     }
 
+    import std.concurrency : prioritySend;
+
     plugin.state.bot.pass = key;
     plugin.state.updates |= typeof(plugin.state.updates).bot;
-
-    enum keyPattern = "
-<l>Your private authorisation key is: <i>%s</>
-It should be entered as <i>pass</> under <i>[IRCBot]</>.
-";
-    writefln(keyPattern.expandTags(LogLevel.off), key);
-
-    if (!plugin.state.settings.saveOnExit)
-    {
-        write("Do you want to save it there now? [Y/*]: ");
-        stdout.flush();
-
-        stdin.flush();
-        immutable input = readln().stripped;
-        if (*plugin.state.abort) return;
-
-        if (!input.length || (input == "y") || (input == "Y"))
-        {
-            import std.concurrency : prioritySend;
-            plugin.state.mainThread.prioritySend(ThreadMessage.save());
-        }
-        else
-        {
-            enum keyAddPattern = "\n* Make sure to add it to <i>%s</>, then.";
-            writefln(keyAddPattern.expandTags(LogLevel.off), plugin.state.settings.configFile);
-            if (plugin.state.settings.flush) stdout.flush();
-        }
-    }
+    plugin.state.mainThread.prioritySend(ThreadMessage.save());
 
     enum issuePattern = "
 --------------------------------------------------------------------------------

--- a/source/kameloso/plugins/twitchbot/keygenhelpers.d
+++ b/source/kameloso/plugins/twitchbot/keygenhelpers.d
@@ -1,0 +1,94 @@
+/++
+    Helper functions for keygen routines.
+ +/
+module kameloso.plugins.twitchbot.keygenhelpers;
+
+private:
+
+import kameloso.common : expandTags, logger;
+import kameloso.logger : LogLevel;
+
+package:
+
+
+// getHTTPClient
+/++
+    Returns a static [arsd.http2.HttpClient|HttpClient] for reuse across function calls.
+
+    Returns:
+        A static [arsd.http2.HttpClient|HttpClient].
+ +/
+auto getHTTPClient()
+{
+    import kameloso.constants : KamelosoInfo, Timeout;
+    import arsd.http2 : HttpClient, Uri;
+    import core.time : seconds;
+
+    static HttpClient client;
+
+    if (!client)
+    {
+        client = new HttpClient;
+        client.useHttp11 = true;
+        client.keepAlive = true;
+        client.acceptGzip = false;
+        client.defaultTimeout = Timeout.httpGET.seconds;
+        client.userAgent = "kameloso/" ~ cast(string)KamelosoInfo.version_;
+    }
+
+    return client;
+}
+
+
+// readNamedString
+/++
+    Prompts the user to enter a string.
+
+    Params:
+        wording = Wording to use in the prompt.
+        expectedLength = Optional expected length of the input string.
+            A value of `0` disables checks.
+        abort = Abort pointer.
+
+    Returns:
+        A string read from standard in, stripped.
+ +/
+auto readNamedString(
+    const string wording,
+    const size_t expectedLength,
+    ref bool abort)
+{
+    import lu.string : stripped;
+    import std.stdio : readln, stdin, stdout, write, writeln;
+
+    string string_;
+
+    while (!string_.length)
+    {
+        scope(exit) stdout.flush();
+
+        write(wording.expandTags(LogLevel.off));
+        stdout.flush();
+
+        stdin.flush();
+        string_ = readln().stripped;
+
+        if (abort)
+        {
+            writeln();
+            logger.warning("Aborting.");
+            logger.trace();
+            return string.init;
+        }
+        else if ((expectedLength > 0) && (string_.length != expectedLength))
+        {
+            writeln();
+            enum invalidMessage = "Invalid length. Try copying again or file a bug.";
+            logger.error(invalidMessage);
+            writeln();
+            continue;
+        }
+    }
+
+    return string_;
+}

--- a/source/kameloso/plugins/twitchbot/songrequesthelpers.d
+++ b/source/kameloso/plugins/twitchbot/songrequesthelpers.d
@@ -92,3 +92,107 @@ auto readNamedString(
 
     return string_;
 }
+
+
+// SongRequestException
+/++
+    A normal [object.Exception|Exception] but where its type conveys the specifi
+    context of a song request failing in a generic manner.
+ +/
+final class SongRequestException : Exception
+{
+    /++
+        Constructor.
+     +/
+    this(const string message,
+        const string file = __FILE__,
+        const size_t line = __LINE__,
+        Throwable nextInChain = null) pure nothrow @nogc @safe
+    {
+        super(message, file, line, nextInChain);
+    }
+}
+
+
+// SongRequestPlaylistException
+/++
+    A normal [object.Exception|Exception] but where its type conveys the specifi
+    context of a playlist ID being missing.
+ +/
+final class SongRequestPlaylistException : Exception
+{
+    /++
+        Constructor.
+     +/
+    this(const string message,
+        const string file = __FILE__,
+        const size_t line = __LINE__,
+        Throwable nextInChain = null) pure nothrow @nogc @safe
+    {
+        super(message, file, line, nextInChain);
+    }
+}
+
+
+// SongRequestTokenException
+/++
+    A normal [object.Exception|Exception] but where its type conveys the specifi
+    context of an OAuth access token being missing or failing to be requested.
+ +/
+final class SongRequestTokenException : Exception
+{
+    /++
+        Constructor.
+     +/
+    this(const string message,
+        const string file = __FILE__,
+        const size_t line = __LINE__,
+        Throwable nextInChain = null) pure nothrow @nogc @safe
+    {
+        super(message, file, line, nextInChain);
+    }
+}
+
+// SongRequestJSONTypeMismatchException
+/++
+    A normal [object.Exception|Exception] but where its type conveys the specifi
+    context of some JSON being of a wrong [std.json.JSONType|JSONType].
+
+    It optionally embeds the JSON.
+ +/
+final class SongRequestJSONTypeMismatchException : Exception
+{
+private:
+    import std.json : JSONValue;
+
+public:
+    /++
+        [std.json.JSONValue|JSONValue] in question.
+     +/
+    JSONValue json;
+
+    /++
+        Create a new [SongRequesstJSONTypeMismatchException], attaching a
+        [std.json.JSONValue|JSONValue].
+     +/
+    this(const string message,
+        const JSONValue json,
+        const string file = __FILE__,
+        const size_t line = __LINE__,
+        Throwable nextInChain = null) pure nothrow @nogc @safe
+    {
+        this.json = json;
+        super(message, file, line, nextInChain);
+    }
+
+    /++
+        Constructor.
+     +/
+    this(const string message,
+        const string file = __FILE__,
+        const size_t line = __LINE__,
+        Throwable nextInChain = null) pure nothrow @nogc @safe
+    {
+        super(message, file, line, nextInChain);
+    }
+}

--- a/source/kameloso/plugins/twitchbot/songrequesthelpers.d
+++ b/source/kameloso/plugins/twitchbot/songrequesthelpers.d
@@ -1,7 +1,7 @@
 /++
-    Helper functions for keygen routines.
+    Helper functions for song request modules.
  +/
-module kameloso.plugins.twitchbot.keygenhelpers;
+module kameloso.plugins.twitchbot.songrequesthelpers;
 
 private:
 

--- a/source/kameloso/plugins/twitchbot/spotify.d
+++ b/source/kameloso/plugins/twitchbot/spotify.d
@@ -422,9 +422,9 @@ package JSONValue addTrackToSpotifyPlaylist(
         {
             throw new Exception(errorJSON.object["message"].str);
         }
-        else if (auto statusJSON = "status" in errorJSON.object)
+        else if (auto messageJSON = "message" in errorJSON.object)
         {
-            if (statusJSON.str == "UNAUTHENTICATED")
+            if (messageJSON.str == "The access token expired")
             {
                 refreshSpotifyToken(client, creds);
                 saveSecretsToDisk(plugin.secretsByChannel, plugin.secretsFile);

--- a/source/kameloso/plugins/twitchbot/spotify.d
+++ b/source/kameloso/plugins/twitchbot/spotify.d
@@ -328,7 +328,7 @@ void refreshSpotifyToken(HttpClient client, ref Credentials creds)
         "&grant_type=refresh_token";
     immutable url = urlPattern.format(creds.spotifyRefreshToken);
 
-    if (!client.authorization.length) client.authorization = getSpotifyBase64Authorization(creds);
+    /*if (!client.authorization.length)*/ client.authorization = getSpotifyBase64Authorization(creds);
     auto req = client.request(Uri(url), HttpVerb.POST);
     req.requestParameters.contentType = "application/x-www-form-urlencoded";
     auto res = req.waitForCompletion();

--- a/source/kameloso/plugins/twitchbot/spotify.d
+++ b/source/kameloso/plugins/twitchbot/spotify.d
@@ -97,7 +97,7 @@ A normal URL to any playlist you can modify will work fine.
         {
             string slice = playlistURL;  // mutable
             slice.nom("spotify.com/playlist/");
-            creds.spotifyPlaylistID = slice.nom!(Yes.inherit)('&');
+            creds.spotifyPlaylistID = slice.nom!(Yes.inherit)('?');
         }
         else
         {

--- a/source/kameloso/plugins/twitchbot/spotify.d
+++ b/source/kameloso/plugins/twitchbot/spotify.d
@@ -56,6 +56,10 @@ package void requestSpotifyKeys(TwitchBotPlugin plugin)
 
     <i>https://developer.spotify.com/dashboard</>
 
+Make sure to go into <l>Edit Settings</> and add <i>http://localhost</> as a
+redirect URI. (You need to press the <i>Add</> button for it to save.)
+Additionally, add your user under <l>Users and Access</>.
+
 You also need to supply a channel for which it all relates.
 (Channels are Twitch lowercase account names, prepended with a '<i>#</>' sign.)
 

--- a/source/kameloso/plugins/twitchbot/spotify.d
+++ b/source/kameloso/plugins/twitchbot/spotify.d
@@ -193,6 +193,7 @@ Follow the instructions and log in to authorise the use of this program with you
             writeln();
             logger.warning("Aborting.");
             logger.trace();
+            *plugin.state.abort = true;
             return;
         }
 

--- a/source/kameloso/plugins/twitchbot/spotify.d
+++ b/source/kameloso/plugins/twitchbot/spotify.d
@@ -276,8 +276,8 @@ void getSpotifyTokens(HttpClient client, ref Credentials creds, const string cod
     import std.json : JSONType, parseJSON;
     import std.string : indexOf;
 
-    enum authNode = "https://accounts.spotify.com/api/token";
-    enum urlPattern = authNode ~
+    enum node = "https://accounts.spotify.com/api/token";
+    enum urlPattern = node ~
         "?code=%s" ~
         "&grant_type=authorization_code" ~
         "&redirect_uri=http://localhost";
@@ -322,8 +322,8 @@ void refreshSpotifyToken(HttpClient client, ref Credentials creds)
     import std.json : JSONType, parseJSON;
     import std.string : indexOf;
 
-    enum authNode = "https://accounts.spotify.com/api/token";
-    enum urlPattern = authNode ~
+    enum node = "https://accounts.spotify.com/api/token";
+    enum urlPattern = node ~
         "?refresh_token=%s" ~
         "&grant_type=refresh_token";
     immutable url = urlPattern.format(creds.spotifyRefreshToken);

--- a/source/kameloso/plugins/twitchbot/spotify.d
+++ b/source/kameloso/plugins/twitchbot/spotify.d
@@ -403,11 +403,6 @@ package JSONValue addTrackToSpotifyPlaylist(
         throw new SongRequestPlaylistException("Missing Spotify playlist ID");
     }
 
-    if (!creds.spotifyAccessToken.length)
-    {
-        throw new SongRequestTokenException("Missing Spotify access token");
-    }
-
     // https://api.spotify.com/v1/playlists/0nqAHNphIb3Qhh5CmD7fg5/tracks?uris=spotify:track:594WPgqPOOy0PqLvScovNO
 
     enum urlPattern = "https://api.spotify.com/v1/playlists/%s/tracks?uris=spotify:track:%s";

--- a/source/kameloso/plugins/twitchbot/spotify.d
+++ b/source/kameloso/plugins/twitchbot/spotify.d
@@ -335,7 +335,10 @@ void refreshSpotifyToken(HttpClient client, ref Credentials creds)
 
     /*
     {
-        ?
+        "access_token": "[redacted]",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "scope": "playlist-modify-private playlist-modify-public"
     }
     */
 
@@ -409,7 +412,15 @@ package JSONValue addTrackToSpotifyPlaylist(
 
     /*
     {
-        ?
+        "snapshot_id" : "[redacted]"
+    }
+    */
+    /*
+    {
+        "error": {
+            "status": 401,
+            "message": "The access token expired"
+        }
     }
     */
 

--- a/source/kameloso/plugins/twitchbot/spotify.d
+++ b/source/kameloso/plugins/twitchbot/spotify.d
@@ -13,7 +13,7 @@ version(WithTwitchBotPlugin):
 private:
 
 import kameloso.plugins.twitchbot.base;
-import kameloso.plugins.twitchbot.keygenhelpers;
+import kameloso.plugins.twitchbot.songrequesthelpers;
 
 import kameloso.common : expandTags, logger;
 import kameloso.logger : LogLevel;


### PR DESCRIPTION
This adds a Twitch `!songrequest` command, with which YouTube videos or Spotify tracks can be added to a playlist the streamer then plays in the background.

The YouTube support isn't perfect, as a video added to the end of the playlist won't be detected if the player already is at the last video in the list. The list is only refreshed when the video advances. Spotify works better.

Captive keygen sessions were added for both Google and Spotify to request access tokens. They can be initiated with `--set twitch.{google,spotify}Keygen`.