### PR TITLE
Support for IRC colours 16 and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Prebuilt binaries for Windows and Linux can be found under [**Releases**](https:
 
 To compile it yourself:
 
-```console
+```shell
 $ dub run kameloso -- --server irc.libera.chat --homeChannels "#mychannel" --guestChannels "#d"
 
 ## alternatively, guaranteed latest
@@ -108,7 +108,7 @@ See the [known issues](#known-issues) section on Windows for information on libr
 
 ## Downloading source
 
-```console
+```shell
 $ git clone https://github.com/zorael/kameloso.git
 ```
 
@@ -116,7 +116,7 @@ It can also be downloaded as a [`.zip` archive](https://github.com/zorael/kamelo
 
 ## Compiling
 
-```console
+```shell
 $ dub build
 ```
 
@@ -133,7 +133,7 @@ Both configurations come in `-lowmem` variants (e.g. `application-lowmem` and `t
 
 List configurations with `dub build --print-configs`. You can specify which to compile with the `-c` switch. Not supplying one will make it build the default `application` configuration.
 
-```console
+```shell
 $ dub build -c twitch
 ```
 
@@ -145,7 +145,7 @@ $ dub build -c twitch
 
 The bot ideally wants the account name of one or more administrators of the bot, and/or one or more home channels to operate in. Without either it's just a read-only log bot, which is a completely valid use-case. To define these you can either supply them on the command line, with flags listed by calling the program with `--help`, or generate a configuration file with `--save` and enter them there.
 
-```console
+```shell
 $ kameloso --save
 ```
 
@@ -182,7 +182,7 @@ Settings not touched will keep their values.
 
 ### Display settings
 
-**kameloso**'s text colours are by default set to go well with dark terminal backgrounds. If you have a bright background, text may be difficult to read (e.g. white on white), depending on your terminal emulator. If so, pass the `--bright` argument, and/or modify the configuration file; `brightTerminal` under `[Core]`. The bot uses 7 colours out of [8-colour ANSI](https://en.wikipedia.org/wiki/ANSI_escape_code#3/4_bit), so if one or more colours are too dark or bright even with the right `brightTerminal` setting, please refer to your terminal appearance settings.
+**kameloso**'s uses [terminal ANSI colouring](https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit), and text colours are by default set to go well with dark terminal backgrounds. If you have a bright background, text may be difficult to read (e.g. white on white), depending on your terminal emulator. If so, try passing the `--bright` argument, and/or modify the configuration file to enable `brightTerminal` under `[Core]`. If only some colours work, try limiting colouring to those by disabling `extendedColours`, also under `[Core]`. If one or more colours are still too dark or too bright even with the right `brightTerminal` setting, please refer to your terminal appearance settings.
 
 An alternative is to disable colours entirely with `--monochrome`.
 

--- a/source/kameloso/constants.d
+++ b/source/kameloso/constants.d
@@ -532,7 +532,7 @@ struct DefaultColours
 {
 private:
     import kameloso.logger : LogLevel;
-    import kameloso.terminal.colours : TerminalForeground;
+    import kameloso.terminal.colours.defs : TerminalForeground;
 
     alias TF = TerminalForeground;
 

--- a/source/kameloso/irccolours.d
+++ b/source/kameloso/irccolours.d
@@ -18,7 +18,7 @@ module kameloso.irccolours;
 
 private:
 
-import kameloso.terminal.colours : TerminalBackground, TerminalForeground,
+import kameloso.terminal.colours.defs : TerminalBackground, TerminalForeground,
     TerminalFormat, TerminalReset;
 import dialect.common : IRCControlCharacter;
 import std.range.primitives : isOutputRange;
@@ -41,7 +41,7 @@ enum IRCColour
     green       = 3,   /// Green
     red         = 4,   /// Red
     brown       = 5,   /// Brown
-    purple      = 6,   /// Purple
+    magenta     = 6,   /// Magenta
     orange      = 7,   /// Orange
     yellow      = 8,   /// Yellow
     lightgreen  = 9,   /// Light green
@@ -55,6 +55,117 @@ enum IRCColour
 }
 
 
+// ircANSIColourMap
+/++
+    Map of IRC colour values above 16 to ANSI terminal colours, as per ircdocs.
+
+    See_Also:
+        https://modern.ircdocs.horse/formatting.html#colors-16-98.
+ +/
+immutable uint[99] ircANSIColourMap =
+[
+     0 : TerminalForeground.default_,
+     1 : TerminalForeground.white,  // replace with .black on bright terminals
+     2 : TerminalForeground.red,
+     3 : TerminalForeground.green,
+     4 : TerminalForeground.yellow,
+     5 : TerminalForeground.blue,
+     6 : TerminalForeground.magenta,
+     7 : TerminalForeground.cyan,
+     8 : TerminalForeground.lightgrey,
+     9 : TerminalForeground.darkgrey,
+    10 : TerminalForeground.lightred,
+    11 : TerminalForeground.lightgreen,
+    12 : TerminalForeground.lightyellow,
+    13 : TerminalForeground.lightblue,
+    14 : TerminalForeground.lightmagenta,
+    15 : TerminalForeground.lightcyan,
+    16 : 52,
+    17 : 94,
+    18 : 100,
+    19 : 58,
+    20 : 22,
+    21 : 29,
+    22 : 23,
+    23 : 24,
+    24 : 17,
+    25 : 54,
+    26 : 53,
+    27 : 89,
+    28 : 88,
+    29 : 130,
+    30 : 142,
+    31 : 64,
+    32 : 28,
+    33 : 35,
+    34 : 30,
+    35 : 25,
+    36 : 18,
+    37 : 91,
+    38 : 90,
+    39 : 125,
+    40 : 124,
+    41 : 166,
+    42 : 184,
+    43 : 106,
+    44 : 34,
+    45 : 49,
+    46 : 37,
+    47 : 33,
+    48 : 19,
+    49 : 129,
+    50 : 127,
+    51 : 161,
+    52 : 196,
+    53 : 208,
+    54 : 226,
+    55 : 154,
+    56 : 46,
+    57 : 86,
+    58 : 51,
+    59 : 75,
+    60 : 21,
+    61 : 171,
+    62 : 201,
+    63 : 198,
+    64 : 203,
+    65 : 215,
+    66 : 227,
+    67 : 191,
+    68 : 83,
+    69 : 122,
+    70 : 87,
+    71 : 111,
+    72 : 63,
+    73 : 177,
+    74 : 207,
+    75 : 205,
+    76 : 217,
+    77 : 223,
+    78 : 229,
+    79 : 193,
+    80 : 157,
+    81 : 158,
+    82 : 159,
+    83 : 153,
+    84 : 147,
+    85 : 183,
+    86 : 219,
+    87 : 212,
+    88 : 16,
+    89 : 233,
+    90 : 235,
+    91 : 237,
+    92 : 239,
+    93 : 241,
+    94 : 244,
+    95 : 247,
+    96 : 250,
+    97 : 254,
+    98 : 231,
+];
+
+
 // ircColourInto
 /++
     Colour-codes the passed string with mIRC colouring, foreground and background.
@@ -63,14 +174,14 @@ enum IRCColour
     Params:
         line = Line to tint.
         sink = Output range sink to fill with the function's output.
-        fg = Foreground [IRCColour].
-        bg = Optional background [IRCColour].
+        fg = Foreground [IRCColour] integer.
+        bg = Optional background [IRCColour] integer.
  +/
 void ircColourInto(Sink)
     (const string line,
     auto ref Sink sink,
-    const IRCColour fg,
-    const IRCColour bg = IRCColour.unset)
+    const int fg,
+    const int bg = IRCColour.unset)
 if (isOutputRange!(Sink, char[]))
 in (line.length, "Tried to apply IRC colours to a string but no string was given")
 {
@@ -114,16 +225,16 @@ unittest
 
     Params:
         line = Line to tint.
-        fg = Foreground [IRCColour].
-        bg = Optional background [IRCColour].
+        fg = Foreground [IRCColour] integer.
+        bg = Optional background [IRCColour] integer.
 
     Returns:
         The passed line, encased within IRC colour tags.
  +/
 string ircColour(
     const string line,
-    const IRCColour fg,
-    const IRCColour bg = IRCColour.unset) pure
+    const int fg,
+    const int bg = IRCColour.unset) pure
 in (line.length, "Tried to apply IRC colours to a string but no string was given")
 {
     import std.array : Appender;
@@ -254,10 +365,11 @@ in (word.length, "Tried to apply IRC colours by hash to a string but no string w
     Appender!(char[]) sink;
     sink.reserve(word.length + 4);  // colour, index, word, colour
 
-    immutable colourIndex = hashOf(word) % 16;
+    immutable colourIndex = (hashOf(word) % ircANSIColourMap.length);
+    immutable colourInteger = ircANSIColourMap[colourIndex];
 
     sink.put(cast(char)IRCControlCharacter.colour);
-    colourIndex.toAlphaInto!(2, 2)(sink);
+    colourInteger.toAlphaInto!(3, 2)(sink);
     sink.put(word);
     sink.put(cast(char)IRCControlCharacter.colour);
 
@@ -273,17 +385,17 @@ unittest
 
     {
         immutable actual = "kameloso".ircColourByHash;
-        immutable expected = I.colour ~ "01kameloso" ~ I.colour;
+        immutable expected = I.colour ~ "24kameloso" ~ I.colour;
         assert((actual == expected), actual);
     }
     {
         immutable actual = "kameloso^".ircColourByHash;
-        immutable expected = I.colour ~ "09kameloso^" ~ I.colour;
+        immutable expected = I.colour ~ "46kameloso^" ~ I.colour;
         assert((actual == expected), actual);
     }
     {
         immutable actual = "kameloso^11".ircColourByHash;
-        immutable expected = I.colour ~ "05kameloso^11" ~ I.colour;
+        immutable expected = I.colour ~ "237kameloso^11" ~ I.colour;
         assert((actual == expected), actual);
     }
 }
@@ -993,7 +1105,7 @@ private string mapEffectsImpl(Flag!"strip" strip, IRCControlCharacter mircToken,
     static if (!strip)
     {
         import kameloso.terminal : TerminalToken;
-        import kameloso.terminal.colours : colourWith;
+        import kameloso.terminal.colours : applyANSI;
 
         enum terminalToken = TerminalToken.format ~ "[" ~ toAlpha(terminalFormatCode) ~ "m";
         sink.reserve(cast(size_t)(line.length * 1.5));
@@ -1040,7 +1152,7 @@ private string mapEffectsImpl(Flag!"strip" strip, IRCControlCharacter mircToken,
                 else
                 {
                     //logger.warning("Unknown terminal effect code: ", TerminalFormatCode);
-                    sink.colourWith(TerminalReset.all);
+                    sink.applyANSI(TerminalReset.all);
                 }
 
                 open = false;
@@ -1055,7 +1167,7 @@ private string mapEffectsImpl(Flag!"strip" strip, IRCControlCharacter mircToken,
 
     static if (!strip)
     {
-        if (open) sink.colourWith(TerminalReset.all);
+        if (open) sink.applyANSI(TerminalReset.all);
     }
 
     return sink.data;
@@ -1293,7 +1405,7 @@ T expandIRCTags(T)(const T line) @system
     {
         immutable line = "hello<h>kameloso<h>hello";
         immutable expanded = line.expandIRCTags;
-        immutable expected = "hello" ~ I.colour ~ "01kameloso" ~ I.colour ~ "hello";
+        immutable expected = "hello" ~ I.colour ~ "24kameloso" ~ I.colour ~ "hello";
         assert((expanded == expected), expanded);
     }
     {

--- a/source/kameloso/logger.d
+++ b/source/kameloso/logger.d
@@ -99,7 +99,8 @@ private:
     version(Colours)
     {
         import kameloso.constants : DefaultColours;
-        import kameloso.terminal.colours : TerminalForeground, TerminalReset, colourWith, colour;
+        import kameloso.terminal.colours.defs : TerminalForeground, TerminalReset;
+        import kameloso.terminal.colours : applyANSI, asANSI;
 
         /// Convenience alias.
         alias logcoloursBright = DefaultColours.logcoloursBright;
@@ -177,7 +178,7 @@ public:
             Example:
             ---
             TerminalForeground errtint = KamelosoLogger.tint(LogLevel.error, No.brightTerminal);
-            immutable errtintString = errtint.colour;
+            immutable errtintString = errtint.asANSI;
             ---
 
             Params:
@@ -187,10 +188,10 @@ public:
 
             Returns:
                 A [kameloso.terminal.colours.TerminalForeground|TerminalForeground] of
-                the right colour. Use with [kameloso.terminal.colours.colour|colour]
+                the right colour. Use with [kameloso.terminal.colours.asANSI|asANSI]
                 to get a string.
          +/
-        static auto tint(const LogLevel level, const Flag!"brightTerminal" bright) pure nothrow @nogc @safe
+        static uint tint(const LogLevel level, const Flag!"brightTerminal" bright) pure nothrow @nogc @safe
         {
             return bright ? logcoloursBright[level] : logcoloursDark[level];
         }
@@ -240,12 +241,12 @@ public:
             }
             else if (brightTerminal)
             {
-                enum ctTintBright = tint(level, Yes.brightTerminal).colour.idup;
+                enum ctTintBright = tint(level, Yes.brightTerminal).asANSI.idup;
                 return ctTintBright;
             }
             else
             {
-                enum ctTintDark = tint(level, No.brightTerminal).colour.idup;
+                enum ctTintDark = tint(level, No.brightTerminal).asANSI.idup;
                 return ctTintDark;
             }
         }
@@ -320,7 +321,8 @@ public:
             if (!monochrome)
             {
                 alias Timestamp = DefaultColours.TimestampColour;
-                linebuffer.colourWith(brightTerminal ? Timestamp.bright : Timestamp.dark);
+                //linebuffer.applyANSI(brightTerminal ? Timestamp.bright : Timestamp.dark);
+                linebuffer.applyANSI(TerminalReset.all);
             }
         }
 
@@ -332,7 +334,7 @@ public:
         {
             if (!monochrome)
             {
-                linebuffer.colourWith(brightTerminal ?
+                linebuffer.applyANSI(brightTerminal ?
                     logcoloursBright[logLevel] :
                     logcoloursDark[logLevel]);
             }
@@ -345,6 +347,7 @@ public:
      +/
     private void finishLogMsg() @trusted  // writeln trusts stdout.flush, so we should be able to too
     {
+        import kameloso.terminal.colours : applyANSI;
         import std.stdio : stdout, writeln;
 
         version(Colours)
@@ -352,7 +355,7 @@ public:
             if (!monochrome)
             {
                 // Reset.blink in case a fatal message was thrown
-                linebuffer.colourWith(TerminalReset.all);
+                linebuffer.applyANSI(TerminalReset.all);
             }
         }
 

--- a/source/kameloso/plugins/admin/classifiers.d
+++ b/source/kameloso/plugins/admin/classifiers.d
@@ -625,7 +625,7 @@ in (mask.length, "Tried to add an empty hostmask definition")
     else
     {
         // No-colours passthrough noop
-        static string colourByHash(const string word, const CoreSettings settings)
+        static string colourByHash(const string word, const CoreSettings _)
         {
             return word;
         }

--- a/source/kameloso/plugins/admin/classifiers.d
+++ b/source/kameloso/plugins/admin/classifiers.d
@@ -609,6 +609,7 @@ void modifyHostmaskDefinition(
 in ((!add || account.length), "Tried to add a hostmask with no account to map it to")
 in (mask.length, "Tried to add an empty hostmask definition")
 {
+    import kameloso.pods : CoreSettings;
     import kameloso.thread : ThreadMessage;
     import lu.json : JSONStorage, populateFromJSON;
     import lu.string : contains;
@@ -624,7 +625,7 @@ in (mask.length, "Tried to add an empty hostmask definition")
     else
     {
         // No-colours passthrough noop
-        static string colourByHash(const string word, const Flag!"brightTerminal")
+        static string colourByHash(const string word, const CoreSettings settings)
         {
             return word;
         }
@@ -639,8 +640,6 @@ in (mask.length, "Tried to add an empty hostmask definition")
 
     string[string] aa;
     aa.populateFromJSON(json);
-
-    immutable brightFlag = cast(Flag!"brightTerminal")plugin.state.settings.brightTerminal;
 
     if (add)
     {
@@ -671,7 +670,7 @@ in (mask.length, "Tried to add an empty hostmask definition")
 
         if (event == IRCEvent.init)
         {
-            immutable colouredAccount = colourByHash(account, brightFlag);
+            immutable colouredAccount = colourByHash(account, plugin.state.settings);
             enum pattern = `Added hostmask "<l>%s</>", mapped to account <h>%s</>.`;
             logger.infof(pattern, mask, colouredAccount);
         }

--- a/source/kameloso/plugins/printer/base.d
+++ b/source/kameloso/plugins/printer/base.d
@@ -80,9 +80,6 @@ public:
 
             /// Whether or not emotes should be highlit in colours.
             bool colourfulEmotes = true;
-
-            /// Compatibility alias.
-            alias randomNickColours = colourfulNicknames;
         }
     }
 

--- a/source/kameloso/plugins/printer/base.d
+++ b/source/kameloso/plugins/printer/base.d
@@ -31,7 +31,7 @@ import kameloso.plugins.common.awareness : ChannelAwareness, UserAwareness;
 import dialect.defs;
 import std.typecons : Flag, No, Yes;
 
-version(Colours) import kameloso.terminal.colours : TerminalForeground;
+version(Colours) import kameloso.terminal.colours.defs : TerminalForeground;
 
 
 // PrinterSettings

--- a/source/kameloso/plugins/printer/formatting.d
+++ b/source/kameloso/plugins/printer/formatting.d
@@ -678,11 +678,9 @@ if (isOutputRange!(Sink, char[]))
                 if ((event.sender.displayName != event.sender.nickname) &&
                     !event.sender.displayName.asLowerCase.equal(event.sender.nickname))
                 {
-                    //.put!(Yes.colours)(sink, TR.all, " (");
                     sink.applyANSI(TR.all);
                     sink.put(" (");
                     colourUserTruecolour(sink, event.sender);
-                    //.put!(Yes.colours)(sink, event.sender.nickname, TR.all, ')');
                     sink.put(event.sender.nickname);
                     sink.applyANSI(TR.all);
                     sink.put(')');
@@ -698,7 +696,6 @@ if (isOutputRange!(Sink, char[]))
 
         version(PrintClassNamesToo)
         {
-            //.put!(Yes.colours)(sink, TR.all, ':', event.sender.class_);
             sink.applyANSI(TR.all);
             .put(sink, ':', event.sender.class_);
         }
@@ -709,7 +706,6 @@ if (isOutputRange!(Sink, char[]))
             if ((plugin.state.server.daemon != IRCServer.Daemon.twitch) &&
                 event.sender.account.length)
             {
-                //.put!(Yes.colours)(sink, TR.all, '(', event.sender.account, ')');
                 sink.applyANSI(TR.all);
                 .put(sink, '(', event.sender.account, ')');
             }
@@ -730,10 +726,6 @@ if (isOutputRange!(Sink, char[]))
                     break;
 
                 default:
-                    /*.put!(Yes.colours)(sink,
-                        TR.all,
-                        TerminalForeground(bright ? Bright.badge : Dark.badge),
-                        " [", event.sender.badges, ']');*/
                     immutable code = bright ? Bright.badge : Dark.badge;
                     sink.applyANSI(TR.all);
                     sink.applyANSI(code, ANSICodeType.foreground);
@@ -760,11 +752,9 @@ if (isOutputRange!(Sink, char[]))
                 // Add more as they become apparent
                 sink.applyANSI(TR.all);
                 sink.put(" <- ");
-                //.put!(Yes.colours)(sink, TR.all, " <- ");
                 break;
 
             default:
-                //.put!(Yes.colours)(sink, TR.all, " -> ");
                 sink.applyANSI(TR.all);
                 sink.put(" -> ");
                 break;
@@ -786,7 +776,6 @@ if (isOutputRange!(Sink, char[]))
                 {
                     sink.put(" (");
                     colourUserTruecolour(sink, event.target);
-                    //.put!(Yes.colours)(sink, event.target.nickname, TR.all, ')');
                     sink.put(event.target.nickname);
                     sink.applyANSI(TR.all);
                     sink.put(')');
@@ -797,7 +786,6 @@ if (isOutputRange!(Sink, char[]))
         if (!putArrow)
         {
             // No need to check isServer; target is never server
-            //.put!(Yes.colours)(sink, TR.all, " -> ");
             sink.applyANSI(TR.all);
             sink.put(" -> ");
             colourUserTruecolour(sink, event.target);
@@ -810,7 +798,6 @@ if (isOutputRange!(Sink, char[]))
 
         version(PrintClassNamesToo)
         {
-            //.put!(Yes.colours)(sink, TR.all, ':', event.target.class_);
             sink.applyANSI(TR.all);
             .put(sink, ':', event.target.class_);
         }
@@ -821,7 +808,6 @@ if (isOutputRange!(Sink, char[]))
             if ((plugin.state.server.daemon != IRCServer.Daemon.twitch) &&
                 event.target.account.length)
             {
-                .put!(Yes.colours)(sink, TR.all, '(', event.target.account, ')');
                 sink.applyANSI(TR.all);
                 sink.put('(', event.target.account, ')');
             }
@@ -832,10 +818,6 @@ if (isOutputRange!(Sink, char[]))
             if ((plugin.state.server.daemon == IRCServer.Daemon.twitch) &&
                 plugin.printerSettings.twitchBadges && event.target.badges.length)
             {
-                /*.put!(Yes.colours)(sink,
-                    TR.all,
-                    TerminalForeground(bright ? Bright.badge : Dark.badge),
-                    " [", event.target.badges, ']');*/
                 immutable code = bright ? Bright.badge : Dark.badge;
                 sink.applyANSI(TR.all);
                 sink.applyANSI(code, ANSICodeType.foreground);
@@ -937,11 +919,9 @@ if (isOutputRange!(Sink, char[]))
         // Reset the background to ward off bad backgrounds bleeding out
         sink.applyANSI(fgBase, ANSICodeType.foreground); //, TerminalBackground.default_);
         sink.applyANSI(TerminalBackground.default_);
-        //sink.applyANSI(TerminalBackground.default_);
         if (!isEmote) sink.put('"');
     }
 
-    //.put!(Yes.colours)(sink, TerminalForeground(bright ? Timestamp.bright : Timestamp.dark), '[');
     immutable timestampCode = bright ? Timestamp.bright : Timestamp.dark;
     sink.applyANSI(timestampCode, ANSICodeType.foreground);
     sink.put('[');
@@ -990,9 +970,6 @@ if (isOutputRange!(Sink, char[]))
 
     if (event.channel.length)
     {
-        /*.put!(Yes.colours)(sink,
-            TerminalForeground(bright ? Bright.channel : Dark.channel),
-            '[', event.channel, "] ");*/
         immutable code = bright ? Bright.channel : Dark.channel;
         sink.applyANSI(code, ANSICodeType.foreground);
         .put(sink, '[', event.channel, "] ");
@@ -1012,9 +989,6 @@ if (isOutputRange!(Sink, char[]))
         {
             /*if (content.length)*/ putContent();
             putTarget();
-            /*.put!(Yes.colours)(sink,
-                TerminalForeground(bright ? Bright.content : Dark.content),
-                `: "`, event.aux[0], '"');*/
             immutable code = bright ? Bright.content : Dark.content;
             sink.applyANSI(code, ANSICodeType.foreground);
             .put(sink, `: "`, event.aux[0], '"');
@@ -1055,7 +1029,6 @@ if (isOutputRange!(Sink, char[]))
     if (event.num > 0)
     {
         import lu.conv : toAlphaInto;
-        //import std.format : formattedWrite;
 
         sink.applyANSI(bright ? Bright.num : Dark.num);
 
@@ -1067,9 +1040,6 @@ if (isOutputRange!(Sink, char[]))
 
     if (event.errors.length)
     {
-        /*.put!(Yes.colours)(sink,
-            TerminalForeground(bright ? Bright.error : Dark.error),
-            " ! ", event.errors, " !");*/
         immutable code = bright ? Bright.error : Dark.error;
         sink.applyANSI(code, ANSICodeType.foreground);
         .put(sink, " ! ", event.errors, " !");

--- a/source/kameloso/plugins/printer/formatting.d
+++ b/source/kameloso/plugins/printer/formatting.d
@@ -1366,11 +1366,15 @@ unittest
 
     Appender!(char[]) sink;
 
+    CoreSettings brightSettings;
+    CoreSettings darkSettings;
+    brightSettings.brightTerminal = true;
+
     {
         immutable emotes = "212612:14-22/75828:24-29";
         immutable line = "Moody the god pownyFine pownyL";
         sink.highlightEmotesImpl(line, emotes, TerminalForeground.white,
-            TerminalForeground.default_, No.colourful, No.brightTerminal);
+            TerminalForeground.default_, No.colourful, darkSettings);
         assert((sink.data == "Moody the god \033[97mpownyFine\033[39m \033[97mpownyL\033[39m"), sink.data);
     }
     {
@@ -1378,7 +1382,7 @@ unittest
         immutable emotes = "25:41-45";
         immutable line = "whoever plays nintendo switch whisper me Kappa";
         sink.highlightEmotesImpl(line, emotes, TerminalForeground.white,
-            TerminalForeground.default_, No.colourful, No.brightTerminal);
+            TerminalForeground.default_, No.colourful, darkSettings);
         assert((sink.data == "whoever plays nintendo switch whisper me \033[97mKappa\033[39m"), sink.data);
     }
     {
@@ -1386,7 +1390,7 @@ unittest
         immutable emotes = "877671:8-17,19-28,30-39";
         immutable line = "NOOOOOO camillsCry camillsCry camillsCry";
         sink.highlightEmotesImpl(line, emotes, TerminalForeground.white,
-            TerminalForeground.default_, No.colourful, No.brightTerminal);
+            TerminalForeground.default_, No.colourful, darkSettings);
         assert((sink.data == "NOOOOOO \033[97mcamillsCry\033[39m " ~
             "\033[97mcamillsCry\033[39m \033[97mcamillsCry\033[39m"), sink.data);
     }
@@ -1395,7 +1399,7 @@ unittest
         immutable emotes = "822112:0-6,8-14,16-22";
         immutable line = "FortOne FortOne FortOne";
         sink.highlightEmotesImpl(line, emotes, TerminalForeground.white,
-            TerminalForeground.default_, No.colourful, No.brightTerminal);
+            TerminalForeground.default_, No.colourful, darkSettings);
         assert((sink.data == "\033[97mFortOne\033[39m \033[97mFortOne\033[39m " ~
             "\033[97mFortOne\033[39m"), sink.data);
     }
