### PR TITLE
Implicit Fibers for generated wrappers of select top-level functions

### DIFF
--- a/source/kameloso/plugins/admin/base.d
+++ b/source/kameloso/plugins/admin/base.d
@@ -444,13 +444,11 @@ in (Fiber.getThis, "Tried to call `addChannel` from outside a Fiber")
 in (rawChannel.length, "Tried to add a home but the channel string was empty")
 {
     import kameloso.plugins.common.delayawait : await, unawait;
-    import kameloso.constants : BufferSize;
     import kameloso.thread : CarryingFiber;
     import dialect.common : isValidChannel;
     import lu.string : stripped;
     import std.algorithm.searching : canFind, countUntil;
     import std.uni : toLower;
-    import core.thread : Fiber;
 
     void sendWeAreAlreadyInChannel()
     {
@@ -993,7 +991,6 @@ void onCommandSet(AdminPlugin plugin, const /*ref*/ IRCEvent event)
 {
     import kameloso.thread : CarryingFiber;
     import std.typecons : Tuple;
-    import core.thread : Fiber;
 
     alias Payload = Tuple!(bool);
 
@@ -1039,7 +1036,6 @@ void onCommandGet(AdminPlugin plugin, const /*ref*/ IRCEvent event)
 {
     import kameloso.thread : CarryingFiber;
     import std.typecons : Tuple;
-    import core.thread : Fiber;
 
     alias Payload = Tuple!(string, string, string);
 
@@ -1249,9 +1245,7 @@ void cycle(
 in (Fiber.getThis, "Tried to call `cycle` from outside a Fiber")
 {
     import kameloso.plugins.common.delayawait : await, delay, unawait;
-    import kameloso.constants : BufferSize;
     import kameloso.thread : CarryingFiber;
-    import core.thread : Fiber;
 
     part(plugin.state, channelName, "Cycling");
 
@@ -1632,10 +1626,8 @@ void onBusMessage(
         return plugin.state.mainThread.prioritySend(ThreadMessage.reconnect(string.init, boxed(true)));
 
     case "set":
-        import kameloso.constants : BufferSize;
         import kameloso.thread : CarryingFiber;
         import std.typecons : Tuple;
-        import core.thread : Fiber;
 
         alias Payload = Tuple!(bool);
 

--- a/source/kameloso/plugins/chatbot.d
+++ b/source/kameloso/plugins/chatbot.d
@@ -86,12 +86,16 @@ void onCommandSay(ChatbotPlugin plugin, const ref IRCEvent event)
 /++
     Does the bash.org dance emotes.
 
+    This will be called on each channel message, so don't annotate it `.fiber(true)`
+    and instead create a Fiber manually iff we should actually go ahead and dance.
+
     See_Also: http://bash.org/?4281
  +/
 @(IRCEventHandler()
     .onEvent(IRCEvent.Type.CHAN)
     .permissionsRequired(Permissions.anyone)
     .channelPolicy(ChannelPolicy.home)
+    //.fiber(true)
 )
 void onDance(ChatbotPlugin plugin, const /*ref*/ IRCEvent event)
 {

--- a/source/kameloso/plugins/common/core.d
+++ b/source/kameloso/plugins/common/core.d
@@ -1712,9 +1712,9 @@ mixin template IRCPluginImpl(
                     import kameloso.constants : BufferSize;
                     import core.thread : Fiber;
 
-                    auto ` ~ funName ~ `Dg()
+                    void ` ~ funName ~ `Dg()
                     {
-                        return .` ~ funName ~ `(this);
+                        .` ~ funName ~ `(this);
                     }
 
                     auto ` ~ funName ~ `Fiber = new Fiber(&` ~ funName ~ `Dg, BufferSize.fiberStack);

--- a/source/kameloso/plugins/common/core.d
+++ b/source/kameloso/plugins/common/core.d
@@ -1709,7 +1709,16 @@ mixin template IRCPluginImpl(
                     is(typeof(.` ~ funName ~ `) == function) &&
                     TakesParams!(.` ~ funName ~ `, typeof(this)))
                 {
-                    .` ~ funName ~ `(this);
+                    import kameloso.constants : BufferSize;
+                    import core.thread : Fiber;
+
+                    auto ` ~ funName ~ `Dg()
+                    {
+                        return .` ~ funName ~ `(this);
+                    }
+
+                    auto ` ~ funName ~ `Fiber = new Fiber(&` ~ funName ~ `Dg, BufferSize.fiberStack);
+                    ` ~ funName ~ `Fiber.call();
                 }
                 else
                 {

--- a/source/kameloso/plugins/counter.d
+++ b/source/kameloso/plugins/counter.d
@@ -207,7 +207,6 @@ public:
 )
 void onCommandCounter(CounterPlugin plugin, const /*ref*/ IRCEvent event)
 {
-    import kameloso.constants : BufferSize;
     import lu.string : advancePast, stripped, strippedLeft;
     import std.algorithm.comparison : among;
     import std.algorithm.searching : canFind;
@@ -301,7 +300,6 @@ void onCommandCounter(CounterPlugin plugin, const /*ref*/ IRCEvent event)
     switch (verb)
     {
     case "add":
-        import kameloso.constants : BufferSize;
         import kameloso.thread : CarryingFiber;
         import std.typecons : Tuple;
         import core.thread : Fiber;

--- a/source/kameloso/plugins/help.d
+++ b/source/kameloso/plugins/help.d
@@ -84,7 +84,6 @@ import std.typecons : Flag, No, Yes;
 )
 void onCommandHelp(HelpPlugin plugin, const /*ref*/ IRCEvent event)
 {
-    import kameloso.constants : BufferSize;
     import kameloso.thread : CarryingFiber;
     import std.typecons : Tuple;
     import core.thread : Fiber;

--- a/source/kameloso/plugins/oneliner.d
+++ b/source/kameloso/plugins/oneliner.d
@@ -410,7 +410,6 @@ void handleNewOneliner(
     const /*ref*/ IRCEvent event,
     /*const*/ string slice)
 {
-    import kameloso.constants : BufferSize;
     import kameloso.thread : CarryingFiber;
     import lu.string : SplitResults, splitInto;
     import std.format : format;

--- a/source/kameloso/plugins/poll.d
+++ b/source/kameloso/plugins/poll.d
@@ -143,7 +143,6 @@ public:
     static auto fromJSON(const JSONValue json)
     {
         import core.memory : GC;
-        import core.time : seconds;
 
         GC.disable();
         scope(exit) GC.enable();

--- a/source/kameloso/plugins/services/chanquery.d
+++ b/source/kameloso/plugins/services/chanquery.d
@@ -136,8 +136,8 @@ void startChannelQueries(ChanQueryService service)
         {
             import std.conv : text;
 
-            await(service, types, No.yield);
             scope(exit) unawait(service, types);
+            await(service, types, No.yield);
 
             version(WithPrinterPlugin)
             {
@@ -158,13 +158,13 @@ void startChannelQueries(ChanQueryService service)
         /++
             Event types that signal the end of a query response.
          +/
-        static immutable topicTypes =
+        static immutable IRCEvent.Type[2] topicTypes =
         [
             IRCEvent.Type.RPL_TOPIC,
             IRCEvent.Type.RPL_NOTOPIC,
         ];
 
-        queryAwaitAndUnlist("TOPIC", topicTypes);
+        queryAwaitAndUnlist("TOPIC", topicTypes[]);
         if (channelName !in service.channelStates) continue chanloop;
         queryAwaitAndUnlist("WHO", IRCEvent.Type.RPL_ENDOFWHO);
         if (channelName !in service.channelStates) continue chanloop;
@@ -251,7 +251,7 @@ void startChannelQueries(ChanQueryService service)
 
     scope(exit)
     {
-        unawait(service, whoisTypes);
+        unawait(service, whoisTypes[]);
 
         version(WithPrinterPlugin)
         {

--- a/source/kameloso/plugins/services/connect.d
+++ b/source/kameloso/plugins/services/connect.d
@@ -1455,7 +1455,6 @@ void startPingMonitor(ConnectService service)
 in (Fiber.getThis, "Tried to call `startPingMonitor` from outside a Fiber")
 {
     import kameloso.plugins.common.delayawait : await, delay, unawait, undelay;
-    import kameloso.constants : BufferSize;
     import kameloso.thread : CarryingFiber;
     import core.time : seconds;
 

--- a/source/kameloso/plugins/services/persistence.d
+++ b/source/kameloso/plugins/services/persistence.d
@@ -242,9 +242,8 @@ void postprocessCommon(PersistenceService service, ref IRCEvent event)
                     if (stored && stored.account.length && (user.account == "*"))
                     {
                         event.aux[0] = stored.account;
-                        goto case RPL_WHOISACCOUNT;
                     }
-                    break;
+                    goto case RPL_WHOISACCOUNT;
 
                 default:
                     if ((user.account.length && (user.account != "*")) ||

--- a/source/kameloso/plugins/timer.d
+++ b/source/kameloso/plugins/timer.d
@@ -966,76 +966,73 @@ void onAnyMessage(TimerPlugin plugin, const ref IRCEvent event)
 
 // onWelcome
 /++
-    Loads timers from disk. Additionally sets up a [core.thread.fiber.Fiber|Fiber]
-    to periodically call timer [core.thread.fiber.Fiber|Fiber]s with a periodicity
-    of [TimerPlugin.timerPeriodicity].
+    Loads timers from disk.
 
-    Don't call `reload` for this! It undoes anything `handleSelfjoin` may have done.
+    Additionally loops to periodically call timer [core.thread.fiber.Fiber|Fiber]s
+    with a periodicity of [TimerPlugin.timerPeriodicity].
+
+    Don't call [reload] for this! It undoes anything [handleSelfjoin] may have done.
  +/
 @(IRCEventHandler()
     .onEvent(IRCEvent.Type.RPL_WELCOME)
+    .fiber(true)
 )
 void onWelcome(TimerPlugin plugin)
 {
     import kameloso.plugins.common.delayawait : delay;
-    import kameloso.constants : BufferSize;
     import core.thread : Fiber;
 
     loadTimers(plugin);
 
-    void fiberTriggerDg()
+    // Delay once before entering loop
+    delay(plugin, plugin.timerPeriodicity, Yes.yield);
+
+    while (true)
     {
-        while (true)
+        import std.datetime.systime : Clock;
+
+        // Micro-optimise getting the current time
+        long nowInUnix; // = Clock.currTime.toUnixTime();
+
+        // Walk through channels, trigger fibers
+        foreach (immutable channelName, channel; plugin.channels)
         {
-            import std.datetime.systime : Clock;
-
-            // Micro-optimise getting the current time
-            long nowInUnix; // = Clock.currTime.toUnixTime();
-
-            // Walk through channels, trigger fibers
-            foreach (immutable channelName, channel; plugin.channels)
+            inner:
+            foreach (timerPtr; channel.timerPointers)
             {
-                innermost:
-                foreach (timerPtr; channel.timerPointers)
+                if (!timerPtr.fiber || (timerPtr.fiber.state != Fiber.State.HOLD))
                 {
-                    if (!timerPtr.fiber || (timerPtr.fiber.state != Fiber.State.HOLD))
+                    logger.error("Dead or busy timer Fiber in channel ", channelName);
+                    continue inner;
+                }
+
+                // Get time here and cache it
+                if (nowInUnix == 0) nowInUnix = Clock.currTime.toUnixTime();
+
+                immutable timeConditionMet =
+                    ((nowInUnix - timerPtr.lastTimestamp) >= timerPtr.timeThreshold);
+                immutable messageConditionMet =
+                    ((channel.messageCount - timerPtr.lastMessageCount) >= timerPtr.messageCountThreshold);
+
+                if (timerPtr.condition == Timer.Condition.both)
+                {
+                    if (timeConditionMet && messageConditionMet)
                     {
-                        logger.error("Dead or busy timer Fiber in channel ", channelName);
-                        continue innermost;
+                        timerPtr.fiber.call();
                     }
-
-                    // Get time here and cache it
-                    if (nowInUnix == 0) nowInUnix = Clock.currTime.toUnixTime();
-
-                    immutable timeConditionMet =
-                        ((nowInUnix - timerPtr.lastTimestamp) >= timerPtr.timeThreshold);
-                    immutable messageConditionMet =
-                        ((channel.messageCount - timerPtr.lastMessageCount) >= timerPtr.messageCountThreshold);
-
-                    if (timerPtr.condition == Timer.Condition.both)
+                }
+                else /*if (timerPtr.condition == Timer.Condition.either)*/
+                {
+                    if (timeConditionMet || messageConditionMet)
                     {
-                        if (timeConditionMet && messageConditionMet)
-                        {
-                            timerPtr.fiber.call();
-                        }
-                    }
-                    else /*if (timerPtr.condition == Timer.Condition.either)*/
-                    {
-                        if (timeConditionMet || messageConditionMet)
-                        {
-                            timerPtr.fiber.call();
-                        }
+                        timerPtr.fiber.call();
                     }
                 }
             }
-
-            delay(plugin, plugin.timerPeriodicity, Yes.yield);
-            // continue;
         }
-    }
 
-    Fiber fiberTriggerFiber = new Fiber(&fiberTriggerDg, BufferSize.fiberStack);
-    delay(plugin, fiberTriggerFiber, plugin.timerPeriodicity);
+        delay(plugin, plugin.timerPeriodicity, Yes.yield);
+    }
 }
 
 

--- a/source/kameloso/plugins/twitch/base.d
+++ b/source/kameloso/plugins/twitch/base.d
@@ -3561,13 +3561,13 @@ in (Fiber.getThis, "Tried to call `startValidator` from outside a Fiber")
 
     if (plugin.state.settings.headless)
     {
-        void onExpiryDg()
+        void onExpiryHeadlessDg()
         {
             quit(plugin.state, expiryMessage);
         }
 
         immutable delta = (expiresWhen - now);
-        delay(plugin, &onExpiryDg, delta);
+        delay(plugin, &onExpiryHeadlessDg, delta);
     }
     else
     {

--- a/source/kameloso/plugins/twitch/keygen.d
+++ b/source/kameloso/plugins/twitch/keygen.d
@@ -37,7 +37,6 @@ package:
  +/
 void requestTwitchKey(TwitchPlugin plugin)
 {
-    import kameloso.constants : BufferSize;
     import kameloso.logger : LogLevel;
     import kameloso.thread : ThreadMessage;
     import std.concurrency : send;
@@ -185,24 +184,18 @@ your <w>BOT</> account.
     writeln();
     logger.info("Validating...");
 
-    void getExpiryDg()
-    {
-        immutable expiry = getTokenExpiry(plugin, plugin.state.bot.pass);
-        if (*plugin.state.abort) return;
+    immutable expiry = getTokenExpiry(plugin, plugin.state.bot.pass);
+    if (*plugin.state.abort) return;
 
-        immutable delta = (expiry - Clock.currTime);
-        immutable numDays = delta.total!"days";
+    immutable delta = (expiry - Clock.currTime);
+    immutable numDays = delta.total!"days";
 
-        enum isValidPattern = "Your key is valid for another <l>%d</> days.";
-        logger.infof(isValidPattern, numDays);
-        logger.trace();
+    enum isValidPattern = "Your key is valid for another <l>%d</> days.";
+    logger.infof(isValidPattern, numDays);
+    logger.trace();
 
-        plugin.state.updates |= typeof(plugin.state.updates).bot;
-        plugin.state.mainThread.send(ThreadMessage.save);
-    }
-
-    Fiber getExpiryFiber = new Fiber(&getExpiryDg, BufferSize.fiberStack);
-    getExpiryFiber.call();
+    plugin.state.updates |= typeof(plugin.state.updates).bot;
+    plugin.state.mainThread.send(ThreadMessage.save);
 }
 
 
@@ -215,7 +208,6 @@ your <w>BOT</> account.
  +/
 void requestTwitchSuperKey(TwitchPlugin plugin)
 {
-    import kameloso.constants : BufferSize;
     import kameloso.logger : LogLevel;
     import lu.meld : MeldingStrategy, meldInto;
     import std.process : Pid, ProcessException, wait;
@@ -390,25 +382,19 @@ your main <w>STREAMER</> account.
     writeln();
     logger.info("Validating...");
 
-    void getExpiryDg()
-    {
-        immutable expiry = getTokenExpiry(plugin, creds.broadcasterKey);
-        if (*plugin.state.abort) return;
+    immutable expiry = getTokenExpiry(plugin, creds.broadcasterKey);
+    if (*plugin.state.abort) return;
 
-        immutable delta = (expiry - Clock.currTime);
-        immutable numDays = delta.total!"days";
+    immutable delta = (expiry - Clock.currTime);
+    immutable numDays = delta.total!"days";
 
-        enum isValidPattern = "Your key is valid for another <l>%d</> days.";
-        logger.infof(isValidPattern, numDays);
-        logger.trace();
+    enum isValidPattern = "Your key is valid for another <l>%d</> days.";
+    logger.infof(isValidPattern, numDays);
+    logger.trace();
 
-        creds.broadcasterBearerToken = "Bearer " ~ creds.broadcasterKey;
-        creds.broadcasterKeyExpiry = expiry.toUnixTime();
-        saveSecretsToDisk(plugin.secretsByChannel, plugin.secretsFile);
-    }
-
-    Fiber getExpiryFiber = new Fiber(&getExpiryDg, BufferSize.fiberStack);
-    getExpiryFiber.call();
+    creds.broadcasterBearerToken = "Bearer " ~ creds.broadcasterKey;
+    creds.broadcasterKeyExpiry = expiry.toUnixTime();
+    saveSecretsToDisk(plugin.secretsByChannel, plugin.secretsFile);
 }
 
 


### PR DESCRIPTION
Plugins' top-level `.setup`, `.initialise`, `.reload` and `.teardown` functions have mixin-generated wrappers in the form of `IRCPlugin.{setup,initialise,reload,teardown}`. These are in place to expose said top-level functions to other parts of the program.

In many cases these functions need Fiber functionality, and ended up individually containing manual Fiber management.

This PR makes the generated wrappers instead always construct a Fiber and then call the original function from inside of it. It also removes the ad-hoc solutions from the plugins that were hitherto doing Fibers manually, to complete the migration.

This does not affect `.tick`, as it is by nature not meant to suspend by delaying or awaiting. Some handlers that would have been run too often (and created a disproportional number of Fibers) were also excluded, such as `onAnyEvent`-style handlers, and such being indiscriminately invoked on all `IRCEvent.Type.CHAN` events.