### PR TITLE
Support for elevated class

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -12,7 +12,7 @@ dflags "-linkonce-templates" platform="ldc"
 x:ddoxTool "scod"
 
 dependency "lu" version="~>1.2.1"
-dependency "dialect" version="~>1.3.0"
+dependency "dialect" version="~>1.4.0"
 dependency "arsd-official:dom" version="~>10.9.0"
 dependency "arsd-official:http" version="~>10.9.0"
 dependency "requests" version="~>2.0.0"

--- a/source/kameloso/net.d
+++ b/source/kameloso/net.d
@@ -1226,7 +1226,7 @@ in (address.length, "Tried to set up a resolving fiber on an empty address")
 
     alias State = ResolveAttempt.State;
 
-    yield(ResolveAttempt.init);
+    yield(ResolveAttempt(State.preresolve));
 
     for (uint i; (i >= 0); ++i)
     {

--- a/source/kameloso/plugins/admin/base.d
+++ b/source/kameloso/plugins/admin/base.d
@@ -547,7 +547,7 @@ in (rawChannel.length, "Tried to delete a home but the channel string was empty"
             .word("whitelist")
             .policy(PrefixPolicy.prefixed)
             .description("Adds or removes an account to/from the whitelist of users " ~
-                "who may trigger the bot (in the current channel).")
+                "(in the current channel).")
             .addSyntax("$command add [account or nickname]")
             .addSyntax("$command del [account or nickname]")
     )