@@ -1404,7 +1408,7 @@ unittest
         immutable emotes = "141844:17-24,26-33,35-42/141073:9-15";
         immutable line = "@mugs123 cohhWow cohhBoop cohhBoop cohhBoop";
         sink.highlightEmotesImpl(line, emotes, TerminalForeground.white,
-            TerminalForeground.default_, No.colourful, No.brightTerminal);
+            TerminalForeground.default_, No.colourful, darkSettings);
         assert((sink.data == "@mugs123 \033[97mcohhWow\033[39m \033[97mcohhBoop\033[39m " ~
             "\033[97mcohhBoop\033[39m \033[97mcohhBoop\033[39m"), sink.data);
     }
@@ -1420,7 +1424,7 @@ unittest
             "twitch.amazon.com/prime | Click subscribe now to check if a " ~
             "free prime sub is available to use!";
         sink.highlightEmotesImpl(line, emotes, TerminalForeground.white,
-            TerminalForeground.default_, No.colourful, No.brightTerminal);
+            TerminalForeground.default_, No.colourful, brightSettings);
         assert((sink.data == highlitLine), sink.data);
     }
     {
@@ -1428,7 +1432,7 @@ unittest
         immutable emotes = "25:32-36";
         immutable line = "@kiwiskool but you’re a sub too Kappa";
         sink.highlightEmotesImpl(line, emotes, TerminalForeground.white,
-            TerminalForeground.default_, No.colourful, No.brightTerminal);
+            TerminalForeground.default_, No.colourful, brightSettings);
         assert((sink.data == "@kiwiskool but you’re a sub too \033[97mKappa\033[39m"), sink.data);
     }
     {
@@ -1436,7 +1440,7 @@ unittest
         immutable emotes = "425618:6-8,16-18/1:20-21";
         immutable line = "高所恐怖症 LUL なにぬねの LUL :)";
         sink.highlightEmotesImpl(line, emotes, TerminalForeground.white,
-            TerminalForeground.default_, No.colourful, No.brightTerminal);
+            TerminalForeground.default_, No.colourful, brightSettings);
         assert((sink.data == "高所恐怖症 \033[97mLUL\033[39m なにぬねの " ~
             "\033[97mLUL\033[39m \033[97m:)\033[39m"), sink.data);
     }
