### PR TITLE
Windows `execvp`

### DIFF
--- a/source/kameloso/kameloso.d
+++ b/source/kameloso/kameloso.d
@@ -803,13 +803,4 @@ public:
         Set when the user explicitly asked to re-exec in the middle of a session.
      +/
     bool askedToReexec;
-
-    version(Windows)
-    {
-        // reexecWithPowershell
-        /++
-            Re-execs with Powershell instead of with `cmd.exe`.
-         +/
-        bool reexecWithPowershell = true;
-    }
 }

--- a/source/kameloso/main.d
+++ b/source/kameloso/main.d
@@ -3032,19 +3032,7 @@ void startBot(ref Kameloso instance, ref AttemptState attempt)
                     writeln();
                 }
 
-                version(Posix)
-                {
-                    execvp(instance.args);
-                }
-                else version(Windows)
-                {
-                    execvp(instance.args, instance.settings.reexecWithPowershell);
-                }
-                else
-                {
-                    static assert(0, "Unsupported platform, please file a bug.");
-                }
-
+                execvp(instance.args);
                 instance.askedToReexec = false;  // In case of failure
             }
 

--- a/source/kameloso/main.d
+++ b/source/kameloso/main.d
@@ -3018,6 +3018,8 @@ void startBot(ref Kameloso instance, ref AttemptState attempt)
             {
                 if ((!lastConnectAttemptFizzled && instance.settings.reexecToReconnect) || instance.askedToReexec)
                 {
+                    import kameloso.platform : execvp;
+
                     if (!instance.settings.headless)
                     {
                         import std.stdio : writeln;
@@ -3041,7 +3043,7 @@ void startBot(ref Kameloso instance, ref AttemptState attempt)
                         writeln();
                     }
 
-                    instance.execvp();
+                    execvp(instance.args);
                     instance.askedToReexec = false;  // In case of failure
                 }
             }

--- a/source/kameloso/main.d
+++ b/source/kameloso/main.d
@@ -3043,7 +3043,19 @@ void startBot(ref Kameloso instance, ref AttemptState attempt)
                         writeln();
                     }
 
-                    execvp(instance.args);
+                    version(Posix)
+                    {
+                        execvp(instance.args);
+                    }
+                    else version(Windows)
+                    {
+                        execvp(instance.args, settings.reexecWithPowershell);
+                    }
+                    else
+                    {
+                        static assert(0, "Unsupported platform, please file a bug.");
+                    }
+
                     instance.askedToReexec = false;  // In case of failure
                 }
             }

--- a/source/kameloso/platform.d
+++ b/source/kameloso/platform.d
@@ -303,3 +303,127 @@ auto openInBrowser(const string url)
         static assert(0, "Unsupported platform, please file a bug.");
     }
 }
+
+
+// execvp
+/++
+    Re-executes the program.
+
+    Filters out any captive `--set twitch.*` keygen settings from the
+    arguments originally passed to the program, then calls
+    [std.process.execvp|execvp].
+
+    On Windows, the behaviour is faked using [std.process.spawnProcess|spawnProcess].
+ +/
+void execvp(/*const*/ string[] args) @system
+{
+    import kameloso.common : logger;
+
+    if (args.length > 1)
+    {
+        size_t[] toRemove;
+
+        for (size_t i; i<args.length; ++i)
+        {
+            import lu.string : beginsWith, nom;
+            import std.algorithm.comparison : among;
+
+            if (i == 0) continue;
+
+            if (args[i] == "--set")
+            {
+                if (args.length <= i+1) continue;  // should never happen
+
+                string fullSetting = args[i+1];  // mutable
+
+                if (fullSetting.beginsWith("twitch."))
+                {
+                    import std.typecons : Flag, No, Yes;
+
+                    immutable setting = fullSetting.nom!(Yes.inherit)('=');
+
+                    if (setting.among!(
+                        "twitch.keygen",
+                        "twitch.superKeygen",
+                        "twitch.googleKeygen",
+                        "twitch.spotifyKeygen"))
+                    {
+                        toRemove ~= i;
+                        toRemove ~= i+1;
+                        ++i;  // Skip next entry
+                    }
+                }
+            }
+            else if (args[i] == "--setup-twitch")
+            {
+                toRemove ~= i;
+            }
+            else
+            {
+                version(Windows)
+                {
+                    if (args[i].among!(
+                    "--setup-twitch",
+                    "--get-cacert",
+                    "--get-openssl"))
+                    {
+                        toRemove ~= i;
+                    }
+                }
+            }
+        }
+
+        foreach_reverse (immutable i; toRemove)
+        {
+            import std.algorithm.mutation : SwapStrategy, remove;
+            args = args.remove!(SwapStrategy.stable)(i);
+        }
+    }
+
+    version(Posix)
+    {
+        import std.process : execvp;
+
+        immutable result = execvp(args[0], args);
+
+        // If we're here, the call failed
+        enum pattern = "Failed to <l>execvp</> with an error value of <l>%d</>.";
+        logger.errorf(pattern, result);
+    }
+    else version(Windows)
+    {
+        import std.process : ProcessException, spawnProcess;
+
+        immutable shell = this.reexecWithPowershell ?
+            [ "powershell.exe" ] :
+            [ "cmd.exe", "/c" ];
+
+        immutable commandLine =
+        [
+            "cmd.exe",
+            "/c",
+            "start",
+            "/min",
+        ] ~ shell ~ args[0] ~ args;
+
+        try
+        {
+            import core.stdc.stdlib : exit;
+
+            spawnProcess(commandLine);
+
+            // If we're here, the call succeeded
+            //resetConsoleModeAndCodepage(); // Don't, it will be called via atexit
+            exit(0);
+        }
+        catch (ProcessException e)
+        {
+            enum pattern = "Failed to spawn a new process: <t>%s</>.";
+            logger.errorf(pattern, e.msg);
+        }
+    }
+    else
+    {
+        static assert(0, "Unsupported platform, please file a bug.");
+    }
+}