@@ -555,6 +555,34 @@ in (rawChannel.length, "Tried to delete a home but the channel string was empty"
 void onCommandWhitelist(AdminPlugin plugin, const ref IRCEvent event)
 {
     return plugin.manageClassLists(event, "whitelist");
+}
+
+
+// onCommandElevated
+/++
+    Adds a nickname to the list of users who may trigger the bot, to the current
+    list of [dialect.defs.IRCClient.Class.elevated|IRCClient.Class.elevated] users of the
+    current [AdminPlugin]'s [kameloso.plugins.common.core.IRCPluginState|IRCPluginState].
+
+    This is on a [kameloso.plugins.common.core.Permissions.operator|Permissions.operator] level.
+ +/
+@(IRCEventHandler()
+    .onEvent(IRCEvent.Type.CHAN)
+    .permissionsRequired(Permissions.operator)
+    .channelPolicy(ChannelPolicy.home)
+    .addCommand(
+        IRCEventHandler.Command()
+            .word("elevated")
+            .policy(PrefixPolicy.prefixed)
+            .description("Adds or removes an account to/from the list of elevated users " ~
+                "(in the current channel).")
+            .addSyntax("$command add [account or nickname]")
+            .addSyntax("$command del [account or nickname]")
+    )
+)
+void onCommandElevated(AdminPlugin plugin, const ref IRCEvent event)
+{
+    return plugin.manageClassLists(event, "elevated");
 }
 
 
@@ -1307,6 +1335,7 @@ void onBusMessage(AdminPlugin plugin, const string header, shared Sendable conte
         return plugin.state.mainThread.send(ThreadMessage.reload(slice));
 
     case "whitelist":
+    case "elevated":
     case "operator":
     case "staff":
     case "blacklist":

--- a/source/kameloso/plugins/common/core.d
+++ b/source/kameloso/plugins/common/core.d
@@ -2006,6 +2006,7 @@ auto filterSender(
         immutable isAdmin = (class_ == IRCUser.Class.admin);  // Trust in Persistence
         immutable isStaff = (class_ == IRCUser.Class.staff);
         immutable isOperator = (class_ == IRCUser.Class.operator);
+        immutable isElevated = (class_ == IRCUser.Class.elevated);
         immutable isWhitelisted = (class_ == IRCUser.Class.whitelist);
         immutable isAnyone = (class_ == IRCUser.Class.anyone);
 
@@ -2018,6 +2019,10 @@ auto filterSender(
             return FilterResult.pass;
         }
         else if (isOperator && (permissionsRequired <= Permissions.operator))
+        {
+            return FilterResult.pass;
+        }
+        else if (isElevated && (permissionsRequired <= Permissions.elevated))
         {
             return FilterResult.pass;
         }
@@ -2054,6 +2059,7 @@ auto filterSender(
         case admin:
         case staff:
         case operator:
+        case elevated:
         case whitelist:
         case registered:
             // Unknown sender; WHOIS if old result expired, otherwise fail
@@ -2379,7 +2385,8 @@ struct Replay
 
 // filterResult
 /++
-    The tristate results from comparing a username with the admin or whitelist lists.
+    The tristate results from comparing a username with the admin or
+    whitelist/elevated/operator/staff lists.
  +/
 enum FilterResult
 {
@@ -2499,12 +2506,18 @@ enum Permissions
     whitelist = 30,
 
     /++
+        Only users with a [dialect.defs.IRCClient.Class.elevated|IRCClient.Class.elevated]
+        classifier (or higher) may trigger the annotated function.
+     +/
+    elevated = 40,
+
+    /++
         Only users with a [dialect.defs.IRCClient.Class.operator|IRCClient.Class.operator]
         classifier (or higiher) may trigger the annotated function.
 
         Note: this does not mean IRC "+o" operators.
      +/
-    operator = 40,
+    operator = 50,
 
     /++
         Only users with a [dialect.defs.IRCClient.Class.staff|IRCClient.Class.staff]
@@ -2512,7 +2525,7 @@ enum Permissions
 
         These are channel owners.
      +/
-    staff = 50,
+    staff = 60,
 
     /++
         Only users defined in the configuration file as an administrator may

--- a/source/kameloso/plugins/common/misc.d
+++ b/source/kameloso/plugins/common/misc.d
@@ -493,6 +493,13 @@ auto replay(Plugin, Fun)(Plugin plugin, const ref IRCEvent event,
             }
             break;
 
+        case elevated:
+            if (replay.event.sender.class_ >= IRCUser.Class.elevated)
+            {
+                goto case ignore;
+            }
+            break;
+
         case whitelist:
             if (replay.event.sender.class_ >= IRCUser.Class.whitelist)
             {

--- a/source/kameloso/plugins/counter.d
+++ b/source/kameloso/plugins/counter.d
@@ -33,7 +33,7 @@ import std.typecons : Flag, No, Yes;
     @Enabler bool enabled = true;
 
     /// User level required to bump a counter.
-    IRCUser.Class minimumPermissionsNeeded = IRCUser.Class.whitelist;
+    IRCUser.Class minimumPermissionsNeeded = IRCUser.Class.elevated;
 }
 
 
@@ -43,7 +43,7 @@ import std.typecons : Flag, No, Yes;
  +/
 @(IRCEventHandler()
     .onEvent(IRCEvent.Type.CHAN)
-    .permissionsRequired(Permissions.whitelist)
+    .permissionsRequired(Permissions.elevated)
     .channelPolicy(ChannelPolicy.home)
     .addCommand(
         IRCEventHandler.Command()

--- a/source/kameloso/plugins/quotes.d
+++ b/source/kameloso/plugins/quotes.d
@@ -168,7 +168,7 @@ auto getSpecificQuote(QuotesPlugin plugin, const string nickname, const size_t i
 @(IRCEventHandler()
     .onEvent(IRCEvent.Type.CHAN)
     .onEvent(IRCEvent.Type.QUERY)
-    .permissionsRequired(Permissions.whitelist)
+    .permissionsRequired(Permissions.elevated)
     .channelPolicy(ChannelPolicy.home)
     .addCommand(
         IRCEventHandler.Command()

--- a/source/kameloso/plugins/seen.d
+++ b/source/kameloso/plugins/seen.d
@@ -444,6 +444,7 @@ else
     [kameloso.plugins.common.core.Permissions.anyone|Permissions.anyone],
     [kameloso.plugins.common.core.Permissions.registered|Permissions.registered],
     [kameloso.plugins.common.core.Permissions.whitelist|Permissions.whitelist],
+    [kameloso.plugins.common.core.Permissions.elevated|Permissions.elevated],
     [kameloso.plugins.common.core.Permissions.operator|Permissions.operator],
     [kameloso.plugins.common.core.Permissions.staff|Permissions.staff] and
     [kameloso.plugins.common.core.Permissions.admin|Permissions.admin].
@@ -464,6 +465,11 @@ else
         resource file, provided they are also not blacklisted. Consider this to
         correspond to "regulars" in the channel.
 
+    * [kameloso.plugins.common.core.Permissions.elevated|Permissions.elevated]
+        will also only allow users in the whitelist section of the `users.json`
+        resource file, provided they are also not blacklisted. Consider this to
+        correspond to VIPs in the channel.
+
     * [kameloso.plugins.common.core.Permissions.operator|Permissions.operator]
         will only allow users in the operator section of the `users.json`
         resource file. Consider this to correspond to "moderators" in the channel.
@@ -479,6 +485,7 @@ else
 
     In the case of
     [kameloso.plugins.common.core.Permissions.whitelist|Permissions.whitelist],
+    [kameloso.plugins.common.core.Permissions.elevated|Permissions.elevated],
     [kameloso.plugins.common.core.Permissions.operator|Permissions.operator],
     [kameloso.plugins.common.core.Permissions.staff|Permissions.staff] and
     [kameloso.plugins.common.core.Permissions.admin|Permissions.admin] it will

--- a/source/kameloso/plugins/services/persistence.d
+++ b/source/kameloso/plugins/services/persistence.d
@@ -507,7 +507,7 @@ void reload(PersistenceService service)
 
 // reloadAccountClassifiersFromDisk
 /++
-    Reloads admin/whitelist/blacklist classifier definitions from disk.
+    Reloads admin/staff/operator/elevated/whitelist/blacklist classifier definitions from disk.
 
     Params:
         service = The current [PersistenceService].
@@ -529,6 +529,7 @@ void reloadAccountClassifiersFromDisk(PersistenceService service)
     [
         IRCUser.Class.staff,
         IRCUser.Class.operator,
+        IRCUser.Class.elevated,
         IRCUser.Class.whitelist,
         IRCUser.Class.blacklist,
     ];
@@ -736,6 +737,7 @@ void initAccountResources(PersistenceService service)
     [
         "staff",
         "operator",
+        "elevated",
         "whitelist",
         "blacklist",
     ];
@@ -787,7 +789,7 @@ void initAccountResources(PersistenceService service)
     }
 
     // Force staff, operator and whitelist to appear before blacklist in the .json
-    static immutable order = [ "staff", "operator", "whitelist", "blacklist" ];
+    static immutable order = [ "staff", "operator", "elevated", "whitelist", "blacklist" ];
     json.save!(JSONStorage.KeyOrderStrategy.inGivenOrder)(service.userFile, order);
 }
 

--- a/source/kameloso/plugins/twitch/base.d
+++ b/source/kameloso/plugins/twitch/base.d
@@ -68,7 +68,7 @@ public:
 
     /++
         Whether or not VIPs are always implicitly (at least) class
-        [dialect.defs.IRCUser.Class.whitelist|IRCUser.Class.whitelist].
+        [dialect.defs.IRCUser.Class.elevated|IRCUser.Class.elevated].
      +/
     bool promoteVIPs = true;
 
@@ -2887,11 +2887,11 @@ void postprocess(TwitchPlugin plugin, ref IRCEvent event)
 
         if (plugin.twitchSettings.promoteVIPs)
         {
-            if ((user.class_ < IRCUser.Class.whitelist) &&
+            if ((user.class_ < IRCUser.Class.elevated) &&
                 user.badges.contains("vip/"))
             {
-                // User is VIP but is not registered as at least whitelist
-                user.class_ = IRCUser.Class.whitelist;
+                // User is VIP but is not registered as at least elevated
+                user.class_ = IRCUser.Class.elevated;
                 return;
             }
         }

--- a/source/kameloso/plugins/twitch/base.d
+++ b/source/kameloso/plugins/twitch/base.d
@@ -822,7 +822,7 @@ void reportStreamTime(
  +/
 @(IRCEventHandler()
     .onEvent(IRCEvent.Type.CHAN)
-    .permissionsRequired(Permissions.ignore)
+    .permissionsRequired(Permissions.anyone)
     .channelPolicy(ChannelPolicy.home)
     .addCommand(
         IRCEventHandler.Command()


### PR DESCRIPTION
This adds support for `IRCUser.Class.elevated`, which is a new user class added in dialect v1.4.0. The dependency version of it is bumped accordingly.

This aditionally adds an `!elevated` command to go with it, changes Twitch VIP promotion to promote class to `elevated` instead of `whitelist`, and changes some permissions here and there.