@@ -1445,7 +1449,7 @@ unittest
         immutable emotes = "425618:6-8,16-18/1:20-21";
         immutable line = "高所恐怖症 LUL なにぬねの LUL :)";
         sink.highlightEmotesImpl(line, emotes, TerminalForeground.white,
-            TerminalForeground.default_, Yes.colourful, No.brightTerminal);
+            TerminalForeground.default_, Yes.colourful, brightSettings);
         assert((sink.data == "高所恐怖症 \033[38;5;171mLUL\033[39m なにぬねの " ~
             "\033[38;5;171mLUL\033[39m \033[35m:)\033[39m"), sink.data);
     }
@@ -1454,15 +1458,15 @@ unittest
         immutable emotes = "212612:14-22/75828:24-29";
         immutable line = "Moody the god pownyFine pownyL";
         sink.highlightEmotesImpl(line, emotes, TerminalForeground.white,
-            TerminalForeground.default_, Yes.colourful, No.brightTerminal);
-        assert((sink.data == "Moody the god \033[38;5;243mpownyFine\033[39m \033[38;5;159mpownyL\033[39m"), sink.data);
+            TerminalForeground.default_, Yes.colourful, brightSettings);
+        assert((sink.data == "Moody the god \033[38;5;237mpownyFine\033[39m \033[38;5;159mpownyL\033[39m"), sink.data);
     }
     {
         sink.clear();
         immutable emotes = "25:41-45";
         immutable line = "whoever plays nintendo switch whisper me Kappa";
         sink.highlightEmotesImpl(line, emotes, TerminalForeground.white,
-            TerminalForeground.default_, Yes.colourful, No.brightTerminal);
+            TerminalForeground.default_, Yes.colourful, brightSettings);
         assert((sink.data == "whoever plays nintendo switch whisper me \033[38;5;49mKappa\033[39m"), sink.data);
     }
     {
@@ -1470,7 +1474,7 @@ unittest
         immutable emotes = "877671:8-17,19-28,30-39";
         immutable line = "NOOOOOO camillsCry camillsCry camillsCry";
         sink.highlightEmotesImpl(line, emotes, TerminalForeground.white,
-            TerminalForeground.default_, Yes.colourful, No.brightTerminal);
+            TerminalForeground.default_, Yes.colourful, brightSettings);
         assert((sink.data == "NOOOOOO \033[38;5;166mcamillsCry\033[39m " ~
             "\033[38;5;166mcamillsCry\033[39m \033[38;5;166mcamillsCry\033[39m"), sink.data);
     }

