### PR TITLE
Bash plugin rewrite

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -29,6 +29,7 @@ importPaths "source"
 versions \
     "WithAdminPlugin" \
     "WithAutomodePlugin" \
+    "WithBashPlugin" \
     "WithChatbotPlugin" \
     "WithCounterPlugin" \
     "WithHelpPlugin" \
@@ -44,7 +45,6 @@ versions \
     "WithTimePlugin" \
     "WithTimerPlugin" \
     "WithWebtitlePlugin"
-    //"WithBashPlugin"
     //"WithSamePlugin"
 
 /**

--- a/source/kameloso/plugins/bash.d
+++ b/source/kameloso/plugins/bash.d
@@ -43,6 +43,11 @@ mixin PluginRegistration!BashPlugin;
         Whether or not the Bash plugin should react to events at all.
      +/
     @Enabler bool enabled = true;
+
+    /++
+        Minimum user class required for the plugin to react to events.
+     +/
+    IRCUser.Class minimumPermissionsNeeded = IRCUser.Class.anyone;
 }
 
 
@@ -110,6 +115,8 @@ void onCommandBash(BashPlugin plugin, const /*ref*/ IRCEvent event)
         immutable message = pattern.format(plugin.state.settings.prefix, event.aux[$-1]);
         privmsg(plugin.state, event.channel, event.sender.nickname, message);
     }
+
+    if (event.sender.class_ < plugin.bashSettings.minimumPermissionsNeeded) return;
 
     immutable quoteID = event.content.startsWith('#') ?
         event.content[1..$] :

--- a/source/kameloso/plugins/bash.d
+++ b/source/kameloso/plugins/bash.d
@@ -557,6 +557,16 @@ void persistentQuerier(
     {
         auto result = sendHTTPRequestImpl(url, caBundleFile);
 
+        if (result.code == 400)
+        {
+            // Sometimes it claims 400 Bad Request for no reason. Retry a few times
+            foreach (immutable _; 0..3)
+            {
+                result = sendHTTPRequestImpl(url, caBundleFile);
+                if (result.code != 400) break;
+            }
+        }
+
         if (result != BashLookupResult.init)
         {
             lookupBucket[id] = result;

--- a/source/kameloso/plugins/bash.d
+++ b/source/kameloso/plugins/bash.d
@@ -223,7 +223,27 @@ void lookupQuote(
 
         foreach (const line; result.lines)
         {
-            privmsg(plugin.state, event.channel, event.sender.nickname, line);
+            if (!line.length) continue;  // Can technically happen
+
+            string correctedLine;  // mutable
+
+            version(TwitchSupport)
+            {
+                if (plugin.state.server.daemon == IRCServer.Daemon.twitch)
+                {
+                    import std.algorithm.comparison : among;
+
+                    if (line[0].among!('/', '.'))
+                    {
+                        // This has the chance to conflict with a Twitch command,
+                        // so prepend a space to invalidate it
+                        correctedLine = ' ' ~ line;
+                    }
+                }
+            }
+
+            if (!correctedLine.length) correctedLine = line;
+            privmsg(plugin.state, event.channel, event.sender.nickname, correctedLine);
         }
     }
 

--- a/source/kameloso/plugins/bash.d
+++ b/source/kameloso/plugins/bash.d
@@ -1,6 +1,6 @@
 /++
     The Bash plugin looks up quotes from `bash.org`
-    (or technically [bashforever.com](https://bashforever.com) and reports them
+    (or technically [bashforever.com](https://bashforever.com)) and reports them
     to the appropriate nickname or channel.
 
     See_Also:
@@ -645,7 +645,7 @@ public:
 // BashPlugin
 /++
     The Bash plugin looks up quotes from `bash.org`
-    (or technically [bashforever.com](https://bashforever.com) and reports them
+    (or technically [bashforever.com](https://bashforever.com)) and reports them
     to the appropriate nickname or channel.
  +/
 final class BashPlugin : IRCPlugin

--- a/source/kameloso/plugins/webtitle.d
+++ b/source/kameloso/plugins/webtitle.d
@@ -205,7 +205,6 @@ void lookupURLs(
     import kameloso.plugins.common.delayawait : delay;
     import kameloso.common : logger;
     import kameloso.constants : BufferSize;
-    import kameloso.thread : ThreadMessage;
     import lu.array: uniqueKey;
     import lu.string : advancePast;
     import std.concurrency : send, spawn;
@@ -235,7 +234,7 @@ void lookupURLs(
             enum caughtPattern = "Caught URL: <l>%s";
             logger.infof(caughtPattern, url);
 
-            auto result = sendHTTPRequest(plugin, url);
+            const result = sendHTTPRequest(plugin, url);
 
             if (result.exceptionText.length)
             {
@@ -684,6 +683,7 @@ auto sendHTTPRequestImpl(
     catch (Exception e)
     {
         TitleLookupResult result;
+        result.url = url;
         result.exceptionText = e.msg;
         return result;
     }


### PR DESCRIPTION
[bash.org](http://bash.org) seems to be permanently dead, but there is apparently a mirror at [bashforever.com](https://bashforever.com). The layout is slightly different however and our previous `dom` parsing doesn't apply, so it's a good opportunity to just rewrite the plugin.

It makes sense to perform the lookups in a separate thread, as it can take up to `Timeout.httpGET` (10) seconds for a query to fail, during which the bot would stall if it did it in a synchronous fashion. The original approach was to spawn a new thread for each lookup, pass it a copy of the plugin state *cast to shared*, and then send the resulting output via concurrency messages to the main thread, to be sent to the channel and/or logged to the screen. It has *obvious* drawbacks and various smells.

The new approach is to spawn a worker thread on end of MOTD, which stays alive until plugin teardown. Queries are sent to it via concurrency messages, and it stores its lookup results in a `MutexedAA!(BashLookupResult[string])`, much like the Webtitle and Twitch plugins do. This also has drawbacks, but it's not as smelly and seems to work well enough.

The minimum user class required to invoke `!bash` is now configurable, as it is a DoS vector.