### PR TITLE
Highlight custom BetterTTV, FrankerFaceZ and 7tv emotes

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -132,6 +132,7 @@ configuration "dev" {
         "ExplainReplay" \
         "GCStatsOnExit"
         //"TwitchPromoteEverywhere" \
+        //"TwitchCustomEmotesEverywhere" \
         //"OmniscientSeen" \
         //"OmniscientQueries" \
         //"OSXTMPDIR" \
@@ -154,6 +155,7 @@ configuration "dev-lowmem" {
         "ExplainReplay" \
         "GCStatsOnExit"
         //"TwitchPromoteEverywhere" \
+        //"TwitchCustomEmotesEverywhere" \
         //"OmniscientSeen" \
         //"OmniscientQueries" \
         //"OSXTMPDIR" \
@@ -179,6 +181,7 @@ configuration "unittest" {
         "OSXTMPDIR"
         //"TraceWhois" \
         //"TwitchPromoteEverywhere" \
+        //"TwitchCustomEmotesEverywhere" \
         //"PrintAccountNamesToo" \
         //"PrintClassNamesToo" \
         //"BenchmarkHTTPRequests"
@@ -201,6 +204,7 @@ configuration "unittest-lowmem" {
         "OSXTMPDIR"
         //"TraceWhois" \
         //"TwitchPromoteEverywhere" \
+        //"TwitchCustomEmotesEverywhere" \
         //"PrintAccountNamesToo" \
         //"PrintClassNamesToo" \
         //"BenchmarkHTTPRequests"

--- a/dub.sdl
+++ b/dub.sdl
@@ -77,6 +77,7 @@ versions \
     "WithTwitchPlugin" \
     "TwitchWarnings" \
     "TwitchPromoteEverywhere" \
+    "TwitchCustomEmotesEverywhere" \
     "OmniscientAdmin" \
     "OmniscientQueries" \
     "OmniscientSeen" \

--- a/source/kameloso/plugins/printer/formatting.d
+++ b/source/kameloso/plugins/printer/formatting.d
@@ -1270,7 +1270,7 @@ void highlightEmotesImpl(Sink)
     const Flag!"brightTerminal" brightTerminal)
 if (isOutputRange!(Sink, char[]))
 {
-    import std.algorithm.iteration : splitter;
+    import std.algorithm.iteration : splitter, uniq;
     import std.algorithm.sorting : sort;
     import std.array : Appender;
     import std.conv : to;
@@ -1296,6 +1296,8 @@ if (isOutputRange!(Sink, char[]))
     {
         import lu.string : nom;
 
+        if (!emote.length) continue;
+
         immutable emoteID = emote.nom(':');
 
         foreach (immutable location; emote.splitter(','))
@@ -1310,10 +1312,10 @@ if (isOutputRange!(Sink, char[]))
         }
     }
 
-    const sortedHighlights = highlights.data
+    auto sortedHighlights = highlights.data
         .dup
-        .sort!((a, b) => a.start < b.start)()
-        .release();
+        .sort!((a, b) => (a.start < b.start))
+        .uniq!((a, b) => (a.start == b.start) && (a.end == b.end));
 
     // We need a dstring since we're slicing something that isn't necessarily ASCII
     // Without this highlights become offset a few characters depending on the text

--- a/source/kameloso/plugins/printer/formatting.d
+++ b/source/kameloso/plugins/printer/formatting.d
@@ -1464,7 +1464,7 @@ unittest
     getting false positives from similar nicknames.
 
     Tries to detect nicknames enclosed in terminal formatting. As such, call this
-    *after* having translated IRC- to terminal such with
+    *after* having translated IRC-to-terminal such with
     [kameloso.irccolours.mapEffects].
 
     Uses [std.string.indexOf|indexOf] internally with hopes of being more resilient to

--- a/source/kameloso/plugins/printer/formatting.d
+++ b/source/kameloso/plugins/printer/formatting.d
@@ -1287,8 +1287,20 @@ if (isOutputRange!(Sink, char[]))
     // That is a standard PRIVMSG line with ":) " repeated until 512 chars.
     //enum maxHighlights = 162;
 
-    Appender!(Highlight[]) highlights;
-    highlights.reserve(64);
+    static Appender!(Highlight[]) highlights;
+
+    scope(exit)
+    {
+        if (highlights.data.length)
+        {
+            highlights.clear();
+        }
+    }
+
+    if (highlights.capacity == 0)
+    {
+        highlights.reserve(64);  // guesstimate
+    }
 
     size_t pos;
 

--- a/source/kameloso/plugins/printer/formatting.d
+++ b/source/kameloso/plugins/printer/formatting.d
@@ -1308,8 +1308,6 @@ if (isOutputRange!(Sink, char[]))
     {
         import lu.string : nom;
 
-        if (!emote.length) continue;
-
         immutable emoteID = emote.nom(':');
 
         foreach (immutable location; emote.splitter(','))

--- a/source/kameloso/plugins/printer/formatting.d
+++ b/source/kameloso/plugins/printer/formatting.d
@@ -1322,10 +1322,19 @@ if (isOutputRange!(Sink, char[]))
         }
     }
 
+    /+
+        We need to use uniq since sometimes there will be custom emotes for which
+        there are already official ones. Example:
+
+            content: Hey Dist, what’s up? distPls distRoll
+            emotes:  emotesv2_1e80339255a84a4ebbd0129851b90aa0:21-27/emotesv2_744f13dfe4a345c5be4becdeb05343ee:29-36/distPls:21-27
+
+        The first and the last are duplicates.
+     +/
     auto sortedHighlights = highlights.data
         .dup
         .sort!((a, b) => (a.start < b.start))
-        .uniq!((a, b) => (a.start == b.start) && (a.end == b.end));
+        .uniq!((a, b) => (a.start == b.start)); // && (a.end == b.end));
 
     // We need a dstring since we're slicing something that isn't necessarily ASCII
     // Without this highlights become offset a few characters depending on the text

--- a/source/kameloso/plugins/twitch/api.d
+++ b/source/kameloso/plugins/twitch/api.d
@@ -2069,6 +2069,7 @@ void getBTTVEmotes(
     TwitchPlugin plugin,
     ref bool[dstring] emoteMap,
     const string idString)
+in (Fiber.getThis, "Tried to call `getBTTVEmotes` from outside a Fiber")
 {
     import std.conv : to;
     import std.json : parseJSON;
@@ -2199,6 +2200,7 @@ void getBTTVEmotes(
 void getBTTVGlobalEmotes(
     TwitchPlugin plugin,
     ref bool[dstring] emoteMap)
+in (Fiber.getThis, "Tried to call `getBTTVGlobalEmotes` from outside a Fiber")
 {
     import std.conv : to;
     import std.json : parseJSON;
@@ -2266,6 +2268,7 @@ void getFFZEmotes(
     TwitchPlugin plugin,
     ref bool[dstring] emoteMap,
     const string idString)
+in (Fiber.getThis, "Tried to call `getFFZEmotes` from outside a Fiber")
 {
     import std.conv : to;
     import std.json : parseJSON;
@@ -2373,6 +2376,7 @@ void get7tvEmotes(
     TwitchPlugin plugin,
     ref bool[dstring] emoteMap,
     const string idString)
+in (Fiber.getThis, "Tried to call `get7tvEmotes` from outside a Fiber")
 {
     import std.conv : to;
     import std.json : parseJSON;
@@ -2458,6 +2462,7 @@ void get7tvEmotes(
 void get7tvGlobalEmotes(
     TwitchPlugin plugin,
     ref bool[dstring] emoteMap)
+in (Fiber.getThis, "Tried to call `get7tvGlobalEmotes` from outside a Fiber")
 {
     import std.conv : to;
     import std.json : parseJSON;

--- a/source/kameloso/plugins/twitch/base.d
+++ b/source/kameloso/plugins/twitch/base.d
@@ -63,11 +63,11 @@ public:
     IRCUser.Class songrequestPermsNeeded = IRCUser.Class.whitelist;
 
     /++
-        Import custom BetterTTV, FrankerFaceZ and 7tv emotes, allowing the Printer
+        Import custom BetterTTV, (FrankerFaceZ and) 7tv emotes, allowing the Printer
         plugin to highlight them, much like it does official Twitch emotes.
         Imports both global and channel-specific emotes.
      +/
-    bool bttvFFZ7tvEmotes = false;
+    bool bttv7tvEmotes = false;
 
     /++
         Whether or not broadcasters are always implicitly class
@@ -427,7 +427,7 @@ void onGlobalUserstate(TwitchPlugin plugin, const /*ref*/ IRCEvent event)
     plugin.state.bot.displayName = event.target.displayName;
     plugin.state.updates |= IRCPluginState.Update.bot;
 
-    if (plugin.twitchSettings.bttvFFZ7tvEmotes) importCustomGlobalEmotes(plugin);
+    if (plugin.twitchSettings.bttv7tvEmotes) importCustomGlobalEmotes(plugin);
 }
 
 
@@ -771,7 +771,7 @@ void onRoomState(TwitchPlugin plugin, const /*ref*/ IRCEvent event)
     room.followsLastCached = event.time;
     startRoomMonitorFibers(plugin, event.channel);
 
-    if (plugin.twitchSettings.bttvFFZ7tvEmotes)
+    if (plugin.twitchSettings.bttv7tvEmotes)
     {
         importCustomEmotes(plugin, room);
     }
@@ -836,7 +836,7 @@ version(TwitchCustomEmotesEverywhere)
 )
 void onGuestRoomState(TwitchPlugin plugin, const /*ref*/ IRCEvent event)
 {
-    if (!plugin.twitchSettings.bttvFFZ7tvEmotes) return;
+    if (!plugin.twitchSettings.bttv7tvEmotes) return;
 
     auto room = event.channel in plugin.rooms;
 
@@ -1639,7 +1639,7 @@ void onCommandEcount(TwitchPlugin plugin, const ref IRCEvent event)
 
     void sendNotATwitchEmote()
     {
-        immutable message = plugin.twitchSettings.bttvFFZ7tvEmotes ?
+        immutable message = plugin.twitchSettings.bttv7tvEmotes ?
             "That is not a Twitch, BetterTTV, FrankerFaceZ or 7tv emote." :
             "That is not a Twitch emote.";
         chan(plugin.state, event.channel, message);

--- a/source/kameloso/plugins/twitch/base.d
+++ b/source/kameloso/plugins/twitch/base.d
@@ -810,6 +810,7 @@ void onRoomState(TwitchPlugin plugin, const /*ref*/ IRCEvent event)
         {
             immutable userJSON = getTwitchData(plugin, userURL);
             room.broadcasterDisplayName = userJSON["display_name"].str;
+            break;
         }
         catch (Exception e)
         {

--- a/source/kameloso/plugins/twitch/base.d
+++ b/source/kameloso/plugins/twitch/base.d
@@ -2110,37 +2110,61 @@ void onCommandCommercial(TwitchPlugin plugin, const /*ref*/ IRCEvent event)
 void importCustomEmotes(TwitchPlugin plugin, TwitchPlugin.Room* room)
 in (room, "Tried to import custom emotes for a nonexistent room")
 {
-    try
+    foreach (immutable i; 0..TwitchPlugin.delegateRetries)
     {
-        getBTTVEmotes(plugin, room.customEmotes, room.id);
-    }
-    catch (TwitchQueryException e)
-    {
-        enum pattern = "Failed to fetch custom <l>BetterTTV</> emotes for channel <l>%s";
-        logger.warningf(pattern, room.channelName);
-        version(PrintStacktraces) logger.trace(e.info);
+        try
+        {
+            getBTTVEmotes(plugin, room.customEmotes, room.id);
+            break;
+        }
+        catch (Exception e)
+        {
+            // Retry until we reach the retry limit
+            if (i < TwitchPlugin.delegateRetries-1) continue;
+
+            enum pattern = "Failed to fetch custom <l>BetterTTV</> emotes for channel <l>%s";
+            logger.warningf(pattern, room.channelName);
+            version(PrintStacktraces) logger.trace(e.info);
+            //throw e;
+        }
     }
 
-    try
+    foreach (immutable i; 0..TwitchPlugin.delegateRetries)
     {
-        getFFZEmotes(plugin, room.customEmotes, room.id);
-    }
-    catch (TwitchQueryException e)
-    {
-        enum pattern = "Failed to fetch custom <l>FrankerFaceZ</> emotes for channel <l>%s";
-        logger.warningf(pattern, room.channelName);
-        version(PrintStacktraces) logger.trace(e.info);
+        try
+        {
+            getFFZEmotes(plugin, room.customEmotes, room.id);
+            break;
+        }
+        catch (Exception e)
+        {
+            // As above
+            if (i < TwitchPlugin.delegateRetries-1) continue;
+
+            enum pattern = "Failed to fetch custom <l>FrankerFaceZ</> emotes for channel <l>%s";
+            logger.warningf(pattern, room.channelName);
+            version(PrintStacktraces) logger.trace(e.info);
+            //throw e;
+        }
     }
 
-    try
+    foreach (immutable i; 0..TwitchPlugin.delegateRetries)
     {
-        get7tvEmotes(plugin, room.customEmotes, room.id);
-    }
-    catch (TwitchQueryException e)
-    {
-        enum pattern = "Failed to fetch custom <l>7tv</> emotes for channel <l>%s";
-        logger.warningf(pattern, room.channelName);
-        version(PrintStacktraces) logger.trace(e.info);
+        try
+        {
+            get7tvEmotes(plugin, room.customEmotes, room.id);
+            break;
+        }
+        catch (Exception e)
+        {
+            // As above
+            if (i < TwitchPlugin.delegateRetries-1) continue;
+
+            enum pattern = "Failed to fetch custom <l>7tv</> emotes for channel <l>%s";
+            logger.warningf(pattern, room.channelName);
+            version(PrintStacktraces) logger.trace(e.info);
+            //throw e;
+        }
     }
 
     room.customEmotes.rehash();
@@ -2156,24 +2180,40 @@ in (room, "Tried to import custom emotes for a nonexistent room")
  +/
 void importCustomGlobalEmotes(TwitchPlugin plugin)
 {
-    try
+    foreach (immutable i; 0..TwitchPlugin.delegateRetries)
     {
-        getBTTVGlobalEmotes(plugin, plugin.customGlobalEmotes);
-    }
-    catch (TwitchQueryException e)
-    {
-        logger.warning("Failed to fetch global BetterTTV emotes");
-        version(PrintStacktraces) logger.trace(e.info);
+        try
+        {
+            getBTTVGlobalEmotes(plugin, plugin.customGlobalEmotes);
+            break;
+        }
+        catch (Exception e)
+        {
+            // Retry until we reach the retry limit
+            if (i < TwitchPlugin.delegateRetries-1) continue;
+
+            logger.warning("Failed to fetch global BetterTTV emotes");
+            version(PrintStacktraces) logger.trace(e.info);
+            //throw e;
+        }
     }
 
-    try
+    foreach (immutable i; 0..TwitchPlugin.delegateRetries)
     {
-        get7tvGlobalEmotes(plugin, plugin.customGlobalEmotes);
-    }
-    catch (TwitchQueryException e)
-    {
-        logger.warning("Failed to fetch global 7tv emotes");
-        version(PrintStacktraces) logger.trace(e.info);
+        try
+        {
+            get7tvGlobalEmotes(plugin, plugin.customGlobalEmotes);
+            break;
+        }
+        catch (Exception e)
+        {
+            // As above
+            if (i < TwitchPlugin.delegateRetries-1) continue;
+
+            logger.warning("Failed to fetch global 7tv emotes");
+            version(PrintStacktraces) logger.trace(e.info);
+            //throw e;
+        }
     }
 
     plugin.customGlobalEmotes.rehash();

--- a/source/kameloso/plugins/twitch/base.d
+++ b/source/kameloso/plugins/twitch/base.d
@@ -2252,6 +2252,50 @@ void embedCustomEmotes(
     }
 }
 
+///
+unittest
+{
+    bool[dstring] customEmotes =
+    [
+        ":tf:"d : true,
+        "FrankerZ"d : true,
+        "NOTED"d : true,
+    ];
+
+    bool[dstring] customGlobalEmotes =
+    [
+        "KEKW"d : true,
+        "NotLikeThis"d : true,
+        "gg"d : true,
+    ];
+
+    IRCEvent event;
+    event.type = IRCEvent.Type.CHAN;
+
+    {
+        event.content = "come on its easy, now rest then talk talk more left, left, " ~
+            "right re st, up, down talk some rest a bit talk poop  :tf:";
+        //event.emotes = string.init;
+        embedCustomEmotes(event, customEmotes, customGlobalEmotes);
+        enum expectedEmotes = ";tf;:113-116";
+        assert((event.emotes == expectedEmotes), event.emotes);
+    }
+    {
+        event.content = "NOTED  FrankerZ  NOTED NOTED    gg";
+        event.emotes = string.init;
+        embedCustomEmotes(event, customEmotes, customGlobalEmotes);
+        enum expectedEmotes = "NOTED:0-4/FrankerZ:7-14/NOTED:17-21,23-27/gg:32-33";
+        assert((event.emotes == expectedEmotes), event.emotes);
+    }
+    {
+        event.content = "No emotes here KAPPA";
+        event.emotes = string.init;
+        embedCustomEmotes(event, customEmotes, customGlobalEmotes);
+        enum expectedEmotes = string.init;
+        assert((event.emotes == expectedEmotes), event.emotes);
+    }
+}
+
 
 // start
 /++

--- a/source/kameloso/plugins/twitch/base.d
+++ b/source/kameloso/plugins/twitch/base.d
@@ -823,6 +823,35 @@ void onRoomState(TwitchPlugin plugin, const /*ref*/ IRCEvent event)
 }
 
 
+// onGuestRoomState
+/++
+    Fetches custom BetterTV, FrankerFaceZ and 7tv emotes for guest channels if
+    the settings say to do so.
+ +/
+version(TwitchCustomEmotesEverywhere)
+@(IRCEventHandler()
+    .onEvent(IRCEvent.Type.ROOMSTATE)
+    .channelPolicy(ChannelPolicy.guest)
+    .fiber(true)
+)
+void onGuestRoomState(TwitchPlugin plugin, const /*ref*/ IRCEvent event)
+{
+    if (!plugin.twitchSettings.bttvFFZ7tvEmotes) return;
+
+    auto room = event.channel in plugin.rooms;
+
+    if (!room)
+    {
+        // Race...
+        initRoom(plugin, event.channel);
+        room = event.channel in plugin.rooms;
+    }
+
+    room.id = event.aux;
+    importCustomEmotes(plugin, room);
+}
+
+
 // onCommandVanish
 /++
     Hides a user's messages (making them "disappear") by briefly timing them out.

--- a/source/kameloso/plugins/twitch/base.d
+++ b/source/kameloso/plugins/twitch/base.d
@@ -1524,7 +1524,6 @@ void onAnyMessage(TwitchPlugin plugin, const ref IRCEvent event)
             if (!emotestring.length) continue;
 
             auto channelcount = event.channel in plugin.ecount;
-
             if (!channelcount)
             {
                 plugin.ecount[event.channel][string.init] = 0L;
@@ -1533,9 +1532,9 @@ void onAnyMessage(TwitchPlugin plugin, const ref IRCEvent event)
             }
 
             string slice = emotestring;  // mutable
-            immutable id = slice.nom(':');//.to!uint;
-            auto thisEmoteCount = id in *channelcount;
+            immutable id = slice.nom(':');
 
+            auto thisEmoteCount = id in *channelcount;
             if (!thisEmoteCount)
             {
                 (*channelcount)[id] = 0L;

--- a/source/kameloso/plugins/twitch/base.d
+++ b/source/kameloso/plugins/twitch/base.d
@@ -1492,6 +1492,8 @@ void onAnyMessage(TwitchPlugin plugin, const ref IRCEvent event)
 
         foreach (immutable emotestring; event.emotes.splitter('/'))
         {
+            if (!emotestring.length) continue;
+
             auto channelcount = event.channel in plugin.ecount;
 
             if (!channelcount)

--- a/source/kameloso/plugins/twitch/base.d
+++ b/source/kameloso/plugins/twitch/base.d
@@ -3279,15 +3279,10 @@ package void saveSecretsToDisk(const Credentials[string] aa, const string filena
 // reload
 /++
     Reloads the plugin, loading resources from disk.
-
-    Additionally re-imports custom emotes, both global ones and channel-specific
-    ones for each current room.
  +/
 void reload(TwitchPlugin plugin)
 {
-    import kameloso.constants : BufferSize;
     import lu.json : JSONStorage, populateFromJSON;
-    import core.thread : Fiber;
 
     JSONStorage ecountJSON;
     ecountJSON.load(plugin.ecountFile);
@@ -3311,22 +3306,6 @@ void reload(TwitchPlugin plugin)
     }
 
     plugin.secretsByChannel = plugin.secretsByChannel.rehash();
-
-    // Emote-importing needs to happen in a Fiber because of async stuff
-    void importEmoteDg()
-    {
-        plugin.customGlobalEmotes = null;
-        importCustomGlobalEmotes(plugin);
-
-        foreach (ref room; plugin.rooms)
-        {
-            room.customEmotes = null;
-            importCustomEmotes(plugin, &room);
-        }
-    }
-
-    Fiber importEmoteFiber = new Fiber(&importEmoteDg, BufferSize.fiberStack);
-    importEmoteFiber.call();
 }
 
 

--- a/source/kameloso/plugins/twitch/base.d
+++ b/source/kameloso/plugins/twitch/base.d
@@ -63,6 +63,13 @@ public:
     IRCUser.Class songrequestPermsNeeded = IRCUser.Class.whitelist;
 
     /++
+        Import custom BetterTTV, FrankerFaceZ and 7tv emotes, allowing the Printer
+        plugin to highlight them, much like it does official Twitch emotes.
+        Imports both global and channel-specific emotes.
+     +/
+    bool bttvFFZ7tvEmotes = false;
+
+    /++
         Whether or not broadcasters are always implicitly class
         [dialect.defs.IRCUser.Class.staff|IRCUser.Class.staff].
      +/

--- a/source/kameloso/plugins/twitch/base.d
+++ b/source/kameloso/plugins/twitch/base.d
@@ -2189,8 +2189,9 @@ void importCustomGlobalEmotes(TwitchPlugin plugin)
     This is called in [postprocess].
 
     Params:
-        plugin = The current [TwitchPlugin].
         event = [dialect.defs.IRCEvent|IRCEvent] in flight.
+        customEmotes = `bool[dstring]` associative array of channel-specific custom emotes.
+        customGlobalEmotes = `bool[dstring]` associative array of global custom emotes.
  +/
 void embedCustomEmotes(
     ref IRCEvent event,
@@ -3057,6 +3058,8 @@ void teardown(TwitchPlugin plugin)
 /++
     Hijacks a reference to a [dialect.defs.IRCEvent|IRCEvent] and modifies the
     sender and target class based on their badges (and the current settings).
+
+    Additionally and optionally embeds custom BTTV/FrankerFaceZ/7tv emotes into the event.
  +/
 void postprocess(TwitchPlugin plugin, ref IRCEvent event)
 {

--- a/source/kameloso/plugins/twitch/base.d
+++ b/source/kameloso/plugins/twitch/base.d
@@ -414,14 +414,20 @@ void onUserstate(const ref IRCEvent event)
     Inherits the bots display name from a
     [dialect.defs.IRCEvent.Type.GLOBALUSERSTATE|GLOBALUSERSTATE]
     into [kameloso.pods.IRCBot.displayName|IRCBot.displayName].
+
+    Additionally fetches global custom BetterTV, FrankerFaceZ and 7tv emotes
+    if the settings say to do so.
  +/
 @(IRCEventHandler()
     .onEvent(IRCEvent.Type.GLOBALUSERSTATE)
+    .fiber(true)
 )
-void onGlobalUserstate(TwitchPlugin plugin, const ref IRCEvent event)
+void onGlobalUserstate(TwitchPlugin plugin, const /*ref*/ IRCEvent event)
 {
     plugin.state.bot.displayName = event.target.displayName;
     plugin.state.updates |= IRCPluginState.Update.bot;
+
+    if (plugin.twitchSettings.bttvFFZ7tvEmotes) importCustomGlobalEmotes(plugin);
 }
 
 
@@ -740,6 +746,9 @@ void onCommandFollowAge(TwitchPlugin plugin, const /*ref*/ IRCEvent event)
 /++
     Records the room ID of a home channel, and queries the Twitch servers for
     the display name of its broadcaster.
+
+    Additionally fetches custom BetterTV, FrankerFaceZ and 7tv emotes for the
+    channel if the settings say to do so.
  +/
 @(IRCEventHandler()
     .onEvent(IRCEvent.Type.ROOMSTATE)
@@ -805,6 +814,11 @@ void onRoomState(TwitchPlugin plugin, const /*ref*/ IRCEvent event)
         broadcasterUser.displayName = room.broadcasterDisplayName;
         IRCUser user = *broadcasterUser;  // dereference and copy
         plugin.state.mainThread.send(ThreadMessage.busMessage("persistence", sendable(user)));
+    }
+
+    if (plugin.twitchSettings.bttvFFZ7tvEmotes)
+    {
+        importCustomEmotes(plugin, room);
     }
 }
 

--- a/source/kameloso/plugins/twitch/base.d
+++ b/source/kameloso/plugins/twitch/base.d
@@ -2092,6 +2092,7 @@ void onCommandCommercial(TwitchPlugin plugin, const /*ref*/ IRCEvent event)
         room = Pointer to [TwitchPlugin.Room|Room] to import custom emotes for.
  +/
 void importCustomEmotes(TwitchPlugin plugin, TwitchPlugin.Room* room)
+in (Fiber.getThis, "Tried to call `importCustomEmotes` from outside a Fiber")
 in (room, "Tried to import custom emotes for a nonexistent room")
 {
     alias GetEmoteFun = void function(TwitchPlugin, ref bool[dstring], const string);
@@ -2133,6 +2134,7 @@ in (room, "Tried to import custom emotes for a nonexistent room")
         plugin = The current [TwitchPlugin].
  +/
 void importCustomGlobalEmotes(TwitchPlugin plugin)
+in (Fiber.getThis, "Tried to call `importCustomGlobalEmotes` from outside a Fiber")
 {
     alias GetGlobalEmoteFun = void function(TwitchPlugin, ref bool[dstring]);
 

--- a/source/kameloso/plugins/twitch/base.d
+++ b/source/kameloso/plugins/twitch/base.d
@@ -2110,63 +2110,33 @@ void onCommandCommercial(TwitchPlugin plugin, const /*ref*/ IRCEvent event)
 void importCustomEmotes(TwitchPlugin plugin, TwitchPlugin.Room* room)
 in (room, "Tried to import custom emotes for a nonexistent room")
 {
-    foreach (immutable i; 0..TwitchPlugin.delegateRetries)
-    {
-        try
-        {
-            getBTTVEmotes(plugin, room.customEmotes, room.id);
-            break;
-        }
-        catch (Exception e)
-        {
-            // Retry until we reach the retry limit
-            if (i < TwitchPlugin.delegateRetries-1) continue;
+    alias GetEmoteFun = void function(TwitchPlugin, ref bool[dstring], const string);
 
-            enum pattern = "Failed to fetch custom <l>BetterTTV</> emotes for channel <l>%s";
-            logger.warningf(pattern, room.channelName);
-            version(PrintStacktraces) logger.trace(e.info);
-            //throw e;
+    void getEmoteSet(GetEmoteFun fun, const string setName)
+    {
+        foreach (immutable i; 0..TwitchPlugin.delegateRetries)
+        {
+            try
+            {
+                fun(plugin, room.customEmotes, room.id);
+                return;
+            }
+            catch (Exception e)
+            {
+                // Retry until we reach the retry limit
+                if (i < TwitchPlugin.delegateRetries-1) continue;
+
+                enum pattern = "Failed to fetch custom <l>%s</> emotes for channel <l>%s";
+                logger.warningf(pattern, setName, room.channelName);
+                version(PrintStacktraces) logger.trace(e.info);
+                //throw e;
+            }
         }
     }
 
-    foreach (immutable i; 0..TwitchPlugin.delegateRetries)
-    {
-        try
-        {
-            getFFZEmotes(plugin, room.customEmotes, room.id);
-            break;
-        }
-        catch (Exception e)
-        {
-            // As above
-            if (i < TwitchPlugin.delegateRetries-1) continue;
-
-            enum pattern = "Failed to fetch custom <l>FrankerFaceZ</> emotes for channel <l>%s";
-            logger.warningf(pattern, room.channelName);
-            version(PrintStacktraces) logger.trace(e.info);
-            //throw e;
-        }
-    }
-
-    foreach (immutable i; 0..TwitchPlugin.delegateRetries)
-    {
-        try
-        {
-            get7tvEmotes(plugin, room.customEmotes, room.id);
-            break;
-        }
-        catch (Exception e)
-        {
-            // As above
-            if (i < TwitchPlugin.delegateRetries-1) continue;
-
-            enum pattern = "Failed to fetch custom <l>7tv</> emotes for channel <l>%s";
-            logger.warningf(pattern, room.channelName);
-            version(PrintStacktraces) logger.trace(e.info);
-            //throw e;
-        }
-    }
-
+    getEmoteSet(&getBTTVEmotes, "BetterTTV");
+    getEmoteSet(&getFFZEmotes, "FrankerFaceZ");
+    getEmoteSet(&get7tvEmotes, "7tv");
     room.customEmotes.rehash();
 }
 
@@ -2180,42 +2150,32 @@ in (room, "Tried to import custom emotes for a nonexistent room")
  +/
 void importCustomGlobalEmotes(TwitchPlugin plugin)
 {
-    foreach (immutable i; 0..TwitchPlugin.delegateRetries)
-    {
-        try
-        {
-            getBTTVGlobalEmotes(plugin, plugin.customGlobalEmotes);
-            break;
-        }
-        catch (Exception e)
-        {
-            // Retry until we reach the retry limit
-            if (i < TwitchPlugin.delegateRetries-1) continue;
+    alias GetGlobalEmoteFun = void function(TwitchPlugin, ref bool[dstring]);
 
-            logger.warning("Failed to fetch global BetterTTV emotes");
-            version(PrintStacktraces) logger.trace(e.info);
-            //throw e;
+    void getGlobalEmoteSet(GetGlobalEmoteFun fun, const string setName)
+    {
+        foreach (immutable i; 0..TwitchPlugin.delegateRetries)
+        {
+            try
+            {
+                fun(plugin, plugin.customGlobalEmotes);
+                return;
+            }
+            catch (Exception e)
+            {
+                // Retry until we reach the retry limit
+                if (i < TwitchPlugin.delegateRetries-1) continue;
+
+                enum pattern = "Failed to fetch global <l>%s</> emotes";
+                logger.warningf(pattern, setName);
+                version(PrintStacktraces) logger.trace(e.info);
+                //throw e;
+            }
         }
     }
 
-    foreach (immutable i; 0..TwitchPlugin.delegateRetries)
-    {
-        try
-        {
-            get7tvGlobalEmotes(plugin, plugin.customGlobalEmotes);
-            break;
-        }
-        catch (Exception e)
-        {
-            // As above
-            if (i < TwitchPlugin.delegateRetries-1) continue;
-
-            logger.warning("Failed to fetch global 7tv emotes");
-            version(PrintStacktraces) logger.trace(e.info);
-            //throw e;
-        }
-    }
-
+    getGlobalEmoteSet(&getBTTVGlobalEmotes, "BetterTTV");
+    getGlobalEmoteSet(&get7tvGlobalEmotes, "7tv");
     plugin.customGlobalEmotes.rehash();
 }
 

--- a/source/kameloso/plugins/twitch/base.d
+++ b/source/kameloso/plugins/twitch/base.d
@@ -3016,6 +3016,20 @@ void postprocess(TwitchPlugin plugin, ref IRCEvent event)
 
     /*if (event.sender.nickname.length)*/ postprocessImpl(plugin, event, event.sender);
     if (event.target.nickname.length) postprocessImpl(plugin, event, event.target);
+
+    version(TwitchPromoteEverywhere)
+    {
+        // We don't know if we're in a home channel or not here, because of the version
+        if (plugin.state.bot.homeChannels.canFind(event.channel))
+        {
+            embedCustomEmotes(plugin, event);
+        }
+    }
+    else
+    {
+        // We returned if we weren't in a home channel earlier, so safe to just embed
+        embedCustomEmotes(plugin, event);
+    }
 }
 
 

--- a/source/kameloso/plugins/twitch/base.d
+++ b/source/kameloso/plugins/twitch/base.d
@@ -3204,6 +3204,12 @@ package:
             Song request history; UNIX timestamps keyed by nickname.
          +/
         long[string] songrequestHistory;
+
+        /++
+            Custom channel-specific BetterTTV, FrankerFaceZ and 7tv emotes, as
+            fetched via API calls.
+         +/
+        bool[dstring] customEmotes;
     }
 
     /++
@@ -3215,6 +3221,11 @@ package:
         Array of active bot channels' state.
      +/
     Room[string] rooms;
+
+    /++
+        Global BetterTTV, FrankerFaceZ and 7tv emotes, as fetched via API calls.
+     +/
+    bool[dstring] customGlobalEmotes;
 
     /++
         [kameloso.terminal.TerminalToken.bell|TerminalToken.bell] as string,

--- a/source/kameloso/plugins/twitch/base.d
+++ b/source/kameloso/plugins/twitch/base.d
@@ -63,13 +63,6 @@ public:
     IRCUser.Class songrequestPermsNeeded = IRCUser.Class.whitelist;
 
     /++
-        Import custom BetterTTV, (FrankerFaceZ and) 7tv emotes, allowing the Printer
-        plugin to highlight them, much like it does official Twitch emotes.
-        Imports both global and channel-specific emotes.
-     +/
-    bool bttv7tvEmotes = false;
-
-    /++
         Whether or not broadcasters are always implicitly class
         [dialect.defs.IRCUser.Class.staff|IRCUser.Class.staff].
      +/
@@ -426,8 +419,7 @@ void onGlobalUserstate(TwitchPlugin plugin, const /*ref*/ IRCEvent event)
 {
     plugin.state.bot.displayName = event.target.displayName;
     plugin.state.updates |= IRCPluginState.Update.bot;
-
-    if (plugin.twitchSettings.bttv7tvEmotes) importCustomGlobalEmotes(plugin);
+    importCustomGlobalEmotes(plugin);
 }
 
 
@@ -770,11 +762,7 @@ void onRoomState(TwitchPlugin plugin, const /*ref*/ IRCEvent event)
     room.follows = getFollows(plugin, event.aux);
     room.followsLastCached = event.time;
     startRoomMonitorFibers(plugin, event.channel);
-
-    if (plugin.twitchSettings.bttv7tvEmotes)
-    {
-        importCustomEmotes(plugin, room);
-    }
+    importCustomEmotes(plugin, room);
 
     version(WithPersistenceService)
     {
@@ -836,8 +824,6 @@ version(TwitchCustomEmotesEverywhere)
 )
 void onGuestRoomState(TwitchPlugin plugin, const /*ref*/ IRCEvent event)
 {
-    if (!plugin.twitchSettings.bttv7tvEmotes) return;
-
     auto room = event.channel in plugin.rooms;
 
     if (!room)
@@ -1639,9 +1625,7 @@ void onCommandEcount(TwitchPlugin plugin, const ref IRCEvent event)
 
     void sendNotATwitchEmote()
     {
-        immutable message = plugin.twitchSettings.bttv7tvEmotes ?
-            "That is not a Twitch, BetterTTV, FrankerFaceZ or 7tv emote." :
-            "That is not a Twitch emote.";
+        enum message = "That is not a Twitch, BetterTTV, FrankerFaceZ or 7tv emote.";
         chan(plugin.state, event.channel, message);
     }
 
@@ -3085,7 +3069,7 @@ void teardown(TwitchPlugin plugin)
     Hijacks a reference to a [dialect.defs.IRCEvent|IRCEvent] and modifies the
     sender and target class based on their badges (and the current settings).
 
-    Additionally and optionally embeds custom BTTV/FrankerFaceZ/7tv emotes into the event.
+    Additionally embeds custom BTTV/FrankerFaceZ/7tv emotes into the event.
  +/
 void postprocess(TwitchPlugin plugin, ref IRCEvent event)
 {


### PR DESCRIPTION
This makes the Twitch plugin issue some API calls to fetch custom [BetterTTV](https://betterttv.com), [FrankerFaceZ](https://www.frankerfacez.com) and [7tv](https://7tv.app) emotes. With this information it can then detect them in messages, and embed them as emotes into `IRCEvent`s. This in turn allows the Printer plugin to highlight them, much as it already does with official Twitch emotes.

The fetching is a one-time thing, done after connection established for global emotes (on `GLOBALUSERSTATE`) and upon joining home channels for channel-specific ones (on `ROOMSTATE`).

Detecting emotes is done manually by walking through channel message contents, *word by word*, checking if they exist in the custom emotes associative arrays.

**edit**: The setting to disable it was removed. The feature does incur a lot of AA lookups, but not an overwhelming amount, and the interplay between it and `ecount` makes it tricky to reason about when it should be disabled.