--- a/source/kameloso/plugins/printer/formatting.d
+++ b/source/kameloso/plugins/printer/formatting.d
@@ -619,7 +619,7 @@ if (isOutputRange!(Sink, char[]))
         {
             if (!user.isServer && user.colour.length &&
                 plugin.printerSettings.truecolour &&
-                plugin.state.settings.extendedANSIColours)
+                plugin.state.settings.extendedColours)
             {
                 import kameloso.terminal.colours : applyTruecolour;
                 import lu.conv : rgbFromHex;

--- a/source/kameloso/plugins/printer/formatting.d
+++ b/source/kameloso/plugins/printer/formatting.d
@@ -434,10 +434,9 @@ if (isOutputRange!(Sink, char[]))
     {
         import lu.conv : toAlphaInto;
 
-        //sink.formattedWrite(" (#%03d)", num);
-        sink.put(" (#");
+        sink.put(" [#");
         event.num.toAlphaInto!(3, 3)(sink);
-        sink.put(')');
+        sink.put(']');
     }
 
     if (event.errors.length)
@@ -526,9 +525,9 @@ if (isOutputRange!(Sink, char[]))
 
     plugin.formatMessageMonochrome(sink, event, No.bellOnMention, No.bellOnError);
     immutable errorLine = sink.data[11..$].idup;
-    version(TwitchSupport) assert((errorLine == `[error] Nickname: "Blah balah" {-42} (#666) ` ~
+    version(TwitchSupport) assert((errorLine == `[error] Nickname: "Blah balah" {-42} [#666] ` ~
         "! DANGER WILL ROBINSON !"), errorLine);
-    else assert((errorLine == `[error] nickname: "Blah balah" {-42} (#666) ` ~
+    else assert((errorLine == `[error] nickname: "Blah balah" {-42} [#666] ` ~
         "! DANGER WILL ROBINSON !"), errorLine);
     //sink.clear();
 }
@@ -1031,11 +1030,9 @@ if (isOutputRange!(Sink, char[]))
         import lu.conv : toAlphaInto;
 
         sink.applyANSI(bright ? Bright.num : Dark.num);
-
-        //sink.formattedWrite(" (#%03d)", event.num);
-        sink.put(" (#");
+        sink.put(" [#");
         event.num.toAlphaInto!(3, 3)(sink);
-        sink.put(')');
+        sink.put(']');
     }
 
     if (event.errors.length)

--- a/source/kameloso/plugins/printer/formatting.d
+++ b/source/kameloso/plugins/printer/formatting.d
@@ -610,8 +610,7 @@ if (isOutputRange!(Sink, char[]))
         This is for Twitch servers that assign such values to users' messages.
         By catching it we can honour the setting by tinting users accordingly.
      +/
-    void colourUserTruecolour(Sink)(auto ref Sink sink, const IRCUser user)
-    if (isOutputRange!(Sink, char[]))
+    void colourUserTruecolour(const IRCUser user)
     {
         bool coloured;
 
@@ -654,7 +653,7 @@ if (isOutputRange!(Sink, char[]))
     {
         scope(exit) sink.applyANSI(TR.all);
 
-        colourUserTruecolour(sink, event.sender);
+        colourUserTruecolour(event.sender);
 
         if (event.sender.isServer)
         {
@@ -679,7 +678,7 @@ if (isOutputRange!(Sink, char[]))
                 {
                     sink.applyANSI(TR.all);
                     sink.put(" (");
-                    colourUserTruecolour(sink, event.sender);
+                    colourUserTruecolour(event.sender);
                     sink.put(event.sender.nickname);
                     sink.applyANSI(TR.all);
                     sink.put(')');
@@ -759,7 +758,7 @@ if (isOutputRange!(Sink, char[]))
                 break;
             }
 
-            colourUserTruecolour(sink, event.target);
+            colourUserTruecolour(event.target);
             putArrow = true;
 
             if (event.target.displayName.length)
@@ -774,7 +773,7 @@ if (isOutputRange!(Sink, char[]))
                     !event.target.displayName.asLowerCase.equal(event.target.nickname))
                 {
                     sink.put(" (");
-                    colourUserTruecolour(sink, event.target);
+                    colourUserTruecolour(event.target);
                     sink.put(event.target.nickname);
                     sink.applyANSI(TR.all);
                     sink.put(')');
@@ -787,7 +786,7 @@ if (isOutputRange!(Sink, char[]))
             // No need to check isServer; target is never server
             sink.applyANSI(TR.all);
             sink.put(" -> ");
-            colourUserTruecolour(sink, event.target);
+            colourUserTruecolour(event.target);
         }
 
         if (!putDisplayName)

--- a/source/kameloso/pods.d
+++ b/source/kameloso/pods.d
@@ -44,6 +44,12 @@ public:
      +/
     bool brightTerminal = false;
 
+    // extendedANSIColours
+    /++
+        FIXME
+     +/
+    bool extendedANSIColours = true;
+
     // preferHostmasks
     /++
         Flag denoting that usermasks should be used instead of accounts to authenticate users.

--- a/source/kameloso/pods.d
+++ b/source/kameloso/pods.d
@@ -44,11 +44,11 @@ public:
      +/
     bool brightTerminal = false;
 
-    // extendedANSIColours
+    // extendedColours
     /++
-        FIXME
+        Flag denoting that the bot should output text using extended ANSI sequences.
      +/
-    bool extendedANSIColours = true;
+    bool extendedColours = true;
 
     // preferHostmasks
     /++

--- a/source/kameloso/pods.d
+++ b/source/kameloso/pods.d
@@ -38,13 +38,11 @@ public:
         bool monochrome = true;
     }
 
-
     // brightTerminal
     /++
         Flag denoting that the terminal has a bright background.
      +/
     bool brightTerminal = false;
-
 
     // preferHostmasks
     /++
@@ -52,13 +50,11 @@ public:
      +/
     bool preferHostmasks = false;
 
-
     // hideOutgoing
     /++
         Whether or not to hide outgoing messages, not printing them to screen.
      +/
     bool hideOutgoing = false;
-
 
     // colouredOutgoing
     /++
@@ -66,20 +62,17 @@ public:
      +/
     bool colouredOutgoing = true;
 
-
     // saveOnExit
     /++
         Flag denoting that we should save configuration changes to file on exit.
      +/
     bool saveOnExit = false;
 
-
     // exitSummary
     /++
         Whether or not to display a connection summary on program exit.
      +/
     bool exitSummary = false;
-
 
     @Hidden
     {
@@ -90,14 +83,12 @@ public:
          +/
         bool eagerLookups = false;
 
-
         // headless
         /++
             Whether or not to be "headless", disabling all terminal output.
          +/
         bool headless;
     }
-
 
     // resourceDirectory
     /++
@@ -106,7 +97,6 @@ public:
     @Hidden
     @CannotContainComments
     string resourceDirectory;
-
 
     // prefix
     /++
@@ -118,7 +108,6 @@ public:
      +/
     @Quoted string prefix = "!";
 
-
     @Unserialisable
     {
         // configFile
@@ -127,20 +116,17 @@ public:
          +/
         string configFile;
 
-
         // configDirectory
         /++
             Path to configuration directory.
          +/
         string configDirectory;
 
-
         // force
         /++
             Whether or not to force connecting, skipping some sanity checks.
          +/
         bool force;
-
 
         // flush
         /++
@@ -154,13 +140,11 @@ public:
          +/
         bool trace;
 
-
         // numericAddresses
         /++
             Whether to print addresses as IPs or as hostnames (where applicable).
          +/
         bool numericAddresses;
-
 
         // observerMode
         /++

--- a/source/kameloso/printing.d
+++ b/source/kameloso/printing.d
@@ -308,7 +308,8 @@ private void formatStringMemberImpl(Flag!"coloured" coloured, T, Sink)
 
     static if (coloured)
     {
-        import kameloso.terminal.colours : F = TerminalForeground, colour;
+        import kameloso.terminal.colours.defs : F = TerminalForeground;
+        import kameloso.terminal.colours : asANSI;
 
         if (args.truncate && (content.length > truncateAfter))
         {
@@ -319,11 +320,11 @@ private void formatStringMemberImpl(Flag!"coloured" coloured, T, Sink)
             immutable typeCode   = args.bright ? F.lightcyan : F.cyan;
 
             sink.formattedWrite(stringPattern,
-                typeCode.colour, args.typewidth, args.typestring,
-                memberCode.colour, args.namewidth, args.memberstring,
+                typeCode.asANSI, args.typewidth, args.typestring,
+                memberCode.asANSI, args.namewidth, args.memberstring,
                 //(content.length ? string.init : " "),
-                valueCode.colour, content[0..truncateAfter],
-                lengthCode.colour, content.length);
+                valueCode.asANSI, content[0..truncateAfter],
+                lengthCode.asANSI, content.length);
         }
         else
         {
@@ -334,11 +335,11 @@ private void formatStringMemberImpl(Flag!"coloured" coloured, T, Sink)
             immutable typeCode   = args.bright ? F.lightcyan : F.cyan;
 
             sink.formattedWrite(stringPattern,
-                typeCode.colour, args.typewidth, args.typestring,
-                memberCode.colour, args.namewidth, args.memberstring,
+                typeCode.asANSI, args.typewidth, args.typestring,
+                memberCode.asANSI, args.namewidth, args.memberstring,
                 (content.length ? string.init : " "),
-                valueCode.colour, content,
-                lengthCode.colour, content.length);
+                valueCode.asANSI, content,
+                lengthCode.asANSI, content.length);
         }
     }
     else
@@ -449,7 +450,8 @@ private void formatArrayMemberImpl(Flag!"coloured" coloured, T, Sink)
 
     static if (coloured)
     {
-        import kameloso.terminal.colours : F = TerminalForeground, colour;
+        import kameloso.terminal.colours.defs : F = TerminalForeground;
+        import kameloso.terminal.colours : asANSI;
 
         immutable memberCode = args.bright ? F.black : F.white;
         immutable valueCode  = args.bright ? F.green : F.lightgreen;
@@ -463,10 +465,10 @@ private void formatArrayMemberImpl(Flag!"coloured" coloured, T, Sink)
                 "%s%*s %s%-*s %s%s%s ... (%d)\n";
 
             sink.formattedWrite(rtArrayPattern,
-                typeCode.colour, args.typewidth, typestring,
-                memberCode.colour, args.namewidth, args.memberstring,
-                valueCode.colour, content[0..truncateAfter],
-                lengthCode.colour, length);
+                typeCode.asANSI, args.typewidth, typestring,
+                memberCode.asANSI, args.namewidth, args.memberstring,
+                valueCode.asANSI, content[0..truncateAfter],
+                lengthCode.asANSI, length);
         }
         else
         {
@@ -475,11 +477,11 @@ private void formatArrayMemberImpl(Flag!"coloured" coloured, T, Sink)
                 "%s%*s %s%-*s %s%s%s%s(%d)\n";
 
             sink.formattedWrite(rtArrayPattern,
-                typeCode.colour, args.typewidth, typestring,
-                memberCode.colour, args.namewidth, args.memberstring,
+                typeCode.asANSI, args.typewidth, typestring,
+                memberCode.asANSI, args.namewidth, args.memberstring,
                 (content.length ? string.init : " "),
-                valueCode.colour, content,
-                lengthCode.colour, length);
+                valueCode.asANSI, content,
+                lengthCode.asANSI, length);
         }
     }
     else
