### PR TITLE
timers-ng2

### DIFF
--- a/source/kameloso/plugins/timer.d
+++ b/source/kameloso/plugins/timer.d
@@ -360,6 +360,12 @@ void handleNewTimer(
         chan(plugin.state, event.channel, message);
     }
 
+    void sendZeroedConditions()
+    {
+        enum message = "A timer cannot have a message threshold *and* a time threshold of zero.";
+        chan(plugin.state, event.channel, message);
+    }
+
     Timer timer;
 
     string type;
@@ -458,8 +464,7 @@ void handleNewTimer(
     }
     else if ((timer.messageCountThreshold == 0) && (timer.timeThreshold == 0))
     {
-        enum message = "A timer cannot have a message threshold *and* a time threshold of zero.";
-        return chan(plugin.state, event.channel, message);
+        return sendZeroedConditions();
     }
 
     timer.channelName = event.channel;

--- a/source/kameloso/plugins/timer.d
+++ b/source/kameloso/plugins/timer.d
@@ -80,11 +80,6 @@ public:
     string name;
 
     /++
-        String name of the channel the [Timer] should trigger in.
-     +/
-    string channelName;
-
-    /++
         The timered lines to send to the channel.
      +/
     string[] lines;
@@ -221,7 +216,6 @@ public:
         json.object = null;
 
         json["name"] = JSONValue(this.name);
-        json["channelName"] = JSONValue(this.channelName);
         json["type"] = JSONValue(cast(int)this.type);
         json["condition"] = JSONValue(cast(int)this.condition);
         json["messageCountThreshold"] = JSONValue(this.messageCountThreshold);

