### PR TITLE
Experimental Twitch polls

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ The second command starts the process of requesting a new API key from Twitch; s
 
 The third command finally launches the program normally and connects to the server. Provided you successfully managed to get an API key and there were no errors, the bot should now enter your channel. Say something in chat in your browser and it should show in your terminal. If there were errors or snags, [*please* report them](https://github.com/zorael/kameloso/issues/new).
 
-> If you don't like the terminal colouring, `--monochrome` disables them.
+> If you don't like the terminal colouring, `--monochrome` disables it.
 
 ### Example configuration
 
@@ -422,8 +422,9 @@ Assuming a prefix of `!`, commands to test are:
 * `!settitle`
 * `!setgame`
 * `!commercial`
+* `!startpoll`/`!endpoll` (Twitch poll, *highly experimental*)
 
-...alongside `!oneliner`, `!counter`, `!timer`, `!poll`, `!stopwatch`, and other non-Twitch-specific commands. Try `!help` or [the wiki](https://github.com/zorael/kameloso/wiki/Current-plugins).
+...alongside `!oneliner`, `!counter`, `!timer`, `!poll` (chat poll), `!stopwatch`, and other non-Twitch-specific commands. Try `!help` or [the wiki](https://github.com/zorael/kameloso/wiki/Current-plugins).
 
 > Note: `.` (dot) and `/` (slash) prefixes will not work on Twitch.
 

--- a/source/kameloso/plugins/twitchbot/api.d
+++ b/source/kameloso/plugins/twitchbot/api.d
@@ -1111,36 +1111,143 @@ in (Fiber.getThis, "Tried to call `startCommercial` from outside a Fiber")
 }
 
 
-// getPoll
+// getPolls
 /++
-    FIXME
+    Fetches information about polls in the specified channel. If an ID string is
+    supplied, it will be included in the query, otherwise all `"ACTIVE"` polls
+    are included in the returned JSON.
+
+    Note: Must be called from inside a [core.thread.fiber.Fiber|Fiber].
+
+    Params:
+        plugin = The current [kameloso.plugins.twitchbot.base.TwitchBotPlugin|TwitchBotPlugin].
+        channelName = Name of channel to fetch polls for.
+        idString = ID of a specific poll to get.
+
+    Returns:
+        A [std.json.JSONValue|JSONValue] [std.json.JSONType.array|array] with
+        all the matched polls.
  +/
-auto getPoll(TwitchBotPlugin plugin, const string channelName)
-in (Fiber.getThis, "Tried to call `getPoll` from outside a Fiber")
+auto getPolls(
+    TwitchBotPlugin plugin,
+    const string channelName,
+    const string idString = string.init)
+in (Fiber.getThis, "Tried to call `getPolls` from outside a Fiber")
 {
-    import std.format : format;
-    import std.json : parseJSON;
+    import std.array : Appender;
+    import std.json : JSONType, parseJSON;
 
     enum url = "https://api.twitch.tv/helix/polls";
-    enum pattern = `
-{
-    "broadcaster_id": "%s"
-}`;
-
-    const room = channelName in plugin.rooms;
-    immutable body_ = pattern.format(room.id);
     immutable authorizationBearer = getBroadcasterAuthorisation(plugin, channelName);
+    const room = channelName in plugin.rooms;
 
-    immutable response = sendHTTPRequest(plugin, url, authorizationBearer,
-        HttpVerb.GET, cast(ubyte[])body_, "application/json");
+    Appender!(char[]) sink;
+    sink.reserve(128);
 
-    return parseJSON(response.str);
+    sink.put(`{"broadcaster_id":"`);
+    sink.put(room.id);
+    sink.put('"');
+
+    if (idString.length)
+    {
+        sink.put(`,"id":"`);
+        sink.put(idString);
+        sink.put('"');
+    }
+
+    const initialBody = sink.data ~ '}';
+    sink.put(`,"after":"%s"}`);
+    const paginationPattern = sink.data;
+
+    JSONValue allPollsJSON;
+    allPollsJSON = null;
+    allPollsJSON.array = null;
+    string after;
+
+    do
+    {
+        import std.format : format;
+
+        const body_ = after.length ? paginationPattern.format(after) : initialBody;
+        immutable response = sendHTTPRequest(plugin, url, authorizationBearer,
+            HttpVerb.GET, cast(ubyte[])body_, "application/json");
+        immutable responseJSON = parseJSON(response.str);
+
+        if ((responseJSON.type != JSONType.object) || ("data" !in responseJSON))
+        {
+            // Invalid response in some way
+            break;
+        }
+
+        /*
+        {
+            "data": [
+                {
+                "id": "ed961efd-8a3f-4cf5-a9d0-e616c590cd2a",
+                "broadcaster_id": "55696719",
+                "broadcaster_name": "TwitchDev",
+                "broadcaster_login": "twitchdev",
+                "title": "Heads or Tails?",
+                "choices": [
+                    {
+                    "id": "4c123012-1351-4f33-84b7-43856e7a0f47",
+                    "title": "Heads",
+                    "votes": 0,
+                    "channel_points_votes": 0,
+                    "bits_votes": 0
+                    },
+                    {
+                    "id": "279087e3-54a7-467e-bcd0-c1393fcea4f0",
+                    "title": "Tails",
+                    "votes": 0,
+                    "channel_points_votes": 0,
+                    "bits_votes": 0
+                    }
+                ],
+                "bits_voting_enabled": false,
+                "bits_per_vote": 0,
+                "channel_points_voting_enabled": false,
+                "channel_points_per_vote": 0,
+                "status": "ACTIVE",
+                "duration": 1800,
+                "started_at": "2021-03-19T06:08:33.871278372Z"
+                }
+            ],
+            "pagination": {}
+        }
+        */
+
+        foreach (const pollJSON; responseJSON["data"].array)
+        {
+            if (pollJSON["status"].str != "ACTIVE") continue;
+            allPollsJSON.array ~= pollJSON;
+        }
+
+        after = responseJSON["after"].str;
+    }
+    while (after.length);
+
+    return allPollsJSON;
 }
 
 
 // createPoll
 /++
-    FIXME
+    Creates a Twitch poll in the specified channel.
+
+    Note: Must be called from inside a [core.thread.fiber.Fiber|Fiber].
+
+    Params:
+        plugin = The current [kameloso.plugins.twitchbot.base.TwitchBotPlugin|TwitchBotPlugin].
+        channelName = Name of channel to create the poll in.
+        title = Poll title.
+        durationString = How long the poll should run for in seconds (as a string).
+        choices = A string array of poll choices.
+
+    Returns:
+        A [std.json.JSONValue|JSONValue] [std.json.JSONType.array|array] with
+        the response returned when creating the poll. On failure, an empty
+        [std.json.JSONValue|JSONValue] is instead returned.
  +/
 auto createPoll(
     TwitchBotPlugin plugin,
@@ -1152,7 +1259,7 @@ in (Fiber.getThis, "Tried to call `createPoll` from outside a Fiber")
 {
     import std.array : Appender, replace;
     import std.format : format;
-    import std.json : parseJSON;
+    import std.json : JSONType, parseJSON;
 
     enum url = "https://api.twitch.tv/helix/polls";
     enum pattern = `
@@ -1183,13 +1290,73 @@ in (Fiber.getThis, "Tried to call `createPoll` from outside a Fiber")
 
     immutable response = sendHTTPRequest(plugin, url, authorizationBearer,
         HttpVerb.POST, cast(ubyte[])body_, "application/json");
-    return parseJSON(response.str);
+
+    /*
+    {
+        "data": [
+            {
+            "id": "ed961efd-8a3f-4cf5-a9d0-e616c590cd2a",
+            "broadcaster_id": "141981764",
+            "broadcaster_name": "TwitchDev",
+            "broadcaster_login": "twitchdev",
+            "title": "Heads or Tails?",
+            "choices": [
+                {
+                "id": "4c123012-1351-4f33-84b7-43856e7a0f47",
+                "title": "Heads",
+                "votes": 0,
+                "channel_points_votes": 0,
+                "bits_votes": 0
+                },
+                {
+                "id": "279087e3-54a7-467e-bcd0-c1393fcea4f0",
+                "title": "Tails",
+                "votes": 0,
+                "channel_points_votes": 0,
+                "bits_votes": 0
+                }
+            ],
+            "bits_voting_enabled": false,
+            "bits_per_vote": 0,
+            "channel_points_voting_enabled": true,
+            "channel_points_per_vote": 100,
+            "status": "ACTIVE",
+            "duration": 1800,
+            "started_at": "2021-03-19T06:08:33.871278372Z"
+            }
+        ]
+    }
+    */
+
+    immutable responseJSON = parseJSON(response.str);
+
+    if ((responseJSON.type != JSONType.object) || ("data" !in responseJSON))
+    {
+        // Invalid response in some way
+        return JSONValue.init;
+    }
+
+    return responseJSON["data"];
 }
 
 
 // endPoll
 /++
-    FIXME
+    Ends a Twitch poll, putting it in either a `"TERMINATED"` or `"ARCHIVED"` state.
+
+    Note: Must be called from inside a [core.thread.fiber.Fiber|Fiber].
+
+    Params:
+        plugin = The current [kameloso.plugins.twitchbot.base.TwitchBotPlugin|TwitchBotPlugin].
+        channelName = Name of channel whose poll to end.
+        voteID = ID of the specific vote to end.
+        terminate = If set, ends the poll by putting it in a `"TERMINATED"` state.
+            If unset, ends it in an `"ARCHIVED"` way.
+
+    Returns:
+        A [std.json.JSONValue|JSONValue] [std.json.JSONType.array|array] with
+        the response returned when ending the poll. On failure, an empty
+        [std.json.JSONValue|JSONValue] is instead returned.
  +/
 auto endPoll(
     TwitchBotPlugin plugin,
@@ -1199,7 +1366,7 @@ auto endPoll(
 in (Fiber.getThis, "Tried to call `endPoll` from outside a Fiber")
 {
     import std.format : format;
-    import std.json : parseJSON;
+    import std.json : JSONType, parseJSON;
 
     enum url = "https://api.twitch.tv/helix/polls";
     enum pattern = `
@@ -1216,5 +1383,52 @@ in (Fiber.getThis, "Tried to call `endPoll` from outside a Fiber")
 
     immutable response = sendHTTPRequest(plugin, url, authorizationBearer,
         HttpVerb.PATCH, cast(ubyte[])body_, "application/json");
-    return parseJSON(response.str);
+
+    /*
+    {
+        "data": [
+            {
+            "id": "ed961efd-8a3f-4cf5-a9d0-e616c590cd2a",
+            "broadcaster_id": "141981764",
+            "broadcaster_name": "TwitchDev",
+            "broadcaster_login": "twitchdev",
+            "title": "Heads or Tails?",
+            "choices": [
+                {
+                "id": "4c123012-1351-4f33-84b7-43856e7a0f47",
+                "title": "Heads",
+                "votes": 0,
+                "channel_points_votes": 0,
+                "bits_votes": 0
+                },
+                {
+                "id": "279087e3-54a7-467e-bcd0-c1393fcea4f0",
+                "title": "Tails",
+                "votes": 0,
+                "channel_points_votes": 0,
+                "bits_votes": 0
+                }
+            ],
+            "bits_voting_enabled": false,
+            "bits_per_vote": 0,
+            "channel_points_voting_enabled": true,
+            "channel_points_per_vote": 100,
+            "status": "TERMINATED",
+            "duration": 1800,
+            "started_at": "2021-03-19T06:08:33.871278372Z",
+            "ended_at": "2021-03-19T06:11:26.746889614Z"
+            }
+        ]
+    }
+    */
+
+    immutable responseJSON = parseJSON(response.str);
+
+    if ((responseJSON.type != JSONType.object) || ("data" !in responseJSON))
+    {
+        // Invalid response in some way
+        return JSONValue.init;
+    }
+
+    return responseJSON["data"].array[0];
 }

--- a/source/kameloso/plugins/twitchbot/base.d
+++ b/source/kameloso/plugins/twitchbot/base.d
@@ -1651,7 +1651,16 @@ void onCommandStartPoll(TwitchBotPlugin plugin, const /*ref*/ IRCEvent event)
                 (e.error == "Forbidden") &&
                 e.msg.endsWith("is not a partner or affiliate"))
             {
-                enum message = "You must be a partner or affiliate to use Twitch polls.";
+                version(WithVotesPlugin)
+                {
+                    enum message = "You must be a partner or affiliate to create Twitch polls. " ~
+                        "(Consider using the Votes plugin.)";
+                }
+                else
+                {
+                    enum message = "You must be a partner or affiliate to create Twitch polls.";
+                }
+
                 chan(plugin.state, event.channel, message);
             }
         }


### PR DESCRIPTION
This adds experimental support for Twitch `!startpoll` and `!endpoll`.

Twitch polls require you to be a Twitch partner or affiliate, and as such we cannot try it out live without help from someone who is. The Twitch API reference has example of response bodies though, so while it's technically untested, it *should* work.

In the case where there is more than one poll running, a call to `!endpoll` will cancel the first one (as seen in the response body when fetching information about current polls). If this is a problem it is easily improved.

The Votes plugin remains a solid alternative with its chat polls.