@@ -533,7 +535,8 @@ private void formatAssociativeArrayMemberImpl(Flag!"coloured" coloured, T, Sink)
 
     static if (coloured)
     {
-        import kameloso.terminal.colours : F = TerminalForeground, colour;
+        import kameloso.terminal.colours.defs : F = TerminalForeground;
+        import kameloso.terminal.colours : asANSI;
 
         immutable memberCode = args.bright ? F.black : F.white;
         immutable valueCode  = args.bright ? F.green : F.lightgreen;
@@ -545,21 +548,21 @@ private void formatAssociativeArrayMemberImpl(Flag!"coloured" coloured, T, Sink)
             enum aaPattern = "%s%*s %s%-*s %s%s%s ... (%d)\n";
 
             sink.formattedWrite(aaPattern,
-                typeCode.colour, args.typewidth, args.typestring,
-                memberCode.colour, args.namewidth, args.memberstring,
-                valueCode.colour, content.keys[0..truncateAfter],
-                lengthCode.colour, content.length);
+                typeCode.asANSI, args.typewidth, args.typestring,
+                memberCode.asANSI, args.namewidth, args.memberstring,
+                valueCode.asANSI, content.keys[0..truncateAfter],
+                lengthCode.asANSI, content.length);
         }
         else
         {
             enum aaPattern = "%s%*s %s%-*s %s%s%s%s(%d)\n";
 
             sink.formattedWrite(aaPattern,
-                typeCode.colour, args.typewidth, args.typestring,
-                memberCode.colour, args.namewidth, args.memberstring,
+                typeCode.asANSI, args.typewidth, args.typestring,
+                memberCode.asANSI, args.namewidth, args.memberstring,
                 (content.length ? string.init : " "),
-                valueCode.colour, content.keys,
-                lengthCode.colour, content.length);
+                valueCode.asANSI, content.keys,
+                lengthCode.asANSI, content.length);
         }
     }
     else