--- a/source/kameloso/platform.d
+++ b/source/kameloso/platform.d
@@ -402,7 +402,7 @@ void execvp(
         import std.process : ProcessException, spawnProcess;
 
         immutable shell = reexecWithPowershell ?
-            [ "powershell.exe" ] :
+            [ "powershell", "-c" ] :
             [ "cmd.exe", "/c" ];
 
         const commandLine =

--- a/source/kameloso/platform.d
+++ b/source/kameloso/platform.d
@@ -314,8 +314,15 @@ auto openInBrowser(const string url)
     [std.process.execvp|execvp].
 
     On Windows, the behaviour is faked using [std.process.spawnProcess|spawnProcess].
+
+    Params:
+        args = Arguments passed to the program.
+        reexecWithPowershell = (Windows) Re-execute the program with Powershell
+            used as shell, as opposed to the conventional `cmd.exe`.
  +/
-void execvp(/*const*/ string[] args) @system
+void execvp(
+    /*const*/ string[] args,
+    const bool reexecWithPowershell = bool.init) @system
 {
     import kameloso.common : logger;
 
@@ -394,7 +401,7 @@ void execvp(/*const*/ string[] args) @system
     {
         import std.process : ProcessException, spawnProcess;
 
-        immutable shell = this.reexecWithPowershell ?
+        immutable shell = reexecWithPowershell ?
             [ "powershell.exe" ] :
             [ "cmd.exe", "/c" ];
 

--- a/source/kameloso/platform.d
+++ b/source/kameloso/platform.d
@@ -417,9 +417,12 @@ void execvp(
         {
             import core.stdc.stdlib : exit;
 
-            spawnProcess(commandLine);
+            auto pid = spawnProcess(commandLine);
 
             // If we're here, the call succeeded
+            enum pattern = "Forked into PID <l>%d</>.";
+            logger.infof(pattern, pid.processID);
+
             //resetConsoleModeAndCodepage(); // Don't, it will be called via atexit
             exit(0);
         }

--- a/source/kameloso/platform.d
+++ b/source/kameloso/platform.d
@@ -405,7 +405,7 @@ void execvp(
             [ "powershell.exe" ] :
             [ "cmd.exe", "/c" ];
 
-        immutable commandLine =
+        const commandLine =
         [
             "cmd.exe",
             "/c",

--- a/source/kameloso/plugins/admin/base.d
+++ b/source/kameloso/plugins/admin/base.d
@@ -1468,13 +1468,10 @@ void onBusMessage(
             return;
     }
 
-    version(Posix)
-    {
-        case "reexec":
-            import kameloso.thread : ThreadMessage, boxed;
-            import std.concurrency : prioritySend;
-            return plugin.state.mainThread.prioritySend(ThreadMessage.reconnect(string.init, boxed(true)));
-    }
+    case "reexec":
+        import kameloso.thread : ThreadMessage, boxed;
+        import std.concurrency : prioritySend;
+        return plugin.state.mainThread.prioritySend(ThreadMessage.reconnect(string.init, boxed(true)));
 
     case "set":
         import kameloso.constants : BufferSize;

--- a/source/kameloso/pods.d
+++ b/source/kameloso/pods.d
@@ -164,15 +164,6 @@ public:
             Re-executes the program instead of reconnecting hot.
          +/
         bool reexecToReconnect = false;
-
-        version(Windows)
-        {
-            // reexecWithPowershell
-            /++
-                Re-executes with Powershell instead of with `cmd.exe`.
-             +/
-            bool reexecWithPowershell = true;
-        }
     }
 }
 

--- a/source/kameloso/pods.d
+++ b/source/kameloso/pods.d
@@ -159,13 +159,19 @@ public:
          +/
         bool observerMode;
 
-        version(Posix)
+        // reexecToReconnect
+        /++
+            Re-executes the program instead of reconnecting hot.
+         +/
+        bool reexecToReconnect = false;
+
+        version(Windows)
         {
-            // reexecToReconnect
+            // reexecWithPowershell
             /++
-                Re-executes the program instead of reconnecting hot.
+                Re-executes with Powershell instead of with `cmd.exe`.
              +/
-            bool reexecToReconnect = false;
+            bool reexecWithPowershell = true;
         }
     }
 }


### PR DESCRIPTION
This implements re-execution on reconnects on Windows.

Windows has no `execvp`, so we fake the behaviour by spawning a new process in a minimised `cmd.exe`/Powershell console. It's better than nothing.