--- a/source/kameloso/plugins/timer.d
+++ b/source/kameloso/plugins/timer.d
@@ -605,14 +605,14 @@ void handleDelTimer(
         plugin = The current [TimerPlugin].
         event = The [dialect.defs.IRCEvent|IRCEvent] that requested the insert or edit.
         slice = Relevant slice of the original request string.
-        shouldInsert = Whether or not an insert action was requested. If `No.shouldInsert`,
+        insert = Whether or not an insert action was requested. If `No.insert`,
             then an edit action was requested.
  +/
 void handleModifyTimerLines(
     TimerPlugin plugin,
     const /*ref*/ IRCEvent event,
     /*const*/ string slice,
-    const Flag!"insert" shouldInsert)
+    const Flag!"insert" insert)
 {
     import lu.string : SplitResults, splitInto;
     import std.conv : ConvException, to;
@@ -620,7 +620,7 @@ void handleModifyTimerLines(
 
     void sendInsertUsage()
     {
-        if (shouldInsert)
+        if (insert)
         {
             enum pattern = "Usage: <b>%s%s insert<b> [timer name] [position] [timer text]";
             immutable message = pattern.format(plugin.state.settings.prefix, event.aux);
@@ -674,7 +674,7 @@ void handleModifyTimerLines(
         immutable linePos = linePosString.to!ptrdiff_t;
         if ((linePos < 0) || (linePos >= timer.lines.length)) return sendOutOfRange(timer.lines.length);
 
-        if (shouldInsert)
+        if (insert)
         {
             import std.array : insertInPlace;
 

--- a/source/kameloso/plugins/timer.d
+++ b/source/kameloso/plugins/timer.d
@@ -279,9 +279,9 @@ public:
             .description("Adds, removes or lists timers.")
             .addSyntax("$command new [name] [type] [condition] [message count threshold] " ~
                 "[time threshold] [stagger message count] [stagger time]")
-            .addSyntax("$command add [timer name] [timer text]")
-            .addSyntax("$command insert [timer name] [position] [timer text]")
-            .addSyntax("$command edit [timer name] [position] [new timer text]")
+            .addSyntax("$command add [existing timer name] [new timer line]")
+            .addSyntax("$command insert [timer name] [position] [new timer line]")
+            .addSyntax("$command edit [timer name] [position] [new timer line]")
             .addSyntax("$command del [timer name] [optional line number]")
             .addSyntax("$command list")
     )

--- a/source/kameloso/plugins/timer.d
+++ b/source/kameloso/plugins/timer.d
@@ -24,7 +24,9 @@ import core.thread : Fiber;
  +/
 @Settings struct TimerSettings
 {
-    /// Toggle whether or not this plugin should do anything at all.
+    /++
+        Toggle whether or not this plugin should do anything at all.
+     +/
     @Enabler bool enabled = true;
 }
 
@@ -39,7 +41,6 @@ private:
     import std.json : JSONValue;
 
 public:
-    // Type
     /++
         The different kinds of [Timer]s. Either one that yields a
         [Type.random|random] response each time, or one that yields a
@@ -58,63 +59,58 @@ public:
         ordered = 1,
     }
 
-    // Condition
     /++
         Conditions upon which timers decide whether they are to fire yet, or wait still.
      +/
     enum Condition
     {
-        /// Both message count and time criteria must be fulfilled.
+        /++
+            Both message count and time criteria must be fulfilled.
+         +/
         both = 0,
 
-        /// Either message count or time criteria may be fulfilled.
+        /++
+            Either message count or time criteria may be fulfilled.
+         +/
         either = 1,
     }
 
-    // name
     /++
         String name identifier of this timer.
      +/
     string name;
 
-    // channelName
     /++
         String name of the channel the [Timer] should trigger in.
      +/
     string channelName;
 
-    // lines
     /++
         The timered lines to send to the channel.
      +/
     string[] lines;
 
-    // type
     /++
         What type of [Timer] this is.
      +/
     Type type;
 
-    // fiber
     /++
         Workhorse [core.thread.fiber.Fiber|Fiber].
      +/
     Fiber fiber;
 
-    // condition
     /++
         What message/time conditions this [Timer] abides by.
      +/
     Condition condition;
 
-    // messageCountThreshold
     /++
         How many messages must have been sent since the last announce before we
         will allow another one.
      +/
     long messageCountThreshold;
 
-    // timeThreshold
     /++
         How many seconds must have passed since the last announce before we will
         allow another one.
@@ -126,13 +122,11 @@ public:
      +/
     long messageCountStagger;
 
-    // timeStagger
     /++
         Delay in seconds before the timer initially comes into effect.
      +/
     long timeStagger;
 
-    // position
     /++
         The current position, kept to keep track of what line should be yielded
         next in the case of ordered timers.
@@ -1273,31 +1267,45 @@ private:
     import core.time : seconds;
 
 public:
-    /// Contained state of a channel, so that there can be several alongside each other.
+    /++
+        Contained state of a channel, so that there can be several alongside each other.
+     +/
     static struct Channel
     {
-        /// Name of the channel.
+        /++
+            Name of the channel.
+         +/
         string channelName;
 
-        /// Current message count.
+        /++
+            Current message count.
+         +/
         ulong messageCount;
 
-        /// Pointers to [Timer]s in [TimerPlugin.timersByChannel].
+        /++
+            Pointers to [Timer]s in [TimerPlugin.timersByChannel].
+         +/
         Timer*[string] timerPointers;
     }
 
-    /// All Timer plugin settings.
+    /++
+        All Timer plugin settings.
+     +/
     TimerSettings timerSettings;
 
-    /// Array of active channels' state.
+    /++
+        Array of active channels' state.
+     +/
     Channel[string] channels;
 
     /++
-        FIXME
+        Associative array of [Timer]s, keyed by nickname keyed by channel.
      +/
     Timer[string][string] timersByChannel;
 
-    /// Filename of file with timer definitions.
+    /++
+        Filename of file with timer definitions.
+     +/
     @Resource string timerFile = "timers.json";
 
     /++

--- a/source/kameloso/plugins/timer.d
+++ b/source/kameloso/plugins/timer.d
@@ -468,15 +468,11 @@ void handleNewTimer(
     }
 
     auto channel = event.channel in plugin.channels;
+    assert(channel, "Tried to create a timer in a channel with no Channel in plugin.channels");
+
     timer.lastMessageCount = channel.messageCount;
     timer.lastTimestamp = event.time;
     timer.fiber = createTimerFiber(plugin, event.channel, timer.name);
-
-    /*if (!channel)
-    {
-        plugin.channels[event.channel] = TimerPlugin.Channel.init;
-        channel = event.channel in plugin.channels;
-    }*/
 
     plugin.timersByChannel[event.channel][timer.name] = timer;
     channel.timerPointers[timer.name] = &plugin.timersByChannel[event.channel][timer.name];

--- a/source/kameloso/plugins/timer.d
+++ b/source/kameloso/plugins/timer.d
@@ -1142,17 +1142,14 @@ auto createTimerFiber(
 }
 
 
-// saveResourceToDisk
+// saveTimersToDisk
 /++
-    Saves the passed resource to disk, but in JSON format.
-
-    This is used with the associative arrays for timers.
+    Saves timers to disk in JSON format.
 
     Params:
-        aa = The associative array to convert into JSON and save.
-        filename = Filename of the file to write to.
+        plugin = The current [TimerPlugin].
  +/
-void saveResourceToDisk(TimerPlugin plugin)
+void saveTimersToDisk(TimerPlugin plugin)
 {
     import lu.json : JSONStorage;
 

--- a/source/kameloso/plugins/timer.d
+++ b/source/kameloso/plugins/timer.d
@@ -4,7 +4,6 @@
  +/
 module kameloso.plugins.timer;
 
-version(TwitchSupport):
 version(WithTimerPlugin):
 
 private:

--- a/source/kameloso/plugins/timer.d
+++ b/source/kameloso/plugins/timer.d
@@ -1300,7 +1300,7 @@ public:
         How often to check whether timers should fire. A smaller number means
         better precision, but also marginally higher gc pressure.
      +/
-    static immutable timerPeriodicity = 15.seconds;
+    static immutable timerPeriodicity = 10.seconds;
 
     mixin IRCPluginImpl;
 }

--- a/source/kameloso/plugins/timer.d
+++ b/source/kameloso/plugins/timer.d
@@ -849,7 +849,12 @@ void onWelcome(TimerPlugin plugin)
     foreach (immutable channelName, const timersJSON; allTimersJSON.object)
     {
         auto channelTimers = channelName in plugin.timersByChannel;
-        if (!channelTimers) plugin.timersByChannel[channelName] = typeof(plugin.timersByChannel[channelName]).init;
+
+        if (!channelTimers)
+        {
+            plugin.timersByChannel[channelName] = typeof(plugin.timersByChannel[channelName]).init;
+            channelTimers = channelName in plugin.timersByChannel;
+        }
 
         foreach (const timerJSON; timersJSON.array)
         {

--- a/source/kameloso/plugins/timer.d
+++ b/source/kameloso/plugins/timer.d
@@ -938,26 +938,11 @@ void handleSelfjoin(
     auto channel = channelName in plugin.channels;
     auto channelTimers = channelName in plugin.timersByChannel;
 
-    if (channel)
-    {
-        if (force && channelTimers)
-        {
-            foreach (timer; *channelTimers)
-            {
-                destroy(timer.fiber);
-            }
-        }
-        else
-        {
-            return;
-        }
-    }
-
     if (!channel || force)
     {
         // No channel or forcing; create
         plugin.channels[channelName] = TimerPlugin.Channel(channelName);  // as above
-        channel = channelName in plugin.channels;
+        if (!channel) channel = channelName in plugin.channels;
     }
 
     if (channelTimers)
@@ -965,7 +950,8 @@ void handleSelfjoin(
         // Populate timers
         foreach (ref timer; *channelTimers)
         {
-            timer.fiber = createTimerFiber(plugin, timer);
+            destroy(timer.fiber);
+            timer.fiber = createTimerFiber(plugin, channelName, timer.name);
             channel.timerPointers[timer.name] = &timer;  // Will this work in release mode?
         }
     }

--- a/source/kameloso/plugins/timer.d
+++ b/source/kameloso/plugins/timer.d
@@ -886,12 +886,13 @@ void onWelcome(TimerPlugin plugin)
             // Walk through channels, trigger fibers
             foreach (immutable channelName, channel; plugin.channels)
             {
+                innermost:
                 foreach (timerPtr; channel.timerPointers)
                 {
                     if (!timerPtr.fiber || (timerPtr.fiber.state != Fiber.State.HOLD))
                     {
                         logger.error("Dead or busy timer Fiber in channel ", channelName);
-                        continue;
+                        continue innermost;
                     }
 
                     // Get time here and cache it

--- a/source/kameloso/plugins/timer.d
+++ b/source/kameloso/plugins/timer.d
@@ -802,7 +802,8 @@ void handleListTimers(
             "message count threshold:%d | " ~
             "time threshold:%d | " ~
             "stagger message count:%d | " ~
-            "stagger time:%d";
+            "stagger time:%d | " ~
+            "suspended:%s";
 
         immutable timerMessage = timerPattern.format(
             timer.name,
@@ -813,6 +814,7 @@ void handleListTimers(
             timer.timeThreshold,
             timer.messageCountStagger,
             timer.timeStagger,
+            timer.suspended,
         );
 
         chan(plugin.state, event.channel, timerMessage);

--- a/source/kameloso/plugins/timer.d
+++ b/source/kameloso/plugins/timer.d
@@ -404,16 +404,10 @@ void handleNewTimer(
     switch (type)
     {
     case "random":
-    case "rnd":
-    case "rng":
         timer.type = Timer.Type.random;
         break;
 
     case "ordered":
-    case "order":
-    case "sequential":
-    case "seq":
-    case "sequence":
         timer.type = Timer.Type.ordered;
         break;
 
@@ -425,12 +419,10 @@ void handleNewTimer(
     switch (condition)
     {
     case "both":
-    case "and":
         timer.condition = Timer.Condition.both;
         break;
 
     case "either":
-    case "or":
         timer.condition = Timer.Condition.either;
         break;
 

--- a/source/kameloso/plugins/timer.d
+++ b/source/kameloso/plugins/timer.d
@@ -878,6 +878,7 @@ void handleSuspendTimer(
     if (!timer) return sendNoSuchTimer();
 
     timer.suspended = suspend;
+    saveTimersToDisk(plugin);
 
     if (suspend)
     {

--- a/source/kameloso/plugins/timer.d
+++ b/source/kameloso/plugins/timer.d
@@ -240,7 +240,6 @@ public:
     {
         Timer timer;
         timer.name = json["name"].str;
-        timer.channelName = json["channelName"].str;
         timer.messageCountThreshold = json["messageCountThreshold"].integer;
         timer.timeThreshold = json["timeThreshold"].integer;
         timer.messageCountStagger = json["messageCountStagger"].integer;

--- a/source/kameloso/plugins/timer.d
+++ b/source/kameloso/plugins/timer.d
@@ -1023,19 +1023,16 @@ auto createTimerFiber(
         auto timer = name in *channelTimers;
         assert(timer, name ~ " not in *channelTimers");
 
-        /// Initial message count.
-        immutable creationMessageCount = channel.messageCount;
-
-        /// When this timer Fiber was created.
-        immutable creationTime = Clock.currTime.toUnixTime;
+        // Ensure that the Timer was set up with a UNIX timestamp prior to creating this
+        assert((timer.lastTimestamp > 0L), "Timer Fiber " ~ name ~ " created before initial timestamp was set");
 
         // Stagger based on message count and time thresholds
         while (true)
         {
             immutable timeStaggerMet =
-                ((Clock.currTime.toUnixTime - creationTime) >= timer.timeStagger);
+                ((Clock.currTime.toUnixTime - timer.lastTimestamp) >= timer.timeStagger);
             immutable messageStaggerMet =
-                ((channel.messageCount - creationMessageCount) >= timer.messageCountStagger);
+                ((channel.messageCount - timer.lastMessageCount) >= timer.messageCountStagger);
 
             if (timer.condition == Timer.Condition.both)
             {

--- a/source/kameloso/plugins/timer.d
+++ b/source/kameloso/plugins/timer.d
@@ -188,10 +188,9 @@ public:
     auto randomLine() const
     {
         import std.random : uniform;
-
-        if (!lines.length) return string.init;
-
-        return lines[uniform(0, lines.length)];
+        return lines.length ?
+            lines[uniform(0, lines.length)] :
+            string.init;
     }
 
     // toJSON
@@ -1253,7 +1252,6 @@ public:
 final class TimerPlugin : IRCPlugin
 {
 private:
-    import core.thread : Fiber;
     import core.time : seconds;
 
 public:


### PR DESCRIPTION
This reworks Timers to be less reliant on closures within Fibers.

Among other effects this allows us to inspect active Timers, and as such the Fiber triggering Timers' Fibers can now tell if a Timer is ready to fire, instead of just invoking its Fiber and letting it decide.

Old `timers.json` should still be compatible.