@@ -636,7 +639,8 @@ private void formatAggregateMemberImpl(Flag!"coloured" coloured, Sink)
 
     static if (coloured)
     {
-        import kameloso.terminal.colours : F = TerminalForeground, colour;
+        import kameloso.terminal.colours.defs : F = TerminalForeground;
+        import kameloso.terminal.colours : asANSI;
 
         enum normalPattern = "%s%*s %s%-*s %s<%s>%s\n";
         immutable memberCode = args.bright ? F.black : F.white;
@@ -644,9 +648,9 @@ private void formatAggregateMemberImpl(Flag!"coloured" coloured, Sink)
         immutable typeCode   = args.bright ? F.lightcyan : F.cyan;
 
         sink.formattedWrite(normalPattern,
-            typeCode.colour, args.typewidth, args.typestring,
-            memberCode.colour, args.namewidth, args.memberstring,
-            valueCode.colour, args.aggregateType, args.initText);
+            typeCode.asANSI, args.typewidth, args.typestring,
+            memberCode.asANSI, args.namewidth, args.memberstring,
+            valueCode.asANSI, args.aggregateType, args.initText);
     }
     else
     {
@@ -700,7 +704,8 @@ private void formatOtherMemberImpl(Flag!"coloured" coloured, T, Sink)
 
     static if (coloured)
     {
-        import kameloso.terminal.colours : F = TerminalForeground, colour;
+        import kameloso.terminal.colours.defs : F = TerminalForeground;
+        import kameloso.terminal.colours : asANSI;
 
         enum normalPattern = "%s%*s %s%-*s  %s%s\n";
         immutable memberCode = args.bright ? F.black : F.white;
@@ -708,9 +713,9 @@ private void formatOtherMemberImpl(Flag!"coloured" coloured, T, Sink)
         immutable typeCode   = args.bright ? F.lightcyan : F.cyan;
 
         sink.formattedWrite(normalPattern,
-            typeCode.colour, args.typewidth, args.typestring,
-            memberCode.colour, args.namewidth, args.memberstring,
-            valueCode.colour, content);
+            typeCode.asANSI, args.typewidth, args.typestring,
+            memberCode.asANSI, args.namewidth, args.memberstring,
+            valueCode.asANSI, content);
     }
     else
     {
@@ -750,7 +755,8 @@ if (isOutputRange!(Sink, char[]) && isAggregateType!Thing)
 {
     static if (coloured)
     {
-        import kameloso.terminal.colours : F = TerminalForeground, colourWith;
+        import kameloso.terminal.colours.defs : F = TerminalForeground;
+        import kameloso.terminal.colours : applyANSI;
     }
 
     import lu.string : stripSuffix;
@@ -762,8 +768,8 @@ if (isOutputRange!(Sink, char[]) && isAggregateType!Thing)
     static if (coloured)
     {
         immutable titleCode = bright ? F.black : F.white;
-        sink.colourWith(titleCode);
-        scope(exit) sink.colourWith(F.default_);
+        sink.applyANSI(titleCode);
+        scope(exit) sink.applyANSI(F.default_);
     }
 
     sink.formattedWrite("-- %s\n", Thing.stringof.stripSuffix("Settings"));

--- a/source/kameloso/terminal/colours/defs.d
+++ b/source/kameloso/terminal/colours/defs.d
@@ -1,0 +1,105 @@
+/++
+    Enum definitions of ANSI codes.
+ +/
+
+module kameloso.terminal.colours.defs;
+
+
+// TerminalFormat
+/++
+    Format codes that work like terminal colouring does, except here for formats
+    like bold, dim, italics, etc.
+ +/
+enum TerminalFormat
+{
+    unset       = 0,  /// Seemingly resets to nothing.
+    bold        = 1,  /// Bold.
+    dim         = 2,  /// Dim, darkens it a bit.
+    italics     = 3,  /// Italics; usually has some other effect.
+    underlined  = 4,  /// Underlined.
+    blink       = 5,  /// Blinking text.
+    reverse     = 7,  /// Inverts text foreground and background.
+    hidden      = 8,  /// "Hidden" text.
+}
+
+
+// TerminalForeground
+/++
+    The basic 16+1 foreground colour codes of terminal colouring.
+ +/
+enum TerminalForeground
+{
+    default_     = 39,  /// Default grey.
+    black        = 30,  /// Black.
+    red          = 31,  /// Red.
+    green        = 32,  /// Green.
+    yellow       = 33,  /// Yellow.
+    blue         = 34,  /// Blue.
+    magenta      = 35,  /// Magenta.
+    cyan         = 36,  /// Cyan.
+    lightgrey    = 37,  /// Light grey.
+    darkgrey     = 90,  /// Dark grey.
+    lightred     = 91,  /// Light red.
+    lightgreen   = 92,  /// Light green.
+    lightyellow  = 93,  /// Light yellow.
+    lightblue    = 94,  /// Light blue.
+    lightmagenta = 95,  /// Light magenta.
+    lightcyan    = 96,  /// Light cyan.
+    white        = 97,  /// White.
+}
+
+
+// TerminalBackground
+/++
+    The basic 16+1 background colour codes of terminal colouring.
+ +/
+enum TerminalBackground
+{
+    default_     = 49,  /// Default background colour.
+    black        = 40,  /// Black.
+    red          = 41,  /// Red.
+    green        = 42,  /// Green.
+    yellow       = 43,  /// Yellow.
+    blue         = 44,  /// Blue.
+    magenta      = 45,  /// Magenta.
+    cyan         = 46,  /// Cyan.
+    lightgrey    = 47,  /// Light grey.
+    darkgrey     = 100, /// Dark grey.
+    lightred     = 101, /// Light red.
+    lightgreen   = 102, /// Light green.
+    lightyellow  = 103, /// Light yellow.
+    lightblue    = 104, /// Light blue.
+    lightmagenta = 105, /// Light magenta.
+    lightcyan    = 106, /// Light cyan.
+    white        = 107, /// White.
+}
+
+
+// TerminalReset
+/++
+    Terminal colour/format reset codes.
+ +/
+enum TerminalReset
+{
+    all         = 0,    /// Resets everything.
+    bright      = 21,   /// Resets "brighter" colours.
+    dim         = 22,   /// Resets "dim" colours.
+    underlined  = 24,   /// Resets underlined text.
+    blink       = 25,   /// Resets blinking text.
+    invert      = 27,   /// Resets inverted text.
+    hidden      = 28,   /// Resets hidden text.
+}
+
+
+// ANSICodeType
+/++
+    ANSI code type bitflag enum.
+ +/
+enum ANSICodeType
+{
+    unset      = 0,
+    foreground = 1 << 0,
+    background = 1 << 1,
+    format     = 1 << 2,
+    reset      = 1 << 3,
+}

--- a/source/kameloso/terminal/colours/defs.d
+++ b/source/kameloso/terminal/colours/defs.d
@@ -97,9 +97,9 @@ enum TerminalReset
  +/
 enum ANSICodeType
 {
-    unset      = 0,
-    foreground = 1 << 0,
-    background = 1 << 1,
-    format     = 1 << 2,
-    reset      = 1 << 3,
+    unset      = 0,       // init value.
+    foreground = 1 << 0,  // Foreground colour.
+    background = 1 << 1,  // Background colour.
+    format     = 1 << 2,  // Format token.
+    reset      = 1 << 3,  // Reset token.
 }

--- a/source/kameloso/terminal/colours/package.d
+++ b/source/kameloso/terminal/colours/package.d
@@ -941,7 +941,7 @@ in (word.length, "Tried to get colour by hash but no word was given")
         return colourTable;
     }();
 
-    const table = settings.extendedANSIColours ?
+    const table = settings.extendedColours ?
         settings.brightTerminal ?
             brightTableExtended[] :
             darkTableExtended []

--- a/source/kameloso/terminal/colours/package.d
+++ b/source/kameloso/terminal/colours/package.d
@@ -939,20 +939,24 @@ unittest
 {
     import std.conv : to;
 
+    CoreSettings brightSettings;
+    CoreSettings darkSettings;
+    brightSettings.brightTerminal = true;
+
     {
-        immutable hash = getColourByHash("kameloso", No.brightTerminal);
+        immutable hash = getColourByHash("kameloso", darkSettings);
         assert((hash == 227), hash.to!string);
     }
     {
-        immutable hash = getColourByHash("kameloso^", No.brightTerminal);
+        immutable hash = getColourByHash("kameloso^", darkSettings);
         assert((hash == 46), hash.to!string);
     }
     {
-        immutable hash = getColourByHash("zorael", No.brightTerminal);
+        immutable hash = getColourByHash("zorael", brightSettings);
         assert((hash == 35), hash.to!string);
     }
     {
-        immutable hash = getColourByHash("NO", No.brightTerminal);
+        immutable hash = getColourByHash("NO", brightSettings);
         assert((hash == 90), hash.to!string);
     }
 }
@@ -979,20 +983,24 @@ unittest
 {
     import std.conv : to;
 
+    CoreSettings brightSettings;
+    CoreSettings darkSettings;
+    brightSettings.brightTerminal = true;
+
     {
-        immutable coloured = "kameloso".colourByHash(No.brightTerminal);
+        immutable coloured = "kameloso".colourByHash(darkSettings);
         assert((coloured == "\033[38;5;227mkameloso\033[0m"), coloured);
     }
     {
-        immutable coloured = "kameloso".colourByHash(Yes.brightTerminal);
+        immutable coloured = "kameloso".colourByHash(brightSettings);
         assert((coloured == "\033[38;5;222mkameloso\033[0m"), coloured);
     }
     {
-        immutable coloured = "zorael".colourByHash(No.brightTerminal);
+        immutable coloured = "zorael".colourByHash(darkSettings);
         assert((coloured == "\033[35mzorael\033[0m"), coloured);
     }
     {
-        immutable coloured = "NO".colourByHash(No.brightTerminal);
+        immutable coloured = "NO".colourByHash(brightSettings);
         assert((coloured == "\033[90mNO\033[0m"), coloured);
     }
 }

--- a/source/kameloso/terminal/colours/package.d
+++ b/source/kameloso/terminal/colours/package.d
@@ -1,8 +1,8 @@
 /++
-    A collection of enums and functions that relate to a terminal shell.
+    A collection of functions that relate to applying ANSI effects to text.
 
-    This submodule has to do with terminal text colouring and its contents are
-    therefore version `Colours`.
+    This submodule has to do with terminal text colouring and is therefore
+    gated behind version `Colours`.
 
     Example:
     ---
@@ -10,25 +10,25 @@
 
     // Output range version
     sink.put("Hello ");
-    sink.colourWith(TerminalForeground.red);
+    sink.applyANSI(TerminalForeground.red);
     sink.put("world!");
-    sink.colourWith(TerminalForeground.default_);
+    sink.applyANSI(TerminalForeground.default_);
 
     with (TerminalForeground)
     {
         // Normal string-returning version
-        writeln("Hello ", red.colour, "world!", default_.colour);
+        writeln("Hello ", red.asANSI, "world!", default_.asANSI);
     }
 
     // Also accepts RGB form
     sink.put(" Also");
-    sink.truecolour(128, 128, 255);
+    sink.applyTruecolour(128, 128, 255);
     sink.put("magic");
-    sink.colourWith(TerminalForeground.default_);
+    sink.applyANSI(TerminalForeground.default_);
 
     with (TerminalForeground)
     {
-        writeln("Also ", truecolour(128, 128, 255), "magic", default_.colour);
+        writeln("Also ", asTruecolour(128, 128, 255), "magic", default_.colour);
     }
 
     immutable line = "Surrounding text kameloso surrounding text";
@@ -46,215 +46,195 @@
     of strings generated.
 
     See_Also:
+        [kameloso.terminal.colours.defs]
+
+        [kameloso.terminal.colours.tags]
+
         [kameloso.terminal]
  +/
-
 module kameloso.terminal.colours;
+
+version(Colours):
 
 private:
 
 import kameloso.terminal : TerminalToken;
-import std.meta : allSatisfy;
-import std.range.primitives : isOutputRange;
+import kameloso.terminal.colours.defs : ANSICodeType;
+import std.range : isOutputRange;
 import std.typecons : Flag, No, Yes;
 
 public:
 
-@safe:
 
+// applyANSI
 /++
-    Format codes that work like terminal colouring does, except here for formats
-    like bold, dim, italics, etc.
- +/
-enum TerminalFormat
-{
-    unset       = 0,  /// Seemingly resets to nothing.
-    bold        = 1,  /// Bold.
-    dim         = 2,  /// Dim, darkens it a bit.
-    italics     = 3,  /// Italics; usually has some other effect.
-    underlined  = 4,  /// Underlined.
-    blink       = 5,  /// Blinking text.
-    reverse     = 7,  /// Inverts text foreground and background.
-    hidden      = 8,  /// "Hidden" text.
-}
-
-/// Foreground colour codes for terminal colouring.
-enum TerminalForeground
-{
-    default_     = 39,  /// Default grey.
-    black        = 30,  /// Black.
-    red          = 31,  /// Red.
-    green        = 32,  /// Green.
-    yellow       = 33,  /// Yellow.
-    blue         = 34,  /// Blue.
-    magenta      = 35,  /// Magenta.
-    cyan         = 36,  /// Cyan.
-    lightgrey    = 37,  /// Light grey.
-    darkgrey     = 90,  /// Dark grey.
-    lightred     = 91,  /// Light red.
-    lightgreen   = 92,  /// Light green.
-    lightyellow  = 93,  /// Light yellow.
-    lightblue    = 94,  /// Light blue.
-    lightmagenta = 95,  /// Light magenta.
-    lightcyan    = 96,  /// Light cyan.
-    white        = 97,  /// White.
-}
-
-/// Background colour codes for terminal colouring.
-enum TerminalBackground
-{
-    default_     = 49,  /// Default background colour.
-    black        = 40,  /// Black.
-    red          = 41,  /// Red.
-    green        = 42,  /// Green.
-    yellow       = 43,  /// Yellow.
-    blue         = 44,  /// Blue.
-    magenta      = 45,  /// Magenta.
-    cyan         = 46,  /// Cyan.
-    lightgrey    = 47,  /// Light grey.
-    darkgrey     = 100, /// Dark grey.
-    lightred     = 101, /// Light red.
-    lightgreen   = 102, /// Light green.
-    lightyellow  = 103, /// Light yellow.
-    lightblue    = 104, /// Light blue.
-    lightmagenta = 105, /// Light magenta.
-    lightcyan    = 106, /// Light cyan.
-    white        = 107, /// White.
-}
-
-/// Terminal colour/format reset codes.
-enum TerminalReset
-{
-    all         = 0,    /// Resets everything.
-    bright      = 21,   /// Resets "brighter" colours.
-    dim         = 22,   /// Resets "dim" colours.
-    underlined  = 24,   /// Resets underlined text.
-    blink       = 25,   /// Resets blinking text.
-    invert      = 27,   /// Resets inverted text.
-    hidden      = 28,   /// Resets hidden text.
-}
-
-
-version(Colours):
-
-// isAColourCode
-/++
-    Bool of whether or not a type is a colour code enum.
- +/
-enum isAColourCode(T) =
-    is(T : TerminalForeground) ||
-    is(T : TerminalBackground) ||
-    is(T : TerminalFormat) ||
-    is(T : TerminalReset);/* ||
-    is(T == int);*/
-
-
-// colour
-/++
-    Takes a mix of a [TerminalForeground], a [TerminalBackground], a
-    [TerminalFormat] and/or a [TerminalReset] and composes them into a single
-    terminal format code token. Overload that creates an [std.array.Appender|Appender]
-    and fills it with the return value of the output range version of `colour`.
-
-    Example:
-    ---
-    string blinkOn = colour(TerminalForeground.white, TerminalBackground.yellow, TerminalFormat.blink);
-    string blinkOff = colour(TerminalForeground.default_, TerminalBackground.default_, TerminalReset.blink);
-    string blinkyName = blinkOn ~ "Foo" ~ blinkOff;
-    ---
+    Applies an ANSI code to a passed output range.
 
     Params:
-        codes = Variadic list of terminal format codes.
+        sink = Output range sink to write to.
+        code = ANSI code to apply.
+        overrideType = Force a specific [kameloso.terminal.colour.defs.ANSICodeType|ANSICodeType]
+            in cases where there is ambiguity.
+ +/
+void applyANSI(Sink)
+    (auto ref Sink sink,
+    const uint code,
+    const ANSICodeType overrideType = ANSICodeType.unset)
+if (isOutputRange!(Sink, char[]))
+{
+    import lu.conv : toAlphaInto;
+
+    void putBasic()
+    {
+        code.toAlphaInto(sink);
+    }
+
+    void putExtendedForegroundColour()
+    {
+        enum foregroundPrelude = "38;5;";
+        sink.put(foregroundPrelude);
+        code.toAlphaInto(sink);
+    }
+
+    void putExtendedBackgroundColour()
+    {
+        enum backgroundPrelude = "48;5;";
+        sink.put(backgroundPrelude);
+        code.toAlphaInto(sink);
+    }
+
+    sink.put(cast(char)TerminalToken.format);
+    sink.put('[');
+    scope(exit) sink.put('m');
+
+    with (ANSICodeType)
+    final switch (overrideType)
+    {
+    case foreground:
+        if (((code >= 30) && (code <= 39)) ||
+            ((code >= 90) && (code <= 97)))
+        {
+            // Basic foreground colour
+            return putBasic();
+        }
+        else
+        {
+            // Extended foreground colour
+            return putExtendedForegroundColour();
+        }
+
+    case background:
+        if (((code >= 40) && (code <= 49)) ||
+            ((code >= 100) && (code <= 107)))
+        {
+            // Basic background colour
+            return putBasic();
+        }
+        else
+        {
+            // Extended background colour
+            return putExtendedBackgroundColour();
+        }
+
+    case format:
+    case reset:
+        return putBasic();
+
+    case unset:
+        // Infer as best as possible
+        switch (code)
+        {
+        case 1:
+        ..
+        case 8:
+            // Format
+            goto case;
+
+        case 0:
+        case 21:
+        ..
+        case 28:
+            // Reset token
+            goto case;
+
+        case 40:
+        ..
+        case 49:
+        case 100:
+        ..
+        case 107:
+            // Background colour
+            //enum backgroundPrelude = "48;5;";
+            //sink.put(backgroundPrelude);
+            goto case;
+
+        case 30:
+        ..
+        case 39:
+        case 90:
+        ..
+        case 97:
+            // Basic foreground colour
+            return putBasic();
+
+        default:
+            // Extended foreground colour
+            return putExtendedForegroundColour();
+        }
+    }
+}
+
+
+// withANSI
+/++
+    Applies an ANSI code to a passed string and returns it as a new one.
+    Convenience function to colour a piece of text without being passed an
+    output sink to fill into.
+
+    Params:
+        text = Original string.
+        code = ANSI code.
+        overrideType = Force a specific [kameloso.terminal.colour.defs.ANSICodeType|ANSICodeType]
+            in cases where there is ambiguity.
 
     Returns:
-        A terminal code sequence of the passed codes.
+        A new string consisting of the passed `text` argument, but with the supplied
+        ANSI code applied.
  +/
-string colour(Codes...)(const Codes codes) pure nothrow
-if (Codes.length && allSatisfy!(isAColourCode, Codes))
+string withANSI(
+    const string text,
+    const uint code,
+    const ANSICodeType overrideType = ANSICodeType.unset) pure @safe nothrow
+{
+    import kameloso.terminal.colours.defs : TerminalReset;
+    import std.array : Appender;
+
+    Appender!(char[]) sink;
+    sink.reserve(text.length + 8);
+    sink.applyANSI(code, overrideType);
+    sink.put(text);
+    sink.applyANSI(TerminalReset.all);
+    return sink.data;
+}
+
+
+// asANSI
+/++
+    Returns an ANSI format sequence containing the passed code.
+
+    Params:
+        code = ANSI code.
+
+    Returns:
+        A string containing the passed ANSI `code` as an ANSI sequence.
+ +/
+string asANSI(const uint code) pure @safe nothrow
 {
     import std.array : Appender;
 
     Appender!(char[]) sink;
     sink.reserve(16);
-
-    sink.colourWith(codes);
-    return sink.data;
-}
-
-
-// colourWith
-/++
-    Takes a mix of a [TerminalForeground], a [TerminalBackground], a
-    [TerminalFormat] and/or a [TerminalReset] and composes them into a format code token.
-
-    This is the composing overload that fills its result into an output range.
-
-    Example:
-    ---
-    Appender!(char[]) sink;
-    sink.colourWith(TerminalForeground.red, TerminalFormat.bold);
-    sink.put("Foo");
-    sink.colourWith(TerminalForeground.default_, TerminalReset.bold);
-    ---
-
-    Params:
-        sink = Output range to write output to.
-        codes = Variadic list of terminal format codes.
- +/
-void colourWith(Sink, Codes...)(auto ref Sink sink, const Codes codes)
-if (isOutputRange!(Sink, char[]) && Codes.length && allSatisfy!(isAColourCode, Codes))
-{
-    /*sink.put(TerminalToken.format);
-    sink.put('[');*/
-
-    enum string prelude = TerminalToken.format ~ "[";
-    sink.put(prelude);
-
-    uint numCodes;
-
-    foreach (immutable code; codes)
-    {
-        import lu.conv : toAlphaInto;
-        import std.conv : to;
-
-        if (++numCodes > 1) sink.put(';');
-
-        //sink.put((cast(uint)code).to!string);
-        (cast(uint)code).toAlphaInto(sink);
-    }
-
-    sink.put('m');
-}
-
-
-// colour
-/++
-    Convenience function to colour or format a piece of text without an output
-    buffer to fill into.
-
-    Example:
-    ---
-    string foo = "Foo Bar".colour(TerminalForeground.bold, TerminalFormat.reverse);
-    ---
-
-    Params:
-        text = Text to format.
-        codes = Terminal formatting codes (colour, underscore, bold, ...) to apply.
-
-    Returns:
-        A terminal code sequence of the passed codes, encompassing the passed text.
- +/
-string colour(Codes...)(const string text, const Codes codes) pure nothrow
-if (Codes.length && allSatisfy!(isAColourCode, Codes))
-{
-    import std.array : Appender;
-
-    Appender!(char[]) sink;
-    sink.reserve(text.length + 15);
-
-    sink.colourWith(codes);
-    sink.put(text);
-    sink.colourWith(TerminalReset.all);
+    sink.applyANSI(code);
     return sink.data;
 }
 
@@ -280,7 +260,7 @@ if (Codes.length && allSatisfy!(isAColourCode, Codes))
         g = Reference to a green value.
         b = Reference to a blue value.
  +/
-private void normaliseColoursBright(ref uint r, ref uint g, ref uint b) pure nothrow @nogc
+private void normaliseColoursBright(ref uint r, ref uint g, ref uint b) pure @safe nothrow @nogc
 {
     enum pureWhiteReplacement = 120;
     enum pureWhiteRange = 200;
@@ -343,7 +323,7 @@ private void normaliseColoursBright(ref uint r, ref uint g, ref uint b) pure not
         g = Reference to a green value.
         b = Reference to a blue value.
  +/
-private void normaliseColours(ref uint r, ref uint g, ref uint b) pure nothrow @nogc
+private void normaliseColours(ref uint r, ref uint g, ref uint b) pure @safe nothrow @nogc
 {
     enum pureBlackReplacement = 120;
 
@@ -476,19 +456,19 @@ unittest
 }
 
 
-// truecolour
+// applyTruecolour
 /++
     Produces a terminal colour token for the colour passed, expressed in terms
-    of red, green and blue.
+    of red, green and blue, then writes it to the passed output range.
 
     Example:
     ---
     Appender!(char[]) sink;
     int r, g, b;
     numFromHex("3C507D", r, g, b);
-    sink.truecolour(r, g, b);
+    sink.applyTruecolour(r, g, b);
     sink.put("Foo");
-    sink.colourWith(TerminalReset.all);
+    sink.applyANSI(TerminalReset.all);
     writeln(sink);  // "Foo" in #3C507D
     ---
 
@@ -501,7 +481,7 @@ unittest
         normalise = Whether or not to normalise colours so that they aren't too
             dark or too bright.
  +/
-void truecolour(Sink)
+void applyTruecolour(Sink)
     (auto ref Sink sink,
     uint r,
     uint g,
@@ -540,18 +520,19 @@ if (isOutputRange!(Sink, char[]))
 }
 
 
-// truecolour
+// asTruecolour
 /++
-    Convenience function to colour a piece of text without being passed an
-    output sink to fill into.
+    Produces a terminal colour token for the colour passed, expressed in terms
+    of red, green and blue. Convenience function to colour a piece of text
+    without being passed an output sink to fill into.
 
     Example:
     ---
-    string foo = "Foo Bar".truecolour(172, 172, 255);
+    string foo = "Foo Bar".asTruecolour(172, 172, 255);
 
     int r, g, b;
     numFromHex("003388", r, g, b);
-    string bar = "Bar Foo".truecolour(r, g, b);
+    string bar = "Bar Foo".asTruecolour(r, g, b);
     ---
 
     Params:
@@ -566,14 +547,15 @@ if (isOutputRange!(Sink, char[]))
     Returns:
         The passed string word encompassed by terminal colour tags.
  +/
-string truecolour(
+string asTruecolour(
     const string word,
     const uint r,
     const uint g,
     const uint b,
     const Flag!"brightTerminal" bright = No.brightTerminal,
-    const Flag!"normalise" normalise = Yes.normalise) pure
+    const Flag!"normalise" normalise = Yes.normalise) pure @safe
 {
+    import kameloso.terminal.colours.defs : TerminalReset;
     import std.array : Appender;
 
     Appender!(char[]) sink;
@@ -581,9 +563,9 @@ string truecolour(
     // \033[48 for background
     sink.reserve(word.length + 23);
 
-    sink.truecolour(r, g, b, bright, normalise);
+    sink.applyTruecolour(r, g, b, bright, normalise);
     sink.put(word);
-    sink.colourWith(TerminalReset.all);
+    sink.applyANSI(TerminalReset.all);
     return sink.data;
 }
 
@@ -592,7 +574,7 @@ unittest
 {
     import std.format : format;
 
-    immutable name = "blarbhl".truecolour(255, 255, 255, No.brightTerminal, No.normalise);
+    immutable name = "blarbhl".asTruecolour(255, 255, 255, No.brightTerminal, No.normalise);
     immutable alsoName = "%c[38;2;%d;%d;%dm%s%c[0m"
         .format(cast(char)TerminalToken.format, 255, 255, 255,
            "blarbhl", cast(char)TerminalToken.format);
@@ -625,8 +607,9 @@ unittest
 string invert(
     const string line,
     const string toInvert,
-    const Flag!"caseSensitive" caseSensitive = Yes.caseSensitive) pure
+    const Flag!"caseSensitive" caseSensitive = Yes.caseSensitive) pure @safe
 {
+    import kameloso.terminal.colours.defs : TerminalFormat, TerminalReset;
     import dialect.common : isValidNicknameCharacter;
     import std.array : Appender;
     import std.format : format;
@@ -649,8 +632,12 @@ string invert(
     if (startpos == -1) return line;
 
     enum pattern = "%c[%dm%s%c[%dm";
-    immutable inverted = format(pattern, TerminalToken.format, TerminalFormat.reverse,
-        toInvert, TerminalToken.format, TerminalReset.invert);
+    immutable inverted = pattern.format(
+        TerminalToken.format,
+        TerminalFormat.reverse,
+        toInvert,
+        TerminalToken.format,
+        TerminalReset.invert);
 
     Appender!(char[]) sink;
     sink.reserve(line.length + 16);
@@ -706,6 +693,7 @@ string invert(
 ///
 unittest
 {
+    import kameloso.terminal.colours.defs : TerminalFormat, TerminalReset;
     import std.format : format;
 
     immutable pre = "%c[%dm".format(TerminalToken.format, TerminalFormat.reverse);
@@ -864,57 +852,8 @@ unittest
 
 // getColourByHash
 /++
-    Hashes the passed string and picks a [TerminalForeground] colour by modulo.
-    Overload that takes an array of [TerminalForeground]s, to pick between.
+    Hashes the passed string and picks an ANSI colour by modulo.
 
-    Params:
-        word = String to hash and base colour on.
-        fgArray = Array of [TerminalForeground]s to pick a colour from.
-
-    Returns:
-        A [TerminalForeground] based on the passed string, picked from the
-            passed `fgArray` array.
- +/
-auto getColourByHash(const string word, const TerminalForeground[] fgArray) pure @nogc nothrow
-in (word.length, "Tried to get colour by hash but no word was given")
-in (fgArray.length, "Tried to get colour by hash but with an empty colour array")
-{
-    size_t colourIndex = hashOf(word) % fgArray.length;
-    return fgArray[colourIndex];
-}
-
-///
-unittest
-{
-    import lu.conv : Enum;
-
-    alias FG = TerminalForeground;
-
-    TerminalForeground[3] fgArray =
-    [
-        FG.red,
-        FG.green,
-        FG.blue,
-    ];
-
-    {
-        immutable foreground = "kameloso".getColourByHash(fgArray[]);
-        assert((foreground == FG.blue), Enum!FG.toString(foreground));
-    }
-    {
-        immutable foreground = "zorael".getColourByHash(fgArray[]);
-        assert((foreground == FG.green), Enum!FG.toString(foreground));
-    }
-    {
-        immutable foreground = "hirrsteff".getColourByHash(fgArray[]);
-        assert((foreground == FG.red), Enum!FG.toString(foreground));
-    }
-}
-
-
-// getColourByHash
-/++
-    Hashes the passed string and picks a [TerminalForeground] colour by modulo.
     Overload that picks any colour, taking care not to pick black or white based on
     the value of the passed `bright` bool (which signifies a bright terminal background).
 
@@ -932,44 +871,71 @@ unittest
     Returns:
         A [TerminalForeground] based on the passed string.
  +/
-auto getColourByHash(const string word, const Flag!"brightTerminal" bright) pure @nogc nothrow
+auto getColourByHash(const string word, const Flag!"brightTerminal" bright) pure @safe /*@nogc*/ nothrow
 in (word.length, "Tried to get colour by hash but no word was given")
 {
-    import std.traits : EnumMembers;
+    import kameloso.irccolours : ircANSIColourMap;
+    import kameloso.terminal.colours.defs : TerminalForeground;
 
-    alias foregroundMembers = EnumMembers!TerminalForeground;
+    enum brightTable = ()
+    {
+        uint[98] colourTable = ircANSIColourMap[1..$].dup;
 
-    static immutable TerminalForeground[foregroundMembers.length+(-2)] fgBright =
-        TerminalForeground.black ~ [ foregroundMembers ][2..$-1];
+        // Tweak colours, darken some very bright ones
+        colourTable[0] = TerminalForeground.black;
+        colourTable[11] = TerminalForeground.yellow;
+        colourTable[53] = 224;
+        colourTable[65] = 222;
+        colourTable[77] = 223;
+        colourTable[78] = 190;
 
-    static immutable TerminalForeground[foregroundMembers.length+(-2)] fgDark =
-        TerminalForeground.white ~ [ foregroundMembers ][2..$-1];
+        return colourTable;
+    }();
 
-    return bright ? word.getColourByHash(fgBright[]) : word.getColourByHash(fgDark[]);
+    enum darkTable = ()
+    {
+        uint[98] colourTable = ircANSIColourMap[1..$].dup;
+
+        // Tweak colours, brighten some very dark ones
+        colourTable[15] = 55;
+        colourTable[23] = 20;
+        colourTable[24] = 56;
+        colourTable[25] = 57;
+        colourTable[35] = 21;
+        colourTable[33] = 243;
+        colourTable[87] = 241;
+        colourTable[88] = 242;
+        colourTable[89] = 243;
+        colourTable[90] = 243;
+        colourTable[97] = 240;
+        return colourTable;
+    }();
+
+    const table = bright ? brightTable[] : darkTable[];
+    immutable colourIndex = (hashOf(word) % table.length);
+    return table[colourIndex];
 }
 
 ///
 unittest
 {
-    import lu.conv : Enum;
-
-    alias FG = TerminalForeground;
+    import std.conv : to;
 
     {
         immutable hash = getColourByHash("kameloso", No.brightTerminal);
-        assert((hash == FG.lightyellow), Enum!FG.toString(hash));
+        assert((hash == 227), hash.to!string);
     }
     {
         immutable hash = getColourByHash("kameloso^", No.brightTerminal);
-        assert((hash == FG.green), Enum!FG.toString(hash));
+        assert((hash == 46), hash.to!string);
     }
     {
         immutable hash = getColourByHash("zorael", No.brightTerminal);
-        assert((hash == FG.lightgrey), Enum!FG.toString(hash));
+        assert((hash == 35), hash.to!string);
     }
     {
         immutable hash = getColourByHash("NO", No.brightTerminal);
-        assert((hash == FG.lightred), Enum!FG.toString(hash));
+        assert((hash == 90), hash.to!string);
     }
 }
 
@@ -985,9 +951,9 @@ unittest
     Returns:
         `word`, now in colour based on the hash of its contents.
  +/
-auto colourByHash(const string word, const Flag!"brightTerminal" bright) pure nothrow
+auto colourByHash(const string word, const Flag!"brightTerminal" bright) pure @safe nothrow
 {
-    return word.colour(getColourByHash(word, bright));
+    return word.withANSI(getColourByHash(word, bright));
 }
 
 ///
@@ -997,22 +963,18 @@ unittest
 
     {
         immutable coloured = "kameloso".colourByHash(No.brightTerminal);
-        assert((coloured == "\033[93mkameloso\033[0m"),
-            "kameloso".getColourByHash(No.brightTerminal).to!string);
+        assert((coloured == "\033[38;5;227mkameloso\033[0m"), coloured);
     }
     {
         immutable coloured = "kameloso".colourByHash(Yes.brightTerminal);
-        assert((coloured == "\033[93mkameloso\033[0m"),
-            "kameloso".getColourByHash(Yes.brightTerminal).to!string);
+        assert((coloured == "\033[38;5;222mkameloso\033[0m"), coloured);
     }
     {
         immutable coloured = "zorael".colourByHash(No.brightTerminal);
-        assert((coloured == "\033[37mzorael\033[0m"),
-            "zorael".getColourByHash(No.brightTerminal).to!string);
+        assert((coloured == "\033[35mzorael\033[0m"), coloured);
     }
     {
         immutable coloured = "NO".colourByHash(No.brightTerminal);
-        assert((coloured == "\033[91mNO\033[0m"),
-            "NO".getColourByHash(No.brightTerminal).to!string);
+        assert((coloured == "\033[90mNO\033[0m"), coloured);
     }
 }

--- a/source/kameloso/terminal/colours/package.d
+++ b/source/kameloso/terminal/colours/package.d
@@ -18,7 +18,7 @@
     {
         // Normal string-returning versions
         writeln("Hello ", red.asANSI, "world!", default_.asANSI);
-        writeln("H3LL0".withANSI(red)), ' ', "W0RLD!".withANSI(default_));
+        writeln("H3LL0".withANSI(red), ' ', "W0RLD!".withANSI(default_));
     }
 
     // Also accepts RGB form
@@ -209,7 +209,7 @@ if (isOutputRange!(Sink, char[]))
     {
         // Normal string-returning versions
         writeln("Hello ", red.asANSI, "world!", default_.asANSI);
-        writeln("H3LL0".withANSI(red)), ' ', "W0RLD!".withANSI(default_));
+        writeln("H3LL0".withANSI(red), ' ', "W0RLD!".withANSI(default_));
     }
     ---
 

--- a/source/kameloso/terminal/colours/tags.d
+++ b/source/kameloso/terminal/colours/tags.d
@@ -484,18 +484,24 @@ unittest
     version(Colours)
     {
         import kameloso.terminal.colours : colourByHash;
+        import kameloso.pods : CoreSettings;
+
+        CoreSettings brightSettings;
+        CoreSettings darkSettings;
+        brightSettings.brightTerminal = true;
 
         {
             immutable line = "hello<h>kameloso</>hello";
             immutable replaced = line.expandTags(LogLevel.off, No.strip);
-            immutable expected = text("hello", colourByHash("kameloso", No.brightTerminal), logger.offtint, "hello");
+            immutable expected = text("hello", colourByHash("kameloso",
+                darkSettings), logger.offtint, "hello");
             assert((replaced == expected), replaced);
         }
         {
             immutable line = `hello\<harbl>kameloso<h>hello</>hi`;
             immutable replaced = line.expandTags(LogLevel.off, No.strip);
             immutable expected = text("hello<harbl>kameloso", colourByHash("hello",
-                No.brightTerminal), logger.offtint, "hi");
+                darkSettings), logger.offtint, "hi");
             assert((replaced == expected), replaced);
         }
         {
@@ -514,7 +520,7 @@ unittest
             immutable line = "Added <h>hirrsteff</> as a blacklisted user in #garderoben";
             immutable replaced = line.expandTags(LogLevel.off, No.strip);
             immutable expected = "Added " ~
-                colourByHash("hirrsteff", No.brightTerminal) ~
+                colourByHash("hirrsteff", brightSettings) ~
                 logger.offtint ~ " as a blacklisted user in #garderoben";
             assert((replaced == expected), replaced);
         }

--- a/source/kameloso/terminal/colours/tags.d
+++ b/source/kameloso/terminal/colours/tags.d
@@ -287,9 +287,7 @@ if (isSomeString!T)
                                 {
                                     import kameloso.terminal.colours : colourByHash;
 
-                                    immutable bright =
-                                        cast(Flag!"brightTerminal")kameloso.common.settings.brightTerminal;
-                                    sink.put(colourByHash(word, bright));
+                                    sink.put(colourByHash(word, *kameloso.common.settings));
 
                                     with (LogLevel)
                                     final switch (baseLevel)


### PR DESCRIPTION
This aims to solve issue #162 by mapping IRC colour values 16 and above to terminal ANSI colouring as recommended over at [ircdocs](https://modern.ircdocs.horse/formatting.html#colors